### PR TITLE
Set CWD in sandbox_command (fixes ido5.3 -O3)

### DIFF
--- a/backend/coreapp/sandbox.py
+++ b/backend/coreapp/sandbox.py
@@ -57,6 +57,7 @@ class Sandbox(contextlib.AbstractContextManager["Sandbox"]):
             "--bindmount_ro", "/usr",
             "--bindmount_ro", str(settings.COMPILER_BASE_PATH),
             "--env", "PATH=/usr/bin:/bin",
+            "--cwd", "/tmp",
             "--disable_proc",  # Needed for running inside Docker
             "--time_limit", "30",  # seconds
         ]
@@ -98,5 +99,11 @@ class Sandbox(contextlib.AbstractContextManager["Sandbox"]):
         )
         logger.debug(f"Sandbox Command: {debug_env_str} {shlex.join(command)}")
         return subprocess.run(
-            command, capture_output=True, text=True, env=env, check=True, shell=False
+            command,
+            capture_output=True,
+            text=True,
+            env=env,
+            cwd=self.path,
+            check=True,
+            shell=False,
         )


### PR DESCRIPTION
Fixes the IDO 5.3 issue with `-O3` (`ujoin: Error: opening code.u: Read-only file system`). It was trying to open `$CWD/code.u` (which is pretty odd, but that's beside the point) -- so the workaround is to set the CWD to the tempdir.

---

For future reference, I debugged this by doing the following:
- Added `strace` to the Dockerfile, rebuilt & restarted the container:
```diff
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -28,6 +28,8 @@ RUN apt-get -y update && apt-get install -y \
     libnl-route-3-200 \
     libprotobuf17 \
     netcat \
+    strace \
     && rm -rf /var/lib/apt/lists/*
```
- Got the command out of the `DEBUG` logs (`docker-compose logs -f backend`)
- Shelled into the backend: `docker exec -it decompme_frontend_1 bash`
- Created a dummy `.c` and ran the command I got, adding an strace wrapper `strace -e trace=file -f --`
```sh
echo "int main(void) { return 0; }" >> /sandbox/tmp/code.c

PATH=/bin:/usr/bin INPUT=/sandbox/tmp/code.c OUTPUT=/sandbox/tmp/object.o COMPILER_DIR=/compilers/ido5.3 CC_OPTS='-g -mips2 -O3' TOOLROOT="$COMPILER_DIR" TMPDIR=/tmp bash -c 'strace -e trace=file -f -- "$COMPILER_DIR/usr/bin/cc" -c -Xcpluscomm -G0 -non_shared -Wab,-r4300_mul -woff 649,838,712 -32 $CC_OPTS -o "$OUTPUT" "$INPUT"'
```
- Found the last `open`-ish call, which showed it was trying to just open `./code.u` instead of `/tmp/code.u`:
```
[pid    34] openat(AT_FDCWD, "code.u", O_WRONLY|O_CREAT, 0666) = -1 EACCES (Permission denied)
```