### PR TITLE
Fix the march setting for plain mips arch, add test, frontend label change

### DIFF
--- a/backend/coreapp/compiler_wrapper.py
+++ b/backend/coreapp/compiler_wrapper.py
@@ -50,7 +50,7 @@ def load_compilers() -> Dict[str, Dict[str, str]]:
 def load_arches() -> Dict[str, str]:
     ret = {}
 
-    ret["mips"] = "mips-linux-gnu-as -march=mips64 -mabi=64 -o \"$OUTPUT\" \"$INPUT\""
+    ret["mips"] = "mips-linux-gnu-as -march=vr4300 -o \"$OUTPUT\" \"$INPUT\""
     ret["mipsel"] = "mips-linux-gnu-as -march=mips64 -mabi=64 -o \"$OUTPUT\" \"$INPUT\""
 
     return ret
@@ -227,6 +227,7 @@ class CompilerWrapper:
                 })
             except subprocess.CalledProcessError as e:
                 # Compilation failed
+                logger.exception("Error running asm-differ")
                 return (None, e.stderr)
 
             # Assembly failed

--- a/backend/coreapp/tests.py
+++ b/backend/coreapp/tests.py
@@ -33,6 +33,29 @@ nop"""
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(Scratch.objects.count(), 1)
 
+    def test_n64_func(self):
+        """
+        Ensure that functions with t6/t7 registers can be assembled.
+        """
+        scratch_dict = {
+            'arch': 'mips',
+            'context': '',
+            'target_asm':
+"""
+.text
+glabel func_8019B378
+lui $t6, %hi(sOcarinaSongAppendPos)
+lbu $t6, %lo(sOcarinaSongAppendPos)($t6)
+lui $at, %hi(D_801D702C)
+jr  $ra
+sb  $t6, %lo(D_801D702C)($at)
+"""
+        }
+
+        response = self.client.post(reverse('scratch'), scratch_dict)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(Scratch.objects.count(), 1)
+
 class CompilationTests(APITestCase):
     def test_simple_compilation(self):
         """

--- a/frontend/src/scratch/NewScratch.tsx
+++ b/frontend/src/scratch/NewScratch.tsx
@@ -83,7 +83,7 @@ export default function NewScratch() {
 
                 <div class={styles.actions}>
                     <Select class={styles.compilerSelect} onChange={e => setArch((e.target as HTMLSelectElement).value)}>
-                        <option value="mips">MIPS (BE)</option>
+                        <option value="mips">MIPS (Nintendo 64)</option>
                         <option value="mipsel">MIPS (LE)</option>
                     </Select>
 


### PR DESCRIPTION
We need to think more about this stuff. I think the arch choice at scratch creation time should be for the platform (Nintendo64, PSX, etc) rather than just the endianness. I changed the label for "mips" from "MIPS (BE)" to "MIPS (Nintendo 64)" because that's what it really is - it's the setting for the vr4300.

An alternative is to have a dropdown for the language, then another for the endianness, then another for the cpu, etc, but I think this is over-complicated and we can just expose a bunch of choices that set the correct settings for the desired platform.