### PR TITLE
backend: Ignore address differences when diffing code

### DIFF
--- a/backend/coreapp/asm_diff_wrapper.py
+++ b/backend/coreapp/asm_diff_wrapper.py
@@ -39,7 +39,7 @@ class AsmDifferWrapper:
             show_source=False,
             stop_jrra=False,
             ignore_large_imms=False,
-            ignore_addr_diffs=False,
+            ignore_addr_diffs=True,
             algorithm="levenshtein",
         )
 


### PR DESCRIPTION
For obvious reasons, function and variable addresses will not match the
original code. asm-differ has an option to ignore address differences
and make the diff less noisy. (This only has an effect for 32-bit ARM
and AArch64 at the moment.)