### PR TITLE
Possibly fix refresh bug? (suspense issue?)

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -258,9 +258,9 @@ export function useScratch(slugOrUrl: string): {
     }, [url, mutate])
 
     const updateLocalScratch = useCallback((partial: Partial<Scratch>) => {
-        setLocalScratch(Object.assign({}, savedScratch, localScratch, partial))
+        setLocalScratch((previous: Scratch) => Object.assign({}, savedScratch, previous, partial))
         setIsSaved(false)
-    }, [savedScratch, localScratch])
+    }, [savedScratch])
 
     const saveScratch = useCallback(() => {
         if (!localScratch) {


### PR DESCRIPTION
I don't fully understand the issue here - as Ethan was saying in the Discord, `localScratch` always seems `undefined` inside `updateLocalScratch` -- even *after* it has been set, even several renders later. (e.g. it's not `undefined` outside of that fn).
