### PR TITLE
execute 'poetry install' at runtime, same as yarn install

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -115,8 +115,8 @@ jobs:
             -e WINEPREFIX=/tmp/wine \
             -e LOCAL_FILE_DIR=/local_files \
             decompme_backend -c 'cd /decomp.me/backend && \
-            /home/user/.local/bin/poetry install && \
-            /home/user/.local/bin/poetry run python manage.py test'
+            poetry install && \
+            poetry run python manage.py test'
 
   frontend_test:
     name: frontend tests

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,9 @@ __pycache__
 node_modules
 build
 .snowpack
+local_files/
 backend/local_files/
+backend/virtualenvs/
 postgres/
 sandbox/
 *.db

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get -y update && apt-get install -y \
     pkg-config \
     protobuf-compiler
 
-# TODO: change this when they tag a release
+# TODO: change this when they tag a release (see https://github.com/google/nsjail/issues/190)
 RUN git clone --recursive --shallow-submodules "https://github.com/google/nsjail" /nsjail \
     && cd /nsjail \
     && git checkout aa0becd547d835ac9b9d63a9536c23530c8d992e \
@@ -49,25 +49,8 @@ RUN apt-get -y update && apt-get install -y \
     libc6-dev-i386 \
     && rm -rf /var/lib/apt/lists/*
 
-
-ENV WINEPREFIX=/tmp/wine
-
-# create a non-root user & /sandbox with correct ownership
-RUN useradd --create-home user \
-    && mkdir -p /sandbox \
-    && chown -R user:user /sandbox \
-    && mkdir -p "${WINEPREFIX}" \
-    && chown user:user "${WINEPREFIX}"
-
-COPY pyproject.toml /backend/pyproject.toml
-COPY poetry.lock /backend/poetry.lock
-
-# Install poetry and dependencies
-USER user
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python -
-ENV PATH="/home/user/.local/bin:$PATH"
-RUN cd backend && poetry install
-USER root
+RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | \
+  POETRY_VERSION=1.1.13 POETRY_HOME=/etc/poetry python -
 
 COPY --from=nsjail /nsjail/nsjail /bin/nsjail
 
@@ -112,6 +95,15 @@ RUN if [ "${ENABLE_SWITCH_SUPPORT}" = "YES" ] ; then \
 
 WORKDIR /backend
 
+ENV WINEPREFIX=/tmp/wine
+
+# create a non-root user & /sandbox with correct ownership
+RUN useradd --create-home user \
+    && mkdir -p /sandbox \
+    && chown -R user:user /sandbox \
+    && mkdir -p "${WINEPREFIX}" \
+    && chown user:user "${WINEPREFIX}"
+
 # switch to non-root user
 USER user
 
@@ -121,6 +113,8 @@ RUN if [ "${ENABLE_PS1_SUPPORT}" = "YES" ] || \
        [ "${ENABLE_NDS_SUPPORT}" = "YES" ]; then \
     wineboot --init; \
     fi
+
+ENV PATH="$PATH:/etc/poetry/bin"
 
 ENTRYPOINT ["/backend/docker_entrypoint.sh"]
 

--- a/backend/docker_entrypoint.sh
+++ b/backend/docker_entrypoint.sh
@@ -11,6 +11,10 @@ until nc -z ${DB_HOST} ${DB_PORT} > /dev/null; do
   sleep 1
 done
 
+poetry config virtualenvs.path /backend/virtualenvs
+
+poetry install
+
 poetry run /backend/manage.py migrate
 
 poetry run /backend/manage.py loaddata /backend/db.json

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -31,6 +31,7 @@ services:
       ALLOWED_HOSTS: "backend,localhost,127.0.0.1"
       USE_SANDBOX_JAIL: "on"
       COMPILER_BASE_PATH: /compilers
+      LOCAL_FILE_DIRL: /local_files
     ports:
     - "8000:8000"
     security_opt:
@@ -38,6 +39,7 @@ services:
       - seccomp=unconfined
     volumes:
     - ./backend:/backend
+    - ./local_files:/local_files
     tmpfs:
     # Use a separate tmpfs to prevent a rogue jailed process
     # from filling /tmp on the parent container


### PR DESCRIPTION
This PR changes the poetry behaviour to match the approach we take for the `frontend`, where the dependencies are pulled down at runtime, and cached locally (in this case `/backend/virtualenvs` vs than `/frontend/node_modules`) so that future instantiations are speedy:

e.g. frontend:
```
frontend_1  | yarn install v1.22.17
frontend_1  | [1/4] Resolving packages...
frontend_1  | success Already up-to-date.
```
and backend:
```
backend_1   | Installing dependencies from lock file
backend_1   | No dependencies to install or update
```

I also pinned poetry to the current version, `1.1.13`.