### PR TITLE
update Pikmin and Pikmin 2 presets

### DIFF
--- a/backend/compilers/mwcc.sh
+++ b/backend/compilers/mwcc.sh
@@ -60,12 +60,6 @@ done
 # patch compilers
 
 if [ -f "${compiler_dir}/mwcc_247_108/${mwcceppc_exe}" ]; then
-    mkdir -p "${compiler_dir}/mwcc_247_108_pikmin2"
-    cp -r "${compiler_dir}/mwcc_247_108/"* "${compiler_dir}/mwcc_247_108_pikmin2/"
-    patch "${compiler_dir}/mwcc_247_108_pikmin2/${mwcceppc_exe}" 222480 117
-fi
-
-if [ -f "${compiler_dir}/mwcc_247_108/${mwcceppc_exe}" ]; then
     mkdir -p "${compiler_dir}/mwcc_247_108_tp"
     cp -r "${compiler_dir}/mwcc_247_108/"* "${compiler_dir}/mwcc_247_108_tp/"
     patch "${compiler_dir}/mwcc_247_108_tp/${mwcceppc_exe}" 1862228 109

--- a/backend/compilers/mwcc_247_108_pikmin2/config.json
+++ b/backend/compilers/mwcc_247_108_pikmin2/config.json
@@ -1,4 +1,0 @@
-{
-    "platform": "gc_wii",
-    "cc": "wine \"${COMPILER_DIR}/mwcceppc.exe\" -c -proc gekko -nostdinc -stderr ${COMPILER_FLAGS} -o \"${OUTPUT}\" \"${INPUT}\""
-}

--- a/frontend/src/components/compiler/PresetSelect.tsx
+++ b/frontend/src/components/compiler/PresetSelect.tsx
@@ -51,8 +51,13 @@ export const PRESETS = [
         opts: "-nodefaults -Cpp_exceptions off -RTTI off -fp hard -enc SJIS -lang=c99 -O4 -use_lmw_stmw on -str pool -rostr -inline all -sdata 4 -sdata2 4",
     },
     {
+        name: "Pikmin",
+        compiler: "mwcc_233_144",
+        opts: "-lang=c++ -nodefaults -Cpp_exceptions off -RTTI on -fp hard -O4,p -proc gekko -msgstyle gcc",
+    },
+    {
         name: "Pikmin 2",
-        compiler: "mwcc_247_108_pikmin2",
+        compiler: "mwcc_247_107",
         opts: "-lang=c++ -nodefaults -Cpp_exceptions off -RTTI off -fp hard -fp_contract on -rostr -O4,p -use_lmw_stmw on -sdata 8 -sdata2 8 -msgstyle gcc",
     },
     {

--- a/frontend/src/components/compiler/PresetSelect.tsx
+++ b/frontend/src/components/compiler/PresetSelect.tsx
@@ -53,7 +53,7 @@ export const PRESETS = [
     {
         name: "Pikmin",
         compiler: "mwcc_233_144",
-        opts: "-lang=c++ -nodefaults -Cpp_exceptions off -RTTI on -fp hard -O4,p -proc gekko -msgstyle gcc",
+        opts: "-lang=c++ -nodefaults -Cpp_exceptions off -RTTI on -fp hard -O4,p -msgstyle gcc",
     },
     {
         name: "Pikmin 2",

--- a/frontend/src/components/compiler/compilers/index.ts
+++ b/frontend/src/components/compiler/compilers/index.ts
@@ -14,7 +14,6 @@ import * as Mwcc242b81 from "./mwcc_242_81"
 import * as Mwcc247b105 from "./mwcc_247_105"
 import * as Mwcc247b107 from "./mwcc_247_107"
 import * as Mwcc247b108 from "./mwcc_247_108"
-import * as Mwcc247b108Pikmin2 from "./mwcc_247_108_pikmin2"
 import * as Mwcc247b108Tp from "./mwcc_247_108_tp"
 import * as Mwcc247b92 from "./mwcc_247_92"
 import * as Mwcc41b60126 from "./mwcc_41_60126"
@@ -40,7 +39,6 @@ const COMPILERS: CompilerModule[] = [
     Mwcc247b105,
     Mwcc247b107,
     Mwcc247b108,
-    Mwcc247b108Pikmin2,
     Mwcc247b108Tp,
     Mwcc247b92,
     Mwcc41b60831,

--- a/frontend/src/components/compiler/compilers/mwcc_247_108_pikmin2.tsx
+++ b/frontend/src/components/compiler/compilers/mwcc_247_108_pikmin2.tsx
@@ -1,6 +1,0 @@
-import { CommonMWCCFlags } from "../compiler_settings/mwcc"
-
-export const name = "2.4.7 build 108 (GC MW 2.7: pikmin2)"
-export const id = "mwcc_247_108_pikmin2"
-
-export const Flags = () => CommonMWCCFlags()


### PR DESCRIPTION
also remove unnecessary compiler logic/config for an obsolete compiler fork