### PR TITLE
Pin backend docker base to `python:3.9-buster`

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9 AS nsjail
+FROM python:3.9-buster AS nsjail
 
 RUN apt-get -y update && apt-get install -y \
     autoconf \
@@ -21,7 +21,7 @@ RUN git clone --recursive --shallow-submodules --depth=1 --branch=3.0 "https://g
     && mv /nsjail/nsjail /bin \
     && rm -rf -- /nsjail
 
-FROM python:3.9 AS build
+FROM python:3.9-buster AS build
 
 RUN apt-get -y update && apt-get install -y \
     binutils-mips-linux-gnu \
@@ -33,8 +33,6 @@ RUN apt-get -y update && apt-get install -y \
 COPY requirements.txt /backend/requirements.txt
 
 RUN python3 -m pip install -r /backend/requirements.txt --no-cache-dir
-
-RUN bash /backend/compilers/download.sh
 
 COPY --from=nsjail /bin/nsjail /bin/nsjail
 


### PR DESCRIPTION
This was needed because the base image on Docker Hub was upgraded from Debian Buster to Debian Bullseye in August, and we rely on certain package versions from Buster to build `nsjail`. (It would be possible to upgrade to Bullseye, but it would require more testing: this PR is to maintain the status quo.)

I also removed the `/backend/compilers/download.sh` command, which does not work. The `/backend/compilers` folder is only available read-only inside the container, and may already have the compiler components downloaded (for an arbitrary OS). I don't think I could find any situation where it could run successfully, but if I'm wrong about that let me know.

The workaround I've been using is to run `download.sh` outside of the container, from Linux, to set the directory up. This wouldn't work on Windows/Mac though, so a better solution still needs to be found.
