### PR TITLE
Remove `FRONTEND_BASE`

### DIFF
--- a/.env
+++ b/.env
@@ -3,7 +3,6 @@ DUMMY_COMPILER=on
 SECRET_KEY=django-insecure-nm#!8%z$hc0wwi#m_*l9l)=m*6gs4&o_^-e5b5vj*k05&yaqc1
 DATABASE_URL=sqlite:///dev.db
 API_BASE=http://127.0.0.1:8000/api
-FRONTEND_BASE=http://127.0.0.1:8080
 USE_SANDBOX_JAIL=on
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=

--- a/README.md
+++ b/README.md
@@ -39,11 +39,6 @@ Dependencies:
 touch .env.local
 ```
 
-- Add `FRONTEND_BASE` to the file:
-```shell
-echo "FRONTEND_BASE=http://localhost:8080" > .env.local
-```
-
 ### Frontend
 ```shell
 cd frontend
@@ -175,7 +170,6 @@ ln -s /etc/nginx/sites-available/decomp.local /etc/nginx/sites-enabled/decomp.lo
 
 - Edit `.env.local`:
     - Set `API_BASE=/api`
-    - Set `FRONTEND_BASE=http://decomp.local`
     - Set `ALLOWED_HOSTS=decomp.local`
 
 - If you set up GitHub authentication, change the application URLs to `http://decomp.local` and `http://decomp.local/login`

--- a/backend/coreapp/models.py
+++ b/backend/coreapp/models.py
@@ -2,8 +2,6 @@ from django.utils.crypto import get_random_string
 from django.db import models
 from django.contrib.auth.models import User
 
-from decompme.settings import FRONTEND_BASE
-
 def gen_scratch_id() -> str:
     ret = get_random_string(length=5)
 

--- a/backend/coreapp/serializers.py
+++ b/backend/coreapp/serializers.py
@@ -6,7 +6,6 @@ from typing import Any, Optional, TYPE_CHECKING
 from .models import Profile, Scratch
 from .github import GitHubUser
 from .middleware import Request
-from decompme.settings import FRONTEND_BASE
 
 def serialize_profile(request: Request, profile: Profile, small = False):
     if profile.user is None:
@@ -79,7 +78,7 @@ class UrlField(serializers.HyperlinkedIdentityField):
 class HtmlUrlField(UrlField):
     """
     Read-only field that takes the value returned by the model's get_html_url method.
-    get_html_url should return a path relative to FRONTEND_BASE that can be used to look at the HTML page for the model.
+    get_html_url should return a path relative to the frontend that can be used to look at the HTML page for the model.
     """
 
     def get_url(self, value, view_name, request, format):

--- a/backend/decompme/settings.py
+++ b/backend/decompme/settings.py
@@ -30,7 +30,6 @@ env = environ.Env(
     COMPILER_BASE_PATH=(str, BASE_DIR / "compilers"),
     COMPILATION_CACHE_SIZE=(int, 100),
     WINEPREFIX=(str, "/tmp/wine"),
-    FRONTEND_BASE=(str, "https://decomp.me"),
 )
 
 for stem in [".env.local", ".env"]:
@@ -44,7 +43,6 @@ DEBUG = env('DEBUG')
 DJANGO_LOG_LEVEL = env('DJANGO_LOG_LEVEL')
 DUMMY_COMPILER = env('DUMMY_COMPILER')
 ALLOWED_HOSTS = env('ALLOWED_HOSTS')
-FRONTEND_BASE = env('FRONTEND_BASE')
 
 # Application definition
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -31,7 +31,6 @@ services:
       ALLOWED_HOSTS: "backend,localhost,127.0.0.1"
       USE_SANDBOX_JAIL: "on"
       COMPILER_BASE_PATH: /compilers
-      FRONTEND_BASE: http://localhost:8080
     ports:
     - "8000:8000"
     security_opt:


### PR DESCRIPTION
As this configuration setting seems to be unused at the moment, it can be removed. This removes all references to the environment variable and local python storage in the backend, as well as the README and one comment still referring to that name.