### PR TITLE
Adding KMC GCC 2.7

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -25,6 +25,7 @@ FROM python:3.9-buster AS build
 
 RUN apt-get -y update && apt-get install -y \
     binutils-mips-linux-gnu \
+    gcc-mips-linux-gnu \
     libnl-route-3-200 \
     libprotobuf17 \
     netcat \

--- a/backend/compilers/download.sh
+++ b/backend/compilers/download.sh
@@ -25,6 +25,12 @@ curl -L "https://github.com/ethteck/ido-static-recomp/releases/download/master/i
 mkdir -p "$compiler_dir/ido7.1"
 curl -L "https://github.com/ethteck/ido-static-recomp/releases/download/master/ido-7.1-recomp-$ido_os-latest.tar.gz" | tar zx -C "$compiler_dir/ido7.1"
 
+# gcc2.7kmc
+if [[ "$uname" != "Darwin" ]]; then
+    mkdir -p "$compiler_dir/gcc2.7kmc"
+    curl -L "https://github.com/Mr-Wiseguy/kmc-gcc-wrapper/releases/download/master/kmc-gcc-wrapper-ubuntu-latest.tar.gz" | tar zx -C "$compiler_dir/gcc2.7kmc"
+fi
+
 # psyq (ps1)
 if [[ "$uname" != "Darwin" ]]; then
     curl -L "https://github.com/mkst/esa/releases/download/psyq-binaries/psyq-compilers.tar.gz" | tar zx -C "$compiler_dir"

--- a/backend/compilers/gcc2.7kmc/config.json
+++ b/backend/compilers/gcc2.7kmc/config.json
@@ -1,0 +1,4 @@
+{
+    "platform": "n64",
+    "cc": "N64ALIGN=ON VR4300MUL=ON \"${COMPILER_DIR}\"/gcc -G0 -c -mgp32 -mfp32 ${COMPILER_FLAGS} \"${INPUT}\" -o \"${OUTPUT}\""
+}

--- a/frontend/src/components/compiler/PresetSelect.tsx
+++ b/frontend/src/components/compiler/PresetSelect.tsx
@@ -36,6 +36,11 @@ export const PRESETS = [
         opts: "-Olimit 2000 -mips2 -O2",
     },
     {
+        name: "Mario Party 3",
+        compiler: "gcc2.7kmc",
+        opts: "-O1 -mips2",
+    },
+    {
         name: "Evo's Space Adventures",
         compiler: "psyq4.6",
         opts: "-O2",

--- a/frontend/src/components/compiler/compilers/gcc2.7kmc.tsx
+++ b/frontend/src/components/compiler/compilers/gcc2.7kmc.tsx
@@ -1,0 +1,25 @@
+import { Checkbox, FlagSet, FlagOption } from "../CompilerOpts"
+
+export const name = "KMC GCC 2.7"
+export const id = "gcc2.7kmc"
+
+export function Flags() {
+    return <>
+        <FlagSet name="Optimization level">
+            <FlagOption flag="-O0" description="No optimization" />
+            <FlagOption flag="-O1" description="Some optimization" />
+            <FlagOption flag="-O2" description="Heavy optimization" />
+        </FlagSet>
+
+        <FlagSet name="Debug information">
+            <FlagOption flag="-g0" description="No debug info" />
+            <FlagOption flag="-g1" description="Minimal trace info" />
+            <FlagOption flag="-g2" description="Local variable tracking" />
+            <FlagOption flag="-g3" description="Macro expansions" />
+        </FlagSet>
+
+        <Checkbox flag="-fforce-addr" description="Load pointers into registers before use" />
+
+        <Checkbox flag="-Wall" description="Enable all warning types" />
+    </>
+}

--- a/frontend/src/components/compiler/compilers/index.ts
+++ b/frontend/src/components/compiler/compilers/index.ts
@@ -3,6 +3,7 @@ import { FunctionComponent } from "react"
 import * as api from "../../../lib/api"
 
 import * as EeGcc296 from "./ee-gcc2.96"
+import * as Gcc27kmc from "./gcc2.7kmc"
 import * as Gcc281 from "./gcc2.8.1"
 import * as Ido53 from "./ido5.3"
 import * as Ido71 from "./ido7.1"
@@ -30,6 +31,7 @@ const COMPILERS: CompilerModule[] = [
     Gcc281,
     Ido53,
     Ido71,
+    Gcc27kmc,
     EeGcc296,
     Mwcc233b144,
     Mwcc233b159,


### PR DESCRIPTION
It requires the cpp from `gcc-mips-linux-gnu` so make sure you install that as part of the deployment :+1: 