### PR TITLE
frontend: Fix scratch exporting (#326)

### DIFF
--- a/frontend/src/components/Scratch/ScratchToolbar.tsx
+++ b/frontend/src/components/Scratch/ScratchToolbar.tsx
@@ -29,7 +29,7 @@ function htmlTextOnly(html: string): string {
 }
 
 function exportScratchZip(scratch: api.Scratch) {
-    const url = `${scratch.url}/export`
+    const url = api.getURL(`${scratch.url}/export`)
     const a = document.createElement("a")
     a.href = url
     a.download = scratch.name + ".zip"

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -56,10 +56,15 @@ export class ResponseError extends Error {
     }
 }
 
-export async function get(url: string, useCacheIfFresh = false) {
+export function getURL(url: string) {
     if (url.startsWith("/")) {
         url = API_BASE + url
     }
+    return url
+}
+
+export async function get(url: string, useCacheIfFresh = false) {
+    url = getURL(url)
 
     const response = await fetch(url, {
         ...commonOpts,
@@ -87,9 +92,7 @@ export async function get(url: string, useCacheIfFresh = false) {
 export const getCached = (url: string) => get(url, true)
 
 export async function post(url: string, json: Json) {
-    if (url.startsWith("/")) {
-        url = API_BASE + url
-    }
+    url = getURL(url)
 
     const body: string = JSON.stringify(json)
 
@@ -112,9 +115,7 @@ export async function post(url: string, json: Json) {
 }
 
 export async function patch(url: string, json: Json) {
-    if (url.startsWith("/")) {
-        url = API_BASE + url
-    }
+    url = getURL(url)
 
     const body = JSON.stringify(json)
 


### PR DESCRIPTION
Related: Issue [#326](https://github.com/decompme/decomp.me/issues/326)

This fixes the exporting of scratches as `zip` files from the site.

Due to earlier changes, it seems like some endpoint for scratches was moved between frontend and backend. The `scratch.url` only contains the "ending" of the URL, so for example `/scratch/bvwj6`. It does *not* contain the URL/API http-endpoint, so the browser relates it to the frontend instead of the backend. Instead, the URL has to be resolved to point to the exporting part of the backend.

As the duplicate code would start to pile up for resolving this kind of "URL-ending" to a full URL, I moved that to a separate function that can be called for directly getting API data, or only for resolving the URL like in this case.