### PR TITLE
Add GCC 2.6.3 for PS1

### DIFF
--- a/backend/compilers/download.sh
+++ b/backend/compilers/download.sh
@@ -40,6 +40,15 @@ if [[ "$uname" != "Darwin" ]]; then
     find . -name "CC1PSX.EXE" | xargs chmod +x
 fi
 
+# GCC mipsel
+if [[ "$uname" != "Darwin" ]]; then
+    curl -L "https://github.com/decompals/old-gcc/releases/download/release/gcc-2.6.3.zip" && unzip gcc-2.6.3.zip -d "$compiler_dir/gcc2.6.3-mipsel" && gcc-2.6.3.zip
+    find . -name "cc1" | xargs chmod +x
+    find . -name "cpp" | xargs chmod +x
+    find . -name "g++" | xargs chmod +x
+    find . -name "gcc" | xargs chmod +x
+fi
+
 # agbcc (gba)
 if [[ "$uname" != "Darwin" ]]; then
     mkdir -p "$compiler_dir/agbcc"

--- a/backend/compilers/gcc2.6.3-mipsel/config.json
+++ b/backend/compilers/gcc2.6.3-mipsel/config.json
@@ -1,0 +1,4 @@
+{
+    "platform": "ps1",
+    "cc": "\"${COMPILER_DIR}\"/gcc -G0 -c -B \"${COMPILER_DIR}\"/ $COMPILER_FLAGS \"$INPUT\" -o \"$OUTPUT\""
+}

--- a/frontend/src/components/compiler/compiler_settings/gcc.tsx
+++ b/frontend/src/components/compiler/compiler_settings/gcc.tsx
@@ -1,0 +1,15 @@
+import { Checkbox, FlagSet, FlagOption } from "../CompilerOpts"
+
+export function CommonGccFlags() {
+    return <>
+        <FlagSet name="Optimization level">
+            <FlagOption flag="-O0" description="No optimization" />
+            <FlagOption flag="-O1" description="Some optimization" />
+            <FlagOption flag="-O2" description="Standard optimization" />
+        </FlagSet>
+
+        <Checkbox flag="-fforce-addr" description="Load pointers into registers before use" />
+
+        <Checkbox flag="-Wall" description="Enable all warning types" />
+    </>
+}

--- a/frontend/src/components/compiler/compilers/gcc2.6.3-mipsel.tsx
+++ b/frontend/src/components/compiler/compilers/gcc2.6.3-mipsel.tsx
@@ -1,0 +1,6 @@
+import { CommonGccFlags } from "../compiler_settings/gcc"
+
+export const name = "GCC 2.6.3"
+export const id = "gcc263"
+
+export const Flags = () => CommonGccFlags()

--- a/frontend/src/components/compiler/compilers/index.ts
+++ b/frontend/src/components/compiler/compilers/index.ts
@@ -8,6 +8,7 @@ import * as Clang391 from "./clang-3.9.1"
 import * as Clang401 from "./clang-4.0.1"
 import * as Dummy from "./dummy"
 import * as EeGcc296 from "./ee-gcc2.96"
+import * as Gcc263mipsel from "./gcc2.6.3-mipsel"
 import * as Gcc27kmc from "./gcc2.7kmc"
 import * as Gcc281 from "./gcc2.8.1"
 import * as Ido53 from "./ido5.3"
@@ -61,6 +62,7 @@ const COMPILERS: CompilerModule[] = [
     Ido53,
     Ido71,
     Gcc27kmc,
+    Gcc263mipsel,
     EeGcc296,
     Mwcc20b72,
     Mwcc20b79,


### PR DESCRIPTION
Some PlayStation 1 games released between 1995 and 1997 uses GCC 2.6.x. As this compiler is not yet installed in the repo, this pull request aims to add its support.

Note that GCC 2.6.3 will always be downloaded from the tag `release` from [decompals' gcc repo](https://github.com/decompals/old-gcc/releases/tag/release).

I am marking the PR as draft as I am not currently able to spin-up an instance of decomp.me locally, but I also want to get feedback from the proposed change.