### PR TITLE
Use flexbox for Diff layout instead of tables

### DIFF
--- a/frontend/src/components/Diff/Diff.module.css
+++ b/frontend/src/components/Diff/Diff.module.css
@@ -50,9 +50,12 @@
 }
 
 .lineNumber {
-    color: rgb(140, 140, 140);
-    font-size: 0.9em;
-    font-style: italic;
+    display: inline-block;
+
+    color: var(--a300);
+
+    min-width: 3ch;
+    text-align: right;
 }
 
 .immediate { color: #6d6dff; }

--- a/frontend/src/components/Diff/Diff.module.css
+++ b/frontend/src/components/Diff/Diff.module.css
@@ -37,13 +37,16 @@
 }
 
 .header .column {
-    padding: 4px;
+    margin: 4px;
+    margin-bottom: 0;
+    padding-bottom: 4px;
+    border-bottom: 1px solid var(--a100);
 }
 
 .body {
     flex: 1;
     overflow: auto;
-    padding-bottom: 1em;
+    padding: 8px 0;
 }
 
 .lineNumber {

--- a/frontend/src/components/Diff/Diff.module.css
+++ b/frontend/src/components/Diff/Diff.module.css
@@ -1,17 +1,4 @@
-.container {
-    padding: 8px;
-    overflow: auto;
-    width: 100%;
-
-    scrollbar-color: #fff3 transparent;
-    scrollbar-width: thin;
-}
-
-.diff {
-    border-spacing: 1em 0;
-}
-
-.diff,
+.container,
 .log {
     display: block;
     user-select: text;
@@ -20,6 +7,43 @@
     font-size: 12px;
     white-space: pre;
     width: 100%;
+}
+
+.container {
+    display: flex;
+    flex-direction: column;
+
+    width: 100%;
+    height: 100%;
+
+    scrollbar-color: #fff3 transparent;
+    scrollbar-width: thin;
+}
+
+.row {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+}
+
+.column {
+    flex: 1;
+    min-width: 190px;
+    padding: 0 4px;
+}
+
+.header {
+    text-align: center;
+}
+
+.header .column {
+    padding: 4px;
+}
+
+.body {
+    flex: 1;
+    overflow: auto;
+    padding-bottom: 1em;
 }
 
 .lineNumber {

--- a/frontend/src/components/Diff/Diff.tsx
+++ b/frontend/src/components/Diff/Diff.tsx
@@ -1,5 +1,7 @@
 /* eslint css-modules/no-unused-class: off */
 
+import classNames from "classnames"
+
 import * as api from "../../lib/api"
 
 import styles from "./Diff.module.css"
@@ -32,24 +34,33 @@ export default function Diff({ compilation }: Props) {
     } else {
         const threeWay = !!diff.header.previous
         return <div className={styles.container}>
-            <table className={styles.diff}>
-                <tr>
-                    <th><FormatDiffText texts={diff.header.base} /></th>
-                    <th>{/* Line */}</th>
-                    <th><FormatDiffText texts={diff.header.current} /></th>
-                    { threeWay && <th><FormatDiffText texts={diff.header.previous} /></th> }
-                </tr>
+            <div className={classNames(styles.row, styles.header)}>
+                <div className={styles.column}>
+                    <FormatDiffText texts={diff.header.base} />
+                </div>
+                <div className={styles.column}>
+                    <FormatDiffText texts={diff.header.current} />
+                </div>
+                {threeWay && <div className={styles.column}>
+                    <FormatDiffText texts={diff.header.previous} />
+                </div>}
+            </div>
+            <div className={styles.body}>
                 {diff.rows.map((row, i) => (
-                    <tr key={i}>
-                        <td>{row.base && <FormatDiffText texts={row.base.text} />}</td>
-                        <td><span className={styles.lineNumber}>{(row.current) && row.current.src_line}</span></td>
-                        <td>{row.current && <FormatDiffText texts={row.current.text} />}</td>
-                        {threeWay && <td>
-                            { row.previous && <FormatDiffText texts={row.previous.text} />}
-                        </td>}
-                    </tr>
+                    <div key={i} className={styles.row}>
+                        <div className={styles.column}>
+                            {row.base && <FormatDiffText texts={row.base.text} />}
+                            <span className={styles.lineNumber}>{(row.current) && row.current.src_line}</span>
+                        </div>
+                        <div className={styles.column}>
+                            {row.current && <FormatDiffText texts={row.current.text} />}
+                        </div>
+                        {threeWay && <div className={styles.column}>
+                            {row.previous && <FormatDiffText texts={row.previous.text} />}
+                        </div>}
+                    </div>
                 ))}
-            </table>
+            </div>
         </div>
     }
 }

--- a/frontend/src/components/Diff/Diff.tsx
+++ b/frontend/src/components/Diff/Diff.tsx
@@ -50,9 +50,9 @@ export default function Diff({ compilation }: Props) {
                     <div key={i} className={styles.row}>
                         <div className={styles.column}>
                             {row.base && <FormatDiffText texts={row.base.text} />}
-                            <span className={styles.lineNumber}>{(row.current) && row.current.src_line}</span>
                         </div>
                         <div className={styles.column}>
+                            {typeof row.current?.src_line != "undefined" && <span className={styles.lineNumber}>{row.current.src_line}</span>}
                             {row.current && <FormatDiffText texts={row.current.text} />}
                         </div>
                         {threeWay && <div className={styles.column}>


### PR DESCRIPTION
This PR makes the diff spread across 100% of the available space, with each column taking up 50% of the space.
It also makes the diff header - 'TARGET' and 'CURRENT' - stay visible as you scroll (requested by @Wrymouth).

<img width="748" alt="image" src="https://user-images.githubusercontent.com/9429556/147408833-0fcde3c2-3aa2-48db-8f5c-3211e79a121a.png">
