### PR TITLE
Assemble NDS asm in thumb mode

### DIFF
--- a/backend/coreapp/compiler_wrapper.py
+++ b/backend/coreapp/compiler_wrapper.py
@@ -283,7 +283,7 @@ def load_platforms() -> Dict[str, Platform]:
             "Nintendo DS",
             "ARMv4T",
             "arm32",
-            assemble_cmd='sed "$INPUT" -e "s/;/;@/" | arm-none-eabi-as -march=armv5te -o "$OUTPUT"',
+            assemble_cmd='sed "$INPUT" -e "s/;/;@/" | arm-none-eabi-as -march=armv5te -mthumb -o "$OUTPUT"',
             objdump_cmd="arm-none-eabi-objdump",
             nm_cmd="arm-none-eabi-nm",
             asm_prelude="""


### PR DESCRIPTION
The majority of arm9 code was compiled in thumb mode (at least for the Pokémon projects). This change adds a flag to assemble asm in thumb mode, as well. This fixes the issue where instruction widths were not matching for NDS scratches.

See example scratch with fix applied:

<img width="1280" alt="Screen Shot 2022-01-11 at 3 33 49 PM" src="https://user-images.githubusercontent.com/46002898/149017451-b79b4be5-237d-45de-baef-4fb62f5e025c.png">

