### PR TITLE
Clean compiler loading logs and allow multiple compilers per dir

### DIFF
--- a/backend/compilers/agbcc/config.json
+++ b/backend/compilers/agbcc/config.json
@@ -1,4 +1,12 @@
-{
-    "platform": "gba",
-    "cc": "\"${COMPILER_DIR}\"/bin/agbcc $COMPILER_FLAGS \"$INPUT\" -o - | arm-none-eabi-as -mcpu=arm7tdmi -o \"$OUTPUT\""
-}
+[
+    {
+        "name": "agbcc",
+        "platform": "gba",
+        "cc": "\"${COMPILER_DIR}\"/bin/agbcc $COMPILER_FLAGS \"$INPUT\" -o - | arm-none-eabi-as -mcpu=arm7tdmi -o \"$OUTPUT\""
+    },
+    {
+        "name": "old_agbcc",
+        "platform": "gba",
+        "cc": "\"${COMPILER_DIR}\"/bin/old_agbcc $COMPILER_FLAGS \"$INPUT\" -o - | arm-none-eabi-as -mcpu=arm7tdmi -o \"$OUTPUT\""
+    }
+]

--- a/backend/coreapp/compiler_wrapper.py
+++ b/backend/coreapp/compiler_wrapper.py
@@ -12,7 +12,7 @@ import os
 from pathlib import Path
 import subprocess
 from dataclasses import dataclass
-from platform import platform, uname
+from platform import uname
 
 logger = logging.getLogger(__name__)
 
@@ -54,7 +54,7 @@ def load_compiler(id: str, cc: Optional[str], platform: Optional[str], compilers
         logger.debug(f"Config found but no binaries found for {id}, ignoring.")
 
 def load_compilers() -> Dict[str, Dict[str, str]]:
-    ret = {}
+    ret: Dict[str, Dict[str, str]] = {}
     compilers_base = settings.BASE_DIR / "compilers"
     compiler_dirs = next(os.walk(compilers_base))
     for compiler_dir_name in compiler_dirs[1]:


### PR DESCRIPTION
Expands the yaml parser to allow for a list format wherein multiple compilers can be specified for the same base directory
Adds old_agbcc as a compiler
Reduces verbosity of some of the logs for loading compilers