### PR TITLE
Use objdump --disassemble to avoid diffing past function end (when possible)

### DIFF
--- a/backend/coreapp/asm_diff_wrapper.py
+++ b/backend/coreapp/asm_diff_wrapper.py
@@ -45,6 +45,9 @@ class AsmDifferWrapper:
 
     @staticmethod
     def get_objdump_target_function_flags(sandbox: Sandbox, target_path, platform: str, label: str) -> List[str]:
+        if compiler_wrapper.supports_objdump_disassemble(platform):
+            return [f"--disassemble={label}"]
+
         nm_command = compiler_wrapper.get_nm_command(platform)
         if not nm_command:
             raise NmError(f"No nm command for {platform}")

--- a/backend/coreapp/asm_diff_wrapper.py
+++ b/backend/coreapp/asm_diff_wrapper.py
@@ -44,7 +44,10 @@ class AsmDifferWrapper:
         )
 
     @staticmethod
-    def get_objdump_target_function_flags(sandbox: Sandbox, target_path, platform: str, label: str) -> List[str]:
+    def get_objdump_target_function_flags(sandbox: Sandbox, target_path, platform: str, label: Optional[str]) -> List[str]:
+        if not label:
+            return ["--start-address=0"]
+
         if compiler_wrapper.supports_objdump_disassemble(platform):
             return [f"--disassemble={label}"]
 
@@ -88,10 +91,7 @@ class AsmDifferWrapper:
             target_path = sandbox.path / "out.s"
             target_path.write_bytes(target_data)
 
-            if label:
-                flags += AsmDifferWrapper.get_objdump_target_function_flags(sandbox, target_path, platform, label)
-            else:
-                flags.append("--start-address=0")
+            flags += AsmDifferWrapper.get_objdump_target_function_flags(sandbox, target_path, platform, label)
 
             objdump_command = compiler_wrapper.get_objdump_command(platform)
 

--- a/backend/coreapp/compiler_wrapper.py
+++ b/backend/coreapp/compiler_wrapper.py
@@ -101,6 +101,7 @@ class Platform:
     assemble_cmd: Optional[str] = None
     objdump_cmd: Optional[str] = None
     nm_cmd: Optional[str] = None
+    supports_objdump_disassemble: bool = False
 
 @dataclass
 class CompilationResult:
@@ -126,6 +127,7 @@ def load_platforms() -> Dict[str, Platform]:
             objdump_cmd="aarch64-linux-gnu-objdump",
             nm_cmd="aarch64-linux-gnu-nm",
             asm_prelude="",
+            supports_objdump_disassemble=True,
         ),
         "n64": Platform(
             "Nintendo 64",
@@ -372,6 +374,11 @@ def get_objdump_command(platform: str) -> Optional[str]:
     if platform in _platforms:
         return _platforms[platform].objdump_cmd
     return None
+
+def supports_objdump_disassemble(platform: str) -> bool:
+    if platform in _platforms:
+        return _platforms[platform].supports_objdump_disassemble
+    return False
 
 def _check_assembly_cache(*args: str) -> Tuple[Optional[Assembly], str]:
     hash = util.gen_hash(args)


### PR DESCRIPTION
...and only when a diff_label was specified by the user.

For some modern platforms it's impossible to force the compiler to only generate code for a single function *even if* the source code and context tabs only contain one function: the compiler may need to generate e.g. PLT stubs for position-independent code.