### PR TITLE
Login UX improvements

### DIFF
--- a/backend/coreapp/compiler_wrapper.py
+++ b/backend/coreapp/compiler_wrapper.py
@@ -170,7 +170,7 @@ def load_platforms() -> Dict[str, Platform]:
         ),
         "gc_wii": Platform(
             "GameCube / Wii",
-            "PPC",
+            "PowerPC",
             "ppc",
             assemble_cmd='powerpc-eabi-as -mgekko -o "$OUTPUT" "$INPUT"',
             objdump_cmd="powerpc-eabi-objdump",

--- a/backend/coreapp/github.py
+++ b/backend/coreapp/github.py
@@ -126,6 +126,7 @@ class GitHubUser(models.Model):
         # If the previous profile was anonymous, give its scratches to the logged-in profile
         if request.profile.is_anonymous() and profile.id != request.profile.id:
             Scratch.objects.filter(owner=request.profile).update(owner=profile)
+            request.profile.delete()
 
         login(request, gh_user.user)
         request.profile = profile

--- a/backend/coreapp/models.py
+++ b/backend/coreapp/models.py
@@ -20,7 +20,7 @@ class Profile(models.Model):
         null=True,
     )
 
-    def is_anonymous(self):
+    def is_anonymous(self) -> bool:
         return self.user is None
 
     def __str__(self):

--- a/backend/coreapp/views/user.py
+++ b/backend/coreapp/views/user.py
@@ -26,8 +26,8 @@ class CurrentUser(APIView):
 
         if "code" in request.data:
             GitHubUser.login(request, request.data["code"])
-
-            return Response(serialize_profile(request, request.profile))
+            assert not request.profile.is_anonymous()
+            return self.get(request)
         else:
             logout(request)
 
@@ -36,7 +36,7 @@ class CurrentUser(APIView):
             request.profile = profile
             request.session["profile_id"] = request.profile.id
 
-            return Response(serialize_profile(request, request.profile))
+            return self.get(request)
 
 @api_view(["GET"])
 def user(request, username):

