### PR TITLE
Request OAuth scopes on-demand

### DIFF
--- a/backend/coreapp/error.py
+++ b/backend/coreapp/error.py
@@ -20,6 +20,9 @@ def custom_exception_handler(exc, context):
             status=HTTP_400_BAD_REQUEST,
         )
 
+    if response is not None:
+        response.data["kind"] = exc.__class__.__name__
+
     return response
 
 

--- a/backend/coreapp/models/github.py
+++ b/backend/coreapp/models/github.py
@@ -99,10 +99,6 @@ class GitHubUser(models.Model):
         except KeyError:
             raise MalformedGitHubApiResponseException()
 
-        scopes = scope_str.split(",")
-        if not "public_repo" in scopes:
-            raise MissingOAuthScopeException("public_repo")
-
         details = Github(access_token).get_user()
 
         try:

--- a/frontend/src/components/GitHubLoginButton.tsx
+++ b/frontend/src/components/GitHubLoginButton.tsx
@@ -1,36 +1,12 @@
 import { MarkGithubIcon } from "@primer/octicons-react"
-import { useSWRConfig } from "swr"
+
+import { isGitHubLoginSupported, showGitHubLoginWindow } from "../lib/oauth"
 
 import Button from "./Button"
 
-const GITHUB_CLIENT_ID = process.env.NEXT_PUBLIC_GITHUB_CLIENT_ID ?? process.env.STORYBOOK_GITHUB_CLIENT_ID
-
-// https://docs.github.com/en/developers/apps/building-oauth-apps/scopes-for-oauth-apps
-const SCOPES = ["public_repo"]
-
-const LOGIN_URL = `https://github.com/login/oauth/authorize?client_id=${GITHUB_CLIENT_ID}&scope=${SCOPES.join("%20")}`
-
 export default function GitHubLoginButton({ label, popup, className }: { label?: string, popup: boolean, className?: string }) {
-    const { mutate } = useSWRConfig()
-
-    const showLoginWindow = () => {
-        const win = popup && window.open(LOGIN_URL, "Sign in with GitHub", "popup,width=520,height=400,resizable,status")
-
-        if (win) {
-            win.addEventListener("message", event => {
-                if (event.data?.source === "decomp_me_login") {
-                    console.info("Got new user from popup", event.data.user)
-                    mutate("/user", event.data.user)
-                }
-            })
-        } else {
-            console.warn("Login popup was blocked")
-            window.location.href = LOGIN_URL
-        }
-    }
-
-    if (GITHUB_CLIENT_ID) {
-        return <Button className={className} onClick={showLoginWindow}>
+    if (isGitHubLoginSupported()) {
+        return <Button className={className} onClick={() => showGitHubLoginWindow(popup, "")}>
             <MarkGithubIcon size={16} /> {label ?? "Sign in with GitHub"}
         </Button>
     } else {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -42,16 +42,16 @@ function undefinedIfUnchanged<O, K extends keyof O>(saved: O, local: O, key: K):
 
 export class ResponseError extends Error {
     status: number
-    responseJSON: Json
+    json: Json
     code: string
 
-    constructor(response: Response, responseJSON) {
+    constructor(response: Response, json) {
         super(`Server responded with HTTP status code ${response.status}`)
 
         this.status = response.status
-        this.responseJSON = responseJSON
-        this.code = responseJSON.code
-        this.message = responseJSON?.detail
+        this.json = json
+        this.code = json.code
+        this.message = json?.detail
         this.name = "ResponseError"
     }
 }
@@ -419,7 +419,7 @@ export function useCompilation(scratch: Scratch | null, autoRecompile = true, au
             setCompileRequestPromise(null)
             setIsCompilationOld(false)
         }).catch(error => {
-            setCompilation({ "errors": error.responseJSON?.detail, "diff_output": null })
+            setCompilation({ "errors": error.json?.detail, "diff_output": null })
         })
 
         setCompileRequestPromise(promise)

--- a/frontend/src/lib/oauth.ts
+++ b/frontend/src/lib/oauth.ts
@@ -1,0 +1,43 @@
+import { mutate } from "swr"
+
+import { ResponseError } from "./api"
+
+const GITHUB_CLIENT_ID = process.env.NEXT_PUBLIC_GITHUB_CLIENT_ID ?? process.env.STORYBOOK_GITHUB_CLIENT_ID
+
+export function isGitHubLoginSupported(): boolean {
+    return !!GITHUB_CLIENT_ID
+}
+
+// https://docs.github.com/en/developers/apps/building-oauth-apps/scopes-for-oauth-apps
+export function showGitHubLoginWindow(popup: boolean, scope: string) {
+    const url = `https://github.com/login/oauth/authorize?client_id=${GITHUB_CLIENT_ID}&scope=${encodeURIComponent(scope)}`
+    const win = popup && window.open(url, "Sign in with GitHub", "popup,width=520,height=400,resizable,status")
+
+    if (win) {
+        win.addEventListener("message", event => {
+            if (event.data?.source === "decomp_me_login") {
+                console.info("Got new user from popup", event.data.user)
+                mutate("/user", event.data.user)
+            }
+        })
+    } else {
+        window.location.href = url
+    }
+}
+
+export async function requestMissingScopes<T>(makeRequest: () => Promise<T>): Promise<T> {
+    try {
+        return await makeRequest()
+    } catch (error) {
+        if (error instanceof ResponseError && error.json.kind == "MissingOAuthScopeException") {
+            const scope = error.json.detail
+
+            console.warn("Missing scopes", scope)
+            showGitHubLoginWindow(true, scope)
+
+            return await requestMissingScopes(makeRequest)
+        } else {
+            throw error
+        }
+    }
+}


### PR DESCRIPTION
Fixes #390, although without the deployment stuff mentioned + `scopes` is not stored in the database (because we can just lazily raise MissingOAuthScopeException if the GitHub API complains that we lack permission for an action).

- request oauth scopes only when server asks
- don't require public_repo
