### PR TITLE
Copy scratch name to fork

### DIFF
--- a/backend/coreapp/serializers.py
+++ b/backend/coreapp/serializers.py
@@ -39,6 +39,7 @@ class ProfileField(ProfileFieldBaseClass):
         return serialize_profile(self.context["request"], profile)
 
 class ScratchCreateSerializer(serializers.Serializer[None]):
+    name = serializers.CharField(allow_blank=True, required=False)
     compiler = serializers.CharField(allow_blank=True, required=True)
     platform = serializers.CharField(allow_blank=True, required=False)
     compiler_flags = serializers.CharField(allow_blank=True, required=False)

--- a/backend/coreapp/tests.py
+++ b/backend/coreapp/tests.py
@@ -160,6 +160,7 @@ class ScratchForkTests(APITestCase):
             'context': '',
             'target_asm': 'glabel meow\njr $ra',
             'diff_label': 'meow',
+            'name': 'cat scratch',
         }
 
         response = self.client.post(reverse('scratch'), scratch_dict)
@@ -191,6 +192,8 @@ class ScratchForkTests(APITestCase):
         # Make sure the diff_label carried over to the fork
         self.assertEqual(scratch.diff_label, fork.diff_label)
 
+        # Make sure the name carried over to the fork
+        self.assertEqual(scratch.name, fork.name)
 
 
 class CompilationTests(APITestCase):

--- a/backend/coreapp/views/scratch.py
+++ b/backend/coreapp/views/scratch.py
@@ -189,11 +189,11 @@ def create_scratch(request):
 
     target_asm = data["target_asm"]
     context = data["context"]
-    diff_label = data.get("diff_label")
+    diff_label = data.get("diff_label", "")
 
     assert isinstance(target_asm, str)
     assert isinstance(context, str)
-    assert diff_label is None or isinstance(diff_label, str)
+    assert isinstance(diff_label, str)
 
     asm = get_db_asm(target_asm)
 
@@ -219,7 +219,7 @@ def create_scratch(request):
 
     slug = gen_scratch_id()
 
-    name = diff_label if diff_label else ""
+    name = data.get("name", diff_label)
 
     scratch_data = {
         "slug": slug,
@@ -299,6 +299,7 @@ def fork(request, slug):
     context = request.data["context"]
 
     new_scratch = Scratch(
+        name=parent_scratch.name,
         compiler=compiler,
         platform=platform,
         compiler_flags=compiler_flags,


### PR DESCRIPTION
I think this is an ideal way of tackling #175) as we already know a fork is a fork via the ui. adding "fork of" is just going to get spammy I think

closes #175 