--- a/frontend/src/components/Diff/Diff.module.css
+++ b/frontend/src/components/Diff/Diff.module.css
@@ -28,6 +28,12 @@
 
 .column {
     min-height: fit-content;
+    overflow-x: auto;
+}
+
+/* Don't let the target column get stupidly wide if there are long symbol names */
+.column:first-child {
+    max-width: 40ch;
 }
 
 .column:not(:last-child) {

--- a/frontend/src/components/Nav/LoginState.tsx
+++ b/frontend/src/components/Nav/LoginState.tsx
@@ -3,8 +3,6 @@ import { useEffect } from "react"
 import Image from "next/image"
 import Link from "next/link"
 
-import useSWR from "swr"
-
 import * as api from "../../lib/api"
 import GitHubLoginButton from "../GitHubLoginButton"
 
@@ -15,7 +13,7 @@ export type Props = {
 }
 
 export default function LoginState({ onChange }: Props) {
-    const { data: user, error } = useSWR<api.AnonymousUser | api.User>("/user", api.get)
+    const user = api.useThisUser()
 
     useEffect(() => {
         if (user) {
@@ -23,9 +21,7 @@ export default function LoginState({ onChange }: Props) {
         }
     }, [user, onChange])
 
-    if (error) {
-        throw error
-    } else if (!user) {
+    if (!user) {
         // Loading...
         return <div />
     } else if (user && !api.isAnonUser(user) && user.username) {
@@ -44,7 +40,7 @@ export default function LoginState({ onChange }: Props) {
         </Link>
     } else {
         return <div>
-            <GitHubLoginButton label="Sign in" />
+            <GitHubLoginButton label="Sign in" popup={true} />
         </div>
     }
 }

--- a/frontend/src/components/Nav/Nav.module.scss
+++ b/frontend/src/components/Nav/Nav.module.scss
@@ -13,7 +13,7 @@
     padding: 4px;
 
     background: var(--g400);
-    border-bottom: 1px solid var(--g600);
+    //border-bottom: 1px solid var(--g600);
 
     font-size: 90%;
     font-weight: 600;

--- a/frontend/src/components/Scratch/AboutScratch.module.scss
+++ b/frontend/src/components/Scratch/AboutScratch.module.scss
@@ -4,6 +4,7 @@
     gap: 1em;
     cursor: default;
 
+    min-width: 300px;
     height: 100%;
 }
 
@@ -97,4 +98,8 @@
     display: flex;
     flex-direction: inherit;
     flex: 1;
+}
+
+.signInPrompt {
+    margin-left: 16px;
 }

--- a/frontend/src/components/Scratch/AboutScratch.tsx
+++ b/frontend/src/components/Scratch/AboutScratch.tsx
@@ -3,6 +3,7 @@ import Link from "next/link"
 import useSWR from "swr"
 
 import * as api from "../../lib/api"
+import GitHubLoginButton from "../GitHubLoginButton"
 import LoadingSpinner from "../loading.svg"
 import UserLink from "../user/UserLink"
 
@@ -41,11 +42,19 @@ export type Props = {
 }
 
 export default function AboutScratch({ scratch, setScratch }: Props) {
+    const userIsYou = api.useUserIsYou()
+
     return <div className={styles.container}>
         <div>
             <div className={styles.horizontalField}>
                 <p className={styles.label}>Owner</p>
-                {scratch.owner ? <UserLink user={scratch.owner} /> : <ClaimScratchButton scratch={scratch} />}
+                {scratch.owner
+                    ? <UserLink user={scratch.owner} />
+                    : <ClaimScratchButton scratch={scratch} />
+                }
+                {scratch.owner?.is_anonymous && userIsYou(scratch.owner)
+                    && <GitHubLoginButton popup label="Sign in to keep" className={styles.signInPrompt} />
+                }
             </div>
             {scratch.parent &&<div className={styles.horizontalField}>
                 <p className={styles.label}>Fork of</p>

--- a/frontend/src/components/Scratch/ScratchToolbar.module.scss
+++ b/frontend/src/components/Scratch/ScratchToolbar.module.scss
@@ -10,7 +10,7 @@
     padding: 4px;
 
     background: var(--g300);
-    border-bottom: 1px solid var(--a100);
+    //border-bottom: 1px solid var(--a100);
 
     @media screen and (min-width: 800px) and (min-height: 800px) {
         gap: 8px;

--- a/frontend/src/components/user/UserLink.tsx
+++ b/frontend/src/components/user/UserLink.tsx
@@ -24,7 +24,7 @@ export default function UserLink({ user }: Props) {
 
     if (api.isAnonUser(user)) {
         return <a className={styles.user}>
-            <span>{userIsYou(user) ? "You" : "Anonymous"} (not signed in)</span>
+            <span>{userIsYou(user) ? "You" : "Anonymous"}</span>
         </a>
     } else {
         return <Link href={`/u/${user.username}`}>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -215,10 +215,13 @@ export function useThisUser(): User | AnonymousUser | undefined {
     return user
 }
 
+export function isUserEq(a: User | AnonymousUser | undefined, b: User | AnonymousUser | undefined): boolean {
+    return a && b && a.id === b.id && a.is_anonymous === b.is_anonymous
+}
+
 export function useUserIsYou(): (user: User | AnonymousUser | undefined) => boolean {
     const you = useThisUser()
-
-    return user => you && user && you.id === user.id && you.is_anonymous === user.is_anonymous
+    return user => isUserEq(you, user)
 }
 
 export function useSavedScratch(scratch: Scratch): Scratch {

--- a/frontend/src/pages/login.module.css
+++ b/frontend/src/pages/login.module.css
@@ -4,6 +4,8 @@
     align-content: center;
     height: 100%;
     cursor: default;
+
+    background: var(--g200);
 }
 
 .container p {
@@ -19,4 +21,13 @@
 
 .error {
     color: #f86;
+}
+
+.loading {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1em;
+
+    color: var(--g1100);
 }

--- a/frontend/src/pages/login.tsx
+++ b/frontend/src/pages/login.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/router"
 import { useSWRConfig } from "swr"
 
 import GitHubLoginButton from "../components/GitHubLoginButton"
+import LoadingSpinner from "../components/loading.svg"
 import * as api from "../lib/api"
 
 import styles from "./login.module.css"
@@ -21,10 +22,19 @@ export default function LoginPage() {
         if (code) {
             setError(null)
             api.post("/user", { code }).then((user: api.User) => {
+                if (user.is_anonymous) {
+                    return Promise.reject(new Error("Still not logged-in."))
+                }
+
+                mutate("/user", user)
+
                 if (next) {
-                    mutate("/user", user)
                     router.replace(next)
-                } else {
+                } else if (window.opener) {
+                    window.postMessage({
+                        source: "decomp_me_login",
+                        user,
+                    }, window.opener)
                     window.close()
                 }
             }).catch(error => {
@@ -44,14 +54,15 @@ export default function LoginPage() {
                 <p>
                     Try again:
                 </p>
-                <GitHubLoginButton />
-            </div> : code ? <>
-                Signing in...
-            </> : <div className={styles.card}>
+                <GitHubLoginButton popup={false} />
+            </div> : code ? <div className={styles.loading}>
+                <LoadingSpinner width={32} />
+                Signing you in...
+            </div> : <div className={styles.card}>
                 <p>
                     Sign in to decomp.me
                 </p>
-                <GitHubLoginButton />
+                <GitHubLoginButton popup={false} />
             </div>}
         </main>
     </>


### PR DESCRIPTION
- A few style tweaks, like removing the border-bottom from the navbar and the scratch toolbar.
- On login, scratches created anonymously are now assigned to the user.
- The login popup looks and behaves a bit better now.
- The size of the Target pane of diffs is now limited to 40 characters in width to avoid [this insanity with triple-figure symbol names](https://media.discordapp.net/attachments/897066363951128590/926142330891800657/unknown.png).
