### PR TITLE
Update backend Dockerfile to Ubuntu 21.04 to align with Prod

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -63,9 +63,7 @@ jobs:
       - name: Run tests
         run: |-
           mkdir -p "${WINEPREFIX}"
-          WINEARCH=win32 wineboot --init
           wineboot --init
-          ls -al "${WINEPREFIX}"/
           python backend/manage.py test backend
         env:
           SYSTEM_ENV: GITHUB_WORKFLOW

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -81,6 +81,7 @@ jobs:
             --build-arg ENABLE_GC_WII_SUPPORT=YES
       - name: Run tests
         run: |-
+          mkdir -p sandbox && chmod 777 sandbox
           docker run \
             -v $(pwd):/decomp.me \
             --security-opt apparmor=unconfined \

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -87,6 +87,7 @@ jobs:
             --security-opt seccomp=unconfined \
             --entrypoint /bin/bash \
             -e COMPILER_BASE_PATH=/compilers \
+            -e WINEPREFIX=/tmp/wine \
             decompme_backend -c 'cd /decomp.me && python backend/manage.py test backend'
 
   frontend_test:

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,14 @@
-FROM python:3.9-bullseye AS nsjail
+FROM ubuntu:21.04 as base
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+    python3-pip \
+    python3 \
+    python-is-python3
+
+
+FROM base AS nsjail
 
 RUN apt-get -y update && apt-get install -y \
     autoconf \
@@ -12,33 +22,34 @@ RUN apt-get -y update && apt-get install -y \
     libtool \
     make \
     pkg-config \
-    protobuf-compiler \
-    && rm -rf /var/lib/apt/lists/*
+    protobuf-compiler
 
 # TODO: change this when they tag a release
 RUN git clone --recursive --shallow-submodules "https://github.com/google/nsjail" /nsjail \
     && cd /nsjail \
     && git checkout aa0becd547d835ac9b9d63a9536c23530c8d992e \
     && git submodule update \
-    && make \
-    && mv /nsjail/nsjail /bin \
-    && rm -rf -- /nsjail
+    && make
 
-FROM python:3.9-bullseye AS build
+
+FROM base AS build
 
 RUN apt-get -y update && apt-get install -y \
     binutils-mips-linux-gnu \
+    curl \
     gcc-mips-linux-gnu \
     libnl-route-3-200 \
     libprotobuf-dev \
     netcat \
+    unzip \
+    wget \
     && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt /backend/requirements.txt
 
-RUN python3 -m pip install -r /backend/requirements.txt --no-cache-dir
+RUN python -m pip install -r /backend/requirements.txt --no-cache-dir
 
-COPY --from=nsjail /bin/nsjail /bin/nsjail
+COPY --from=nsjail /nsjail/nsjail /bin/nsjail
 
 # nsjail wants to mount this so ensure it exists
 RUN mkdir -p /lib32
@@ -47,16 +58,13 @@ COPY compilers/*.sh /compilers/
 
 RUN bash /compilers/download.sh
 
-RUN mkdir -p /tmp/wine
-
 # windows compilers need i386 wine
 ARG ENABLE_PS1_SUPPORT
 ARG ENABLE_GC_WII_SUPPORT
 RUN if [ "${ENABLE_PS1_SUPPORT}" = "YES" ] || [ "${ENABLE_GC_WII_SUPPORT}" = "YES" ] ; then \
     dpkg --add-architecture i386 && apt-get update && \
     apt-get install -y -o APT::Immediate-Configure=false \
-        wine && \
-    WINEPREFIX=/tmp/wine winecfg; \
+        wine; \
     fi
 
 # ps1 specifics
@@ -71,6 +79,19 @@ RUN if [ "${ENABLE_GC_WII_SUPPORT}" = "YES" ] ; then \
     fi
 
 WORKDIR /backend
+
+# create a non-root user & /sandbox with correct ownership
+RUN useradd --create-home user \
+    && mkdir -p /sandbox \
+    && chown -R user:user /sandbox
+
+# switch to non-root user
+USER user
+
+# initialize wine files to /home/user/.wine
+RUN if [ "${ENABLE_PS1_SUPPORT}" = "YES" ] || [ "${ENABLE_GC_WII_SUPPORT}" = "YES" ] ; then \
+    wineboot --init; \
+    fi
 
 ENTRYPOINT ["/backend/docker_entrypoint.sh"]
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -80,10 +80,14 @@ RUN if [ "${ENABLE_GC_WII_SUPPORT}" = "YES" ] ; then \
 
 WORKDIR /backend
 
+ENV WINEPREFIX=/tmp/wine
+
 # create a non-root user & /sandbox with correct ownership
 RUN useradd --create-home user \
     && mkdir -p /sandbox \
-    && chown -R user:user /sandbox
+    && chown -R user:user /sandbox \
+    && mkdir -p "${WINEPREFIX}" \
+    && chown user:user "${WINEPREFIX}"
 
 # switch to non-root user
 USER user

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,7 +10,7 @@ django-stubs-ext
 djangorestframework
 djangorestframework-stubs
 mypy
-psycopg2
+psycopg2-binary
 pycparser
 python-Levenshtein
 responses

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -29,7 +29,6 @@ services:
       ALLOWED_HOSTS: "backend,localhost,127.0.0.1"
       USE_SANDBOX_JAIL: "on"
       COMPILER_BASE_PATH: /compilers
-      WINEPREFIX: /home/user/.wine
     ports:
     - "8000:8000"
     security_opt:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -29,6 +29,7 @@ services:
       ALLOWED_HOSTS: "backend,localhost,127.0.0.1"
       USE_SANDBOX_JAIL: "on"
       COMPILER_BASE_PATH: /compilers
+      WINEPREFIX: /home/user/.wine
     ports:
     - "8000:8000"
     security_opt:


### PR DESCRIPTION
A few changes:

1. Install `python3` into an Ubuntu 21.04 base image, use this instead of the python3.9-bullseye which is based on Debian 11
2. Create and use a non-root user, `user`, to catch any weird root-related permissions issues
3. ~~Use `/home/user/.wine` as the WINEPREFIX as that is more in-line with Production~~
4. Use `psycopg2-binary` instead of compiling `psycopg2` from source (seemed to be required for latest Ubuntu)