### PR TITLE
Fix issues introduced in previous PR

### DIFF
--- a/frontend/src/components/Scratch/ScratchBody.tsx
+++ b/frontend/src/components/Scratch/ScratchBody.tsx
@@ -11,6 +11,7 @@ import styles from "./ScratchBody.module.scss"
 
 const LEFT_PANE_MIN_WIDTH = 100
 const RIGHT_PANE_MIN_WIDTH = 100
+const TWO_PANE_MIN_CONTAINER_WIDTH = 800
 
 export type Props = {
     container: {width: number | undefined, height: number | undefined, ref: RefObject<HTMLDivElement>}
@@ -35,7 +36,7 @@ export default function ScratchBody({
     setCompilerOpts,
     scratch,
 }: Props) {
-    return container.width > (LEFT_PANE_MIN_WIDTH + RIGHT_PANE_MIN_WIDTH)
+    return container.width > TWO_PANE_MIN_CONTAINER_WIDTH
         ? (<resizer.Container className={styles.resizer}>
             <resizer.Section minSize={LEFT_PANE_MIN_WIDTH}>
                 <resizer.Container vertical style={{ height: "100%" }}>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -273,17 +273,17 @@ export async function claimScratch(scratch: Scratch): Promise<void> {
     })
 }
 
-export async function forkScratch(parent: Scratch, localScratch: Partial<Scratch> = {}): Promise<Scratch> {
-    const scratch = await post(`/scratch/${parent.slug}/fork`, Object.assign({}, parent, localScratch))
+export async function forkScratch(parent: Scratch): Promise<Scratch> {
+    const scratch = await post(`/scratch/${parent.slug}/fork`, parent)
     await claimScratch(scratch)
     return scratch
 }
 
-export function useForkScratchAndGo(parent: Scratch, localScratch: Partial<Scratch> = {}): () => Promise<void> {
+export function useForkScratchAndGo(parent: Scratch): () => Promise<void> {
     const router = useRouter()
 
     return async () => {
-        const fork = await forkScratch(parent, localScratch)
+        const fork = await forkScratch(parent)
 
         ignoreNextWarnBeforeUnload()
         await router.push(`/scratch/${fork.slug}`)

--- a/frontend/src/pages/scratch/[slug].tsx
+++ b/frontend/src/pages/scratch/[slug].tsx
@@ -1,6 +1,6 @@
 import { Suspense, useState } from "react"
 
-import { GetStaticProps } from "next"
+import { GetServerSideProps } from "next"
 
 import { useSWRConfig } from "swr"
 
@@ -30,30 +30,21 @@ function ScratchPageTitle({ scratch }: { scratch: api.Scratch }) {
     return <PageTitle title={title} description={description} />
 }
 
-// dynamically render all pages
-export async function getStaticPaths() {
-    return {
-        paths: [],
-        fallback: "blocking",
-    }
-}
-
-export const getStaticProps: GetStaticProps = async context => {
+export const getServerSideProps: GetServerSideProps = async context => {
     const { slug } = context.params
 
     try {
+        // TODO: pass along context.req.cookies
         const initialScratch: api.Scratch = await api.get(`/scratch/${slug}`)
 
         return {
             props: {
                 initialScratch,
             },
-            revalidate: 10,
         }
     } catch (error) {
         return {
             notFound: true,
-            revalidate: 10,
         }
     }
 }


### PR DESCRIPTION
- use single-tab mode at 800px instead of 200px
- render scratch pages dynamically
- reduce args to api.forkScratch
