### PR TITLE
backend: Fix `musl` for `clang-3.9.1`

### DIFF
--- a/backend/compilers/clang-3.9.1/config.json
+++ b/backend/compilers/clang-3.9.1/config.json
@@ -1,4 +1,4 @@
 {
     "platform": "switch",
-    "cc": "TOOLROOT=\"$COMPILER_DIR\" \"$COMPILER_DIR\"/bin/clang++ -target aarch64-linux-elf -fuse-ld=lld -mcpu=cortex-a57+fp+simd+crypto+crc -mno-implicit-float -fstandalone-debug -fPIC -Wl,-Bsymbolic-functions -shared -stdlib=libc++ -nostdlib $COMPILER_FLAGS -o \"$OUTPUT\" \"$INPUT\""
+    "cc": "TOOLROOT=\"$COMPILER_DIR\" \"$COMPILER_DIR\"/bin/clang++ -target aarch64-linux-elf --sysroot=\"$COMPILER_DIR\"/botw-lib-musl-25ed8669943bee65a650700d340e451eda2a26ba -D_LIBCPP_HAS_MUSL_LIBC -fuse-ld=lld -mcpu=cortex-a57+fp+simd+crypto+crc -mno-implicit-float -fstandalone-debug -fPIC -Wl,-Bsymbolic-functions -shared -stdlib=libc++ -nostdlib $COMPILER_FLAGS -o \"$OUTPUT\" \"$INPUT\""
 }

--- a/backend/compilers/clang.sh
+++ b/backend/compilers/clang.sh
@@ -26,7 +26,7 @@ fi
 # set up musl
 curl -L https://github.com/open-ead/botw-lib-musl/archive/25ed8669943bee65a650700d340e451eda2a26ba.zip > /tmp/musl.zip
 unzip -d /tmp /tmp/musl.zip
-#cp -r /tmp/botw-lib-musl-25ed8669943bee65a650700d340e451eda2a26ba "$compiler_dir/clang-3.9.1" # commented out because of a compatibility issue
+cp -r /tmp/botw-lib-musl-25ed8669943bee65a650700d340e451eda2a26ba "$compiler_dir/clang-3.9.1"
 cp -r /tmp/botw-lib-musl-25ed8669943bee65a650700d340e451eda2a26ba "$compiler_dir/clang-4.0.1"
 rm -r /tmp/botw-lib-musl-25ed8669943bee65a650700d340e451eda2a26ba
 rm /tmp/musl.zip


### PR DESCRIPTION
By adding the compiler flag `-D_LIBCPP_HAS_MUSL_LIBC`, the broken parts of musl/clang can be circumvented. The [testing scratch](https://decomp.me/scratch/MaJuR) compiles fine with this on version 3.9.1.