### PR TITLE
Give target asm object to asm_differ as a byte array

### DIFF
--- a/backend/coreapp/asm_diff_wrapper.py
+++ b/backend/coreapp/asm_diff_wrapper.py
@@ -139,7 +139,7 @@ class AsmDifferWrapper:
 
         # Preprocess the dumps
         try:
-            basedump = asm_differ.preprocess_objdump_out(None, target_assembly.elf_object, basedump, config)
+            basedump = asm_differ.preprocess_objdump_out(None, bytes(target_assembly.elf_object), basedump, config)
         except AssertionError as e:
             logger.exception("Error preprocessing base dump")
             raise DiffError(f"Error preprocessing base dump: {e}")


### PR DESCRIPTION
Fixes problems with diffing target asm (section labels not showing up, among possibly other things)