### PR TITLE
Improve diff layout

### DIFF
--- a/frontend/src/components/Diff/Diff.module.css
+++ b/frontend/src/components/Diff/Diff.module.css
@@ -11,36 +11,51 @@
 
 .container {
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
 
     width: 100%;
     height: 100%;
+
+    overflow: auto;
 
     scrollbar-color: #fff3 transparent;
     scrollbar-width: thin;
 }
 
-.row {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
+.column {
+    min-height: fit-content;
 }
 
-.column {
-    flex: 1;
-    min-width: 190px;
+.column:not(:last-child) {
+    border-right: 1px solid var(--a50);
+}
+
+.column:last-child {
+    flex-grow: 1;
+}
+
+.row {
     padding: 0 4px;
 }
 
 .header {
-    text-align: center;
+    display: block;
+    padding: 4px;
+
+    position: sticky;
+    top: 0;
+
+    color: var(--g1200);
+    user-select: none;
+    border-bottom: 1px solid var(--a50);
+
+    backdrop-filter: blur(10px);
 }
 
-.header .column {
-    margin: 4px;
-    margin-bottom: 0;
-    padding-bottom: 4px;
-    border-bottom: 1px solid var(--a100);
+@supports not (backdrop-filter: blur(10px)) {
+    .header {
+        background: var(--g200);
+    }
 }
 
 .body {

--- a/frontend/src/components/Diff/Diff.tsx
+++ b/frontend/src/components/Diff/Diff.tsx
@@ -20,6 +20,25 @@ function FormatDiffText({ texts }: { texts: api.DiffText[] }) {
     } </>
 }
 
+function DiffColumn({ diff, prop }: {
+    diff: api.DiffOutput
+    prop: keyof api.DiffRow & keyof api.DiffHeader
+}) {
+    return <div className={styles.column}>
+        <div className={classNames(styles.row, styles.header)}>
+            <FormatDiffText texts={diff.header[prop]} />
+        </div>
+        <div className={styles.body}>
+            {diff.rows.map((row, i) => (
+                <div key={i} className={styles.row}>
+                    {typeof row[prop]?.src_line != "undefined" && <span className={styles.lineNumber}>{row[prop].src_line}</span>}
+                    {row[prop] && <FormatDiffText texts={row[prop].text} />}
+                </div>
+            ))}
+        </div>
+    </div>
+}
+
 export type Props = {
     compilation: api.Compilation
 }
@@ -34,33 +53,9 @@ export default function Diff({ compilation }: Props) {
     } else {
         const threeWay = !!diff.header.previous
         return <div className={styles.container}>
-            <div className={classNames(styles.row, styles.header)}>
-                <div className={styles.column}>
-                    <FormatDiffText texts={diff.header.base} />
-                </div>
-                <div className={styles.column}>
-                    <FormatDiffText texts={diff.header.current} />
-                </div>
-                {threeWay && <div className={styles.column}>
-                    <FormatDiffText texts={diff.header.previous} />
-                </div>}
-            </div>
-            <div className={styles.body}>
-                {diff.rows.map((row, i) => (
-                    <div key={i} className={styles.row}>
-                        <div className={styles.column}>
-                            {row.base && <FormatDiffText texts={row.base.text} />}
-                        </div>
-                        <div className={styles.column}>
-                            {typeof row.current?.src_line != "undefined" && <span className={styles.lineNumber}>{row.current.src_line}</span>}
-                            {row.current && <FormatDiffText texts={row.current.text} />}
-                        </div>
-                        {threeWay && <div className={styles.column}>
-                            {row.previous && <FormatDiffText texts={row.previous.text} />}
-                        </div>}
-                    </div>
-                ))}
-            </div>
+            <DiffColumn diff={diff} prop="base" />
+            <DiffColumn diff={diff} prop="current" />
+            {threeWay && <DiffColumn diff={diff} prop="previous" />}
         </div>
     }
 }

--- a/frontend/src/pages/theme.scss
+++ b/frontend/src/pages/theme.scss
@@ -28,7 +28,7 @@
         $peak: 255;
     }
 
-    @for $i from 1 through 10 {
-        --a#{$i * 100}: #{rgba($peak, $peak, $peak, $i * 0.1)};
+    @for $i from 1 through 20 {
+        --a#{$i * 50}: #{rgba($peak, $peak, $peak, $i * 0.05)};
     }
 }


### PR DESCRIPTION
Builds on #252:

- Fixes layout on mobile; thin viewports will not cause the columns to compress (notice horizontal scrollbar in image)

<img width="404" alt="image" src="https://user-images.githubusercontent.com/9429556/147516298-19981e7f-3f2a-40b2-807e-259d579badaa.png">

- Reverts to having the columns being left-justified, instead of 50-50

<img width="804" alt="image" src="https://user-images.githubusercontent.com/9429556/147516259-ee4f3b24-c8a4-4ba2-b42e-f46403aa45ef.png">

- Various style changes e.g. adds lines between the columns