### PR TITLE
Support -KPIC for IDO

### DIFF
--- a/backend/compilers/ido5.3/config.json
+++ b/backend/compilers/ido5.3/config.json
@@ -1,4 +1,4 @@
 {
     "platform": "n64",
-    "cc": "TOOLROOT=\"$COMPILER_DIR\" \"$COMPILER_DIR/usr/bin/cc\" -c -Xcpluscomm -G0 -non_shared -Wab,-r4300_mul -woff 649,838,712 -32 $COMPILER_FLAGS -o \"$OUTPUT\" \"$INPUT\""
+    "cc": "TOOLROOT=\"$COMPILER_DIR\" \"$COMPILER_DIR/usr/bin/cc\" -c -Xcpluscomm -G0 -Wab,-r4300_mul -woff 649,838,712 -32 $COMPILER_FLAGS -o \"$OUTPUT\" \"$INPUT\""
 }

--- a/backend/compilers/ido7.1/config.json
+++ b/backend/compilers/ido7.1/config.json
@@ -1,4 +1,4 @@
 {
     "platform": "n64",
-    "cc": "TOOLROOT=\"$COMPILER_DIR\" \"$COMPILER_DIR/usr/bin/cc\" -c -Xcpluscomm -G0 -non_shared -Wab,-r4300_mul -woff 649,838,712 -32 $COMPILER_FLAGS -o \"$OUTPUT\" \"$INPUT\""
+    "cc": "TOOLROOT=\"$COMPILER_DIR\" \"$COMPILER_DIR/usr/bin/cc\" -c -Xcpluscomm -G0 -Wab,-r4300_mul -woff 649,838,712 -32 $COMPILER_FLAGS -o \"$OUTPUT\" \"$INPUT\""
 }

--- a/backend/coreapp/compiler_wrapper.py
+++ b/backend/coreapp/compiler_wrapper.py
@@ -425,7 +425,6 @@ class CompilerWrapper:
         }
         skip_flags = {
             "-ffreestanding",
-            "-non_shared",
             "-Xcpluscomm",
             "-Xfullwarn",
             "-fullwarn",

--- a/backend/coreapp/tests.py
+++ b/backend/coreapp/tests.py
@@ -122,7 +122,8 @@ class ScratchModificationTests(BaseTestCase):
         # Update the scratch's code and compiler output
         scratch_patch = {
             'source_code': "int func() { return 2; }",
-            'compiler': 'ido5.3'
+            'compiler': 'ido5.3',
+            'compiler_flags': '-non_shared',
         }
 
         response = self.client.patch(reverse('scratch-detail', kwargs={'pk': slug}), scratch_patch)
@@ -169,6 +170,7 @@ class ScratchModificationTests(BaseTestCase):
         scratch_dict = {
             'platform': 'n64',
             'compiler': 'ido7.1',
+            'compiler_flags': '-non_shared',
             'context': '',
             'target_asm': 'jr $ra\nli $v0,2',
             'source_code': 'int func() { return 2; }'

--- a/frontend/src/components/compiler/PresetSelect.tsx
+++ b/frontend/src/components/compiler/PresetSelect.tsx
@@ -8,12 +8,12 @@ export const PRESETS = [
     {
         name: "Super Mario 64",
         compiler: "ido5.3",
-        opts: "-O1 -g -mips2",
+        opts: "-non_shared -O1 -g -mips2",
     },
     {
         name: "Mario Kart 64",
         compiler: "ido5.3",
-        opts: "-O2 -mips2",
+        opts: "-non_shared -O2 -mips2",
     },
     {
         name: "Paper Mario",
@@ -23,22 +23,22 @@ export const PRESETS = [
     {
         name: "Ocarina of Time",
         compiler: "ido7.1",
-        opts: "-O2 -mips2",
+        opts: "-non_shared -O2 -mips2",
     },
     {
         name: "Majora's Mask",
         compiler: "ido7.1",
-        opts: "-O2 -g3 -mips2",
+        opts: "-non_shared -O2 -g3 -mips2",
     },
     {
         name: "GoldenEye / Perfect Dark",
         compiler: "ido5.3",
-        opts: "-Olimit 2000 -mips2 -O2",
+        opts: "-non_shared -Olimit 2000 -mips2 -O2",
     },
     {
         name: "Diddy Kong Racing",
         compiler: "ido5.3",
-        opts: "-mips1 -O2",
+        opts: "-non_shared -mips1 -O2",
     },
     {
         name: "Mario Party 3",
@@ -48,7 +48,12 @@ export const PRESETS = [
     {
         name: "Dinosaur Planet",
         compiler: "ido5.3",
-        opts: "-O2 -g3 -mips2",
+        opts: "-non_shared -O2 -g3 -mips2",
+    },
+    {
+        name: "Dinosaur Planet (DLLs)",
+        compiler: "ido5.3",
+        opts: "-KPIC -O2 -g3 -mips2",
     },
     {
         name: "Evo's Space Adventures",

--- a/frontend/src/components/compiler/compiler_settings/ido.tsx
+++ b/frontend/src/components/compiler/compiler_settings/ido.tsx
@@ -22,6 +22,11 @@ export function CommonIDOFlags() {
             <FlagOption flag="-mips3" />
         </FlagSet>
 
+        <FlagSet name="-non_shared / -KPIC">
+            <FlagOption flag="-non_shared" />
+            <FlagOption flag="-KPIC" />
+        </FlagSet>
+
         <Checkbox flag="-Wall" description="Enable all warning types" />
     </>
 }


### PR DESCRIPTION
Makes -non_shared no longer an implicit ido flag. Adds it to all existing presets and creates a UI selector for -non_shared or -KPIC. Adds Dinosaur Planet preset for its DLLs