### PR TITLE
Add preset for mk64

### DIFF
--- a/frontend/src/components/compiler/PresetSelect.tsx
+++ b/frontend/src/components/compiler/PresetSelect.tsx
@@ -12,7 +12,7 @@ export const PRESETS = [
     {
         name: "Mario Kart 64",
         compiler: "ido5.3",
-        opts: "-O2 -g -mips2 -32",
+        opts: "-O2 -mips2",
     },
     {
         name: "Paper Mario",


### PR DESCRIPTION
I'm not sure if the -32 is necessary:
make:
```makefile
MIPSISET := -mips2 -32
OPT_FLAGS := -O2
```