### PR TITLE
Add `/run/user/$UID` directory to nsjail

### DIFF
--- a/backend/coreapp/sandbox.py
+++ b/backend/coreapp/sandbox.py
@@ -46,12 +46,14 @@ class Sandbox(contextlib.AbstractContextManager["Sandbox"]):
         settings.WINEPREFIX.mkdir(parents=True, exist_ok=True)
 
         assert ":" not in str(self.path)
+        assert ":" not in str(settings.WINEPREFIX)
         # fmt: off
         wrapper = [
             str(settings.SANDBOX_NSJAIL_BIN_PATH),
             "--mode", "o",
             "--chroot", str(settings.SANDBOX_CHROOT_PATH),
             "--bindmount", f"{self.path}:/tmp",
+            "--bindmount", f"{self.path}:/run/user/{os.getuid()}",
             "--bindmount_ro", "/bin",
             "--bindmount_ro", "/etc/alternatives",
             "--bindmount_ro", "/etc/fonts",


### PR DESCRIPTION
This should fix the issues with `wine` we were having on Ubuntu. 
There is a wine [patch ](https://www.mail-archive.com/debian-wine@lists.debian.org/msg00433.html) which tries to put the `wineserver` temp files in a directory we have mapped as read-only in the `nsjail`. Adding `/run/user/$UID` as a writeable directory changes the logic to put the temp files there instead.