### PR TITLE
[WIP, testers needed] implement gcc 4.0.1 cross compiler from amd64 linux to ppc mac os x

### DIFF
--- a/backend/compilers/download.py
+++ b/backend/compilers/download.py
@@ -183,6 +183,32 @@ def download_gba():
         "agbccpp",
     )
 
+def download_ppc_darwin():
+    if host_os != LINUX:
+        return
+    download_zip(
+        url="https://github.com/ChrisNonyminus/powerpc-darwin-cross/releases/download/initial/powerpc-darwin-cross.new.zip",
+        dl_name="powerpc-darwin-cross.zip",
+        dest_name="powerpc-darwin-cross",
+        create_subdir=True,
+    )
+    download_zip(
+        url="https://github.com/ChrisNonyminus/powerpc-darwin-cross/releases/download/initial/powerpc-darwin-cross.new.zip",
+        dl_name="powerpc-darwin-cross.zip",
+        dest_name="powerpc-darwin-cross-cpp",
+        create_subdir=True,
+    )
+    download_file(
+        url="https://raw.githubusercontent.com/ChrisNonyminus/sims2_mac_decomp/master/tools/convert_gas_syntax.py",
+        log_name="convert_gas_syntax.py",
+        dest_path=COMPILERS_DIR / "powerpc-darwin-cross" / "convert_gas_syntax.py",
+    )
+    download_file(
+        url="https://raw.githubusercontent.com/ChrisNonyminus/sims2_mac_decomp/master/tools/convert_gas_syntax.py",
+        log_name="convert_gas_syntax.py",
+        dest_path=COMPILERS_DIR / "powerpc-darwin-cross-cpp" / "convert_gas_syntax.py",
+    )
+
 
 def download_switch():
     def dest_for_version(version: str) -> Path:
@@ -471,6 +497,8 @@ def main(args):
         download_ps1()
     if should_download("switch"):
         download_switch()
+    if should_download("darwin"):
+        download_ppc_darwin()
     if should_download("wii_gc"):
         download_wii_gc()
 

--- a/backend/coreapp/compiler_wrapper.py
+++ b/backend/coreapp/compiler_wrapper.py
@@ -102,7 +102,7 @@ class CompilerWrapper:
     @staticmethod
     @lru_cache(maxsize=settings.COMPILATION_CACHE_SIZE)  # type: ignore
     def compile_code(
-        compiler: Compiler, compiler_flags: str, code: str, context: str
+        compiler: Compiler, compiler_flags: str, code: str, context: str, function: str
     ) -> CompilationResult:
         if compiler == compilers.DUMMY:
             return CompilationResult(f"compiled({context}\n{code}".encode("UTF-8"), "")
@@ -141,6 +141,8 @@ class CompilerWrapper:
                         "OUTPUT": sandbox.rewrite_path(object_path),
                         "COMPILER_DIR": sandbox.rewrite_path(compiler.path),
                         "COMPILER_FLAGS": sandbox.quote_options(compiler_flags),
+                        "GENERATED_ASM": sandbox.rewrite_path(code_path).replace("code.c", "code.s"),
+                        "FUNCTION_TO_DIFF": function,
                         "MWCIncludes": "/tmp",
                     },
                 )

--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -8,6 +8,7 @@ from coreapp.flags import (
     COMMON_CLANG_FLAGS,
     COMMON_GCC_FLAGS,
     COMMON_IDO_FLAGS,
+    COMMON_MWCC_EPPC_FLAGS,
     COMMON_MWCC_FLAGS,
     COMMON_GCC_PS1_FLAGS,
     FlagSet,
@@ -16,7 +17,7 @@ from coreapp.flags import (
 
 from coreapp import platforms
 
-from coreapp.platforms import GBA, GC_WII, N64, NDS_ARM9, Platform, PS1, PS2, SWITCH
+from coreapp.platforms import DARWIN, GBA, GC_WII, N64, NDS_ARM9, Platform, PS1, PS2, SWITCH
 
 logger = logging.getLogger(__name__)
 
@@ -92,6 +93,11 @@ class IDOCompiler(Compiler):
 class MWCCCompiler(Compiler):
     is_mwcc: ClassVar[bool] = True
     flags: ClassVar[Flags] = COMMON_MWCC_FLAGS
+
+
+@dataclass(frozen=True)
+class MWCCEPPCCompiler(MWCCCompiler):
+    flags: ClassVar[Flags] = COMMON_MWCC_EPPC_FLAGS
 
 
 def from_id(compiler_id: str) -> Compiler:
@@ -170,6 +176,19 @@ CLANG_401 = ClangCompiler(
             "-x c++ -O3 -g2 -std=c++1z -fno-rtti -fno-exceptions -Wall -Wextra -Wdeprecated -Wno-unused-parameter -Wno-unused-private-field -fno-strict-aliasing -Wno-invalid-offsetof -D SWITCH -D NNSDK -D MATCHING_HACK_NX_CLANG",
         ),
     ],
+)
+
+# DARWIN
+DARWIN_GCC401 = GCCCompiler(
+    id="powerpc-darwin-cross",
+    platform=DARWIN,
+    cc='"${COMPILER_DIR}"/powerpc-darwin-cross/bin/cc1 $COMPILER_FLAGS "$INPUT" -D__ppc__ -D__POWERPC__ -D__NATURAL_ALIGNMENT__ -D__MACH__ -D__BIG_ENDIAN__ -D__APPLE__ -I${COMPILER_DIR}/powerpc-darwin-cross/powerpc-apple-darwin/include -I${COMPILER_DIR}/powerpc-darwin-cross/powerpc-apple-darwin/include/c++/4.0.0 -I${COMPILER_DIR}/powerpc-darwin-cross/powerpc-apple-darwin/include/c++/4.0.0/powerpc-apple-darwin8 -I${COMPILER_DIR}/powerpc-darwin-cross/powerpc-apple-darwin/include/gcc/darwin/3.3 -o "$GENERATED_ASM"; python3 "${COMPILER_DIR}"/convert_gas_syntax.py "$GENERATED_ASM" "$FUNCTION_TO_DIFF" new | powerpc-linux-gnu-as -o "$OUTPUT"',
+)
+
+DARWIN_GCC401_CPP = GCCCompiler(
+    id="powerpc-darwin-cross-cpp",
+    platform=DARWIN,
+    cc='"${COMPILER_DIR}"/powerpc-darwin-cross/bin/cc1plus $COMPILER_FLAGS "$INPUT" -D__ppc__ -D__POWERPC__ -D__NATURAL_ALIGNMENT__ -D__MACH__ -D__BIG_ENDIAN__ -D__APPLE__ -I${COMPILER_DIR}/powerpc-darwin-cross/powerpc-apple-darwin/include -I${COMPILER_DIR}/powerpc-darwin-cross/powerpc-apple-darwin/include/c++/4.0.0 -I${COMPILER_DIR}/powerpc-darwin-cross/powerpc-apple-darwin/include/c++/4.0.0/powerpc-apple-darwin8 -I${COMPILER_DIR}/powerpc-darwin-cross/powerpc-apple-darwin/include/gcc/darwin/3.3 -o "$GENERATED_ASM"; python3 "${COMPILER_DIR}"/convert_gas_syntax.py "$GENERATED_ASM" "$FUNCTION_TO_DIFF" new | powerpc-linux-gnu-as -o "$OUTPUT"',
 )
 
 # PS1
@@ -283,13 +302,13 @@ GCC281 = GCCCompiler(
 # GC_WII
 MWCCEPPC_CC = '${WINE} "${COMPILER_DIR}/mwcceppc.exe" -c -proc gekko -nostdinc -stderr ${COMPILER_FLAGS} -o "${OUTPUT}" "${INPUT}"'
 
-MWCC_233_144 = MWCCCompiler(
+MWCC_233_144 = MWCCEPPCCompiler(
     id="mwcc_233_144",
     platform=GC_WII,
     cc=MWCCEPPC_CC,
 )
 
-MWCC_233_159 = MWCCCompiler(
+MWCC_233_159 = MWCCEPPCCompiler(
     id="mwcc_233_159",
     platform=GC_WII,
     cc=MWCCEPPC_CC,
@@ -301,7 +320,7 @@ MWCC_233_159 = MWCCCompiler(
     ],
 )
 
-MWCC_233_163 = MWCCCompiler(
+MWCC_233_163 = MWCCEPPCCompiler(
     id="mwcc_233_163",
     platform=GC_WII,
     cc=MWCCEPPC_CC,
@@ -313,7 +332,7 @@ MWCC_233_163 = MWCCCompiler(
     ],
 )
 
-MWCC_233_163E = MWCCCompiler(
+MWCC_233_163E = MWCCEPPCCompiler(
     id="mwcc_233_163e",
     platform=GC_WII,
     cc='${WINE} "${COMPILER_DIR}/mwcceppc.125.exe" -c -proc gekko -nostdinc -stderr ${COMPILER_FLAGS} -o "${OUTPUT}.1" "${INPUT}" && ${WINE} "${COMPILER_DIR}/mwcceppc.exe" -c -proc gekko -nostdinc -stderr ${COMPILER_FLAGS} -o "${OUTPUT}.2" "${INPUT}" && python3 "${COMPILER_DIR}/frank.py" "${OUTPUT}.1" "${OUTPUT}.2" "${OUTPUT}"',
@@ -329,13 +348,13 @@ MWCC_233_163E = MWCCCompiler(
     ],
 )
 
-MWCC_242_81 = MWCCCompiler(
+MWCC_242_81 = MWCCEPPCCompiler(
     id="mwcc_242_81",
     platform=GC_WII,
     cc=MWCCEPPC_CC,
 )
 
-MWCC_247_92 = MWCCCompiler(
+MWCC_247_92 = MWCCEPPCCompiler(
     id="mwcc_247_92",
     platform=GC_WII,
     cc=MWCCEPPC_CC,
@@ -347,13 +366,13 @@ MWCC_247_92 = MWCCCompiler(
     ],
 )
 
-MWCC_247_105 = MWCCCompiler(
+MWCC_247_105 = MWCCEPPCCompiler(
     id="mwcc_247_105",
     platform=GC_WII,
     cc=MWCCEPPC_CC,
 )
 
-MWCC_247_107 = MWCCCompiler(
+MWCC_247_107 = MWCCEPPCCompiler(
     id="mwcc_247_107",
     platform=GC_WII,
     cc=MWCCEPPC_CC,
@@ -365,7 +384,7 @@ MWCC_247_107 = MWCCCompiler(
     ],
 )
 
-MWCC_247_108 = MWCCCompiler(
+MWCC_247_108 = MWCCEPPCCompiler(
     id="mwcc_247_108",
     platform=GC_WII,
     cc=MWCCEPPC_CC,
@@ -381,7 +400,7 @@ MWCC_247_108 = MWCCCompiler(
     ],
 )
 
-MWCC_41_60831 = MWCCCompiler(
+MWCC_41_60831 = MWCCEPPCCompiler(
     id="mwcc_41_60831",
     platform=GC_WII,
     cc=MWCCEPPC_CC,
@@ -401,37 +420,37 @@ MWCC_41_60831 = MWCCCompiler(
     ],
 )
 
-MWCC_41_60126 = MWCCCompiler(
+MWCC_41_60126 = MWCCEPPCCompiler(
     id="mwcc_41_60126",
     platform=GC_WII,
     cc=MWCCEPPC_CC,
     presets=[
         Preset(
             "Super Mario Galaxy",
-            "-Cpp_exceptions off -stdinc -nodefaults -fp hard -lang=c++ -inline auto,level=2 -ipa file -O4,s -rtti off -sdata 4 -sdata2 4 -enum int",
+            "-Cpp_exceptions off -stdinc -nodefaults -fp hard -lang=c++ -inline auto,level=2 -ipa file -O4,s -rtti off -sdata 4 -sdata2 4 -align powerpc -enum int",
         ),
     ],
 )
 
-MWCC_42_142 = MWCCCompiler(
+MWCC_42_142 = MWCCEPPCCompiler(
     id="mwcc_42_142",
     platform=GC_WII,
     cc=MWCCEPPC_CC,
 )
 
-MWCC_43_151 = MWCCCompiler(
+MWCC_43_151 = MWCCEPPCCompiler(
     id="mwcc_43_151",
     platform=GC_WII,
     cc=MWCCEPPC_CC,
 )
 
-MWCC_43_172 = MWCCCompiler(
+MWCC_43_172 = MWCCEPPCCompiler(
     id="mwcc_43_172",
     platform=GC_WII,
     cc=MWCCEPPC_CC,
 )
 
-MWCC_43_213 = MWCCCompiler(
+MWCC_43_213 = MWCCEPPCCompiler(
     id="mwcc_43_213",
     platform=GC_WII,
     cc=MWCCEPPC_CC,
@@ -655,6 +674,9 @@ _all_compilers: List[Compiler] = [
     MWCC_40_1034,
     MWCC_40_1036,
     MWCC_40_1051,
+    # DARWIN
+    DARWIN_GCC401,
+    DARWIN_GCC401_CPP,
 ]
 
 _compilers = OrderedDict({c.id: c for c in _all_compilers if c.available()})

--- a/backend/coreapp/platforms.py
+++ b/backend/coreapp/platforms.py
@@ -129,6 +129,90 @@ PS2 = Platform(
 """,
 )
 
+DARWIN = Platform(
+    id="darwin",
+    name="Mac OS X",
+    description="PowerPC",
+    arch="ppc",
+    assemble_cmd='powerpc-linux-gnu-as -o "$OUTPUT" "$INPUT"',
+    objdump_cmd="powerpc-linux-gnu-objdump",
+    nm_cmd="powerpc-linux-gnu-nm",
+    asm_prelude="""
+    .set r0, 0
+    .set r1, 1
+    .set r2, 2
+    .set r3, 3
+    .set r4, 4
+    .set r5, 5
+    .set r6, 6
+    .set r7, 7
+    .set r8, 8
+    .set r9, 9
+    .set r10, 10
+    .set r11, 11
+    .set r12, 12
+    .set r13, 13
+    .set r14, 14
+    .set r15, 15
+    .set r16, 16
+    .set r17, 17
+    .set r18, 18
+    .set r19, 19
+    .set r20, 20
+    .set r21, 21
+    .set r22, 22
+    .set r23, 23
+    .set r24, 24
+    .set r25, 25
+    .set r26, 26
+    .set r27, 27
+    .set r28, 28
+    .set r29, 29
+    .set r30, 30
+    .set r31, 31
+    .set f0, 0
+    .set f1, 1
+    .set f2, 2
+    .set f3, 3
+    .set f4, 4
+    .set f5, 5
+    .set f6, 6
+    .set f7, 7
+    .set f8, 8
+    .set f9, 9
+    .set f10, 10
+    .set f11, 11
+    .set f12, 12
+    .set f13, 13
+    .set f14, 14
+    .set f15, 15
+    .set f16, 16
+    .set f17, 17
+    .set f18, 18
+    .set f19, 19
+    .set f20, 20
+    .set f21, 21
+    .set f22, 22
+    .set f23, 23
+    .set f24, 24
+    .set f25, 25
+    .set f26, 26
+    .set f27, 27
+    .set f28, 28
+    .set f29, 29
+    .set f30, 30
+    .set f31, 31
+    .set qr0, 0
+    .set qr1, 1
+    .set qr2, 2
+    .set qr3, 3
+    .set qr4, 4
+    .set qr5, 5
+    .set qr6, 6
+    .set qr7, 7
+""",
+)
+
 GC_WII = Platform(
     id="gc_wii",
     name="GameCube / Wii",
@@ -298,5 +382,6 @@ _platforms: OrderedDict[str, Platform] = OrderedDict(
         "gc_wii": GC_WII,
         "nds_arm9": NDS_ARM9,
         "gba": GBA,
+        "darwin": DARWIN,
     }
 )

--- a/backend/coreapp/views/compilers.py
+++ b/backend/coreapp/views/compilers.py
@@ -7,6 +7,8 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from coreapp import compilers
 
+from coreapp import compilers
+
 from ..decorators.django import condition
 
 boot_time = now()
@@ -17,6 +19,7 @@ class CompilersDetail(APIView):
     def compilers_json() -> Dict[str, Dict[str, object]]:
         return {
             c.id: {
+                "name": "COMPILER NAME",  # c.name
                 "platform": c.platform.id,
                 "flags": [f.to_json() for f in c.flags],
                 "presets": [p.to_json() for p in c.presets],

--- a/backend/coreapp/views/scratch.py
+++ b/backend/coreapp/views/scratch.py
@@ -60,6 +60,7 @@ def compile_scratch(scratch: Scratch) -> CompilationResult:
         scratch.compiler_flags,
         scratch.source_code,
         scratch.context,
+        scratch.diff_label,
     )
 
 

--- a/frontend/src/components/compiler/CompilerFlags.tsx
+++ b/frontend/src/components/compiler/CompilerFlags.tsx
@@ -1,27 +1,19 @@
-import useTranslation from "next-translate/useTranslation"
-
 import * as api from "../../lib/api"
 
 import { Checkbox, FlagSet, FlagOption } from "./CompilerOpts"
-
-export const NO_TRANSLATION = "NO_TRANSLATION"
 
 export interface Props {
     schema: api.CompilerFlag[]
 }
 
 export default function CompilerFlags({ schema }: Props) {
-    const compilersTranslation = useTranslation("compilers")
-
     return <>
         {schema.map(flag => {
             if (flag.type === "checkbox") {
-                return <Checkbox key={flag.id} flag={flag.flag} description={compilersTranslation.t(flag.id)} />
+                return <Checkbox key={flag.id} flag={flag.flag} description={"Description"} />
             } else if (flag.type === "flagset") {
-                return <FlagSet key={flag.id} name={compilersTranslation.t(flag.id)}>
-                    {flag.flags.map(f => <FlagOption key={f} flag={f} description={
-                        compilersTranslation.t(flag.id + "." + f, null, { default: NO_TRANSLATION })
-                    } />)}
+                return <FlagSet key={flag.id} name={"Set name"}>
+                    {flag.flags.map(f => <FlagOption key={f} flag={f} description={"Description"} />)}
                 </FlagSet>
             }
         })}

--- a/frontend/src/components/compiler/CompilerOpts.tsx
+++ b/frontend/src/components/compiler/CompilerOpts.tsx
@@ -1,12 +1,10 @@
 import { createContext, useContext } from "react"
 
-import useTranslation from "next-translate/useTranslation"
-
 import * as api from "../../lib/api"
 import PlatformIcon from "../PlatformSelect/PlatformIcon"
 import Select from "../Select"
 
-import CompilerFlags, { NO_TRANSLATION } from "./CompilerFlags"
+import CompilerFlags from "./CompilerFlags"
 import styles from "./CompilerOpts.module.css"
 import { useCompilersForPlatform } from "./compilers"
 import PresetSelect from "./PresetSelect"
@@ -56,7 +54,7 @@ export function FlagOption({ flag, description }: { flag: string, description?: 
         value={flag}
         selected={checkFlag(flag)}
     >
-        {flag} {description && description !== NO_TRANSLATION && `(${description})`}
+        {flag} {description && `(${description})`}
     </option>
 }
 
@@ -132,8 +130,6 @@ export function OptsEditor({ platform, compiler: compilerId, setCompiler, opts, 
     opts: string
     setOpts: (opts: string) => void
 }) {
-    const compilersTranslation = useTranslation("compilers")
-
     const compilers = useCompilersForPlatform(platform)
     const compiler = compilers[compilerId]
 
@@ -149,12 +145,12 @@ export function OptsEditor({ platform, compiler: compilerId, setCompiler, opts, 
                 className={styles.compilerSelect}
                 onChange={e => setCompiler((e.target as HTMLSelectElement).value)}
             >
-                {Object.keys(compilers).map(id => <option
+                {Object.entries(compilers).map(([id, c]) => <option
                     key={id}
                     value={id}
                     selected={id === compilerId}
                 >
-                    {compilersTranslation.t(id)}
+                    {c.name}
                 </option>)}
             </Select>
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -285,6 +285,7 @@ export type CompilerPreset = {
 }
 
 export type Compiler = {
+    name: string
     platform: string
     flags: CompilerFlag[]
     presets: CompilerPreset[]

--- a/frontend/src/pages/new.tsx
+++ b/frontend/src/pages/new.tsx
@@ -6,7 +6,6 @@ import Link from "next/link"
 import { useRouter } from "next/router"
 
 import { usePlausible } from "next-plausible"
-import useTranslation from "next-translate/useTranslation"
 
 import AsyncButton from "../components/AsyncButton"
 import { useCompilersForPlatform } from "../components/compiler/compilers"
@@ -167,8 +166,6 @@ export default function NewScratch({ serverCompilers }: {
         }
     }
 
-    const { t } = useTranslation()
-
     return <>
         <PageTitle title="New scratch" />
         <Nav />
@@ -202,10 +199,10 @@ export default function NewScratch({ serverCompilers }: {
                         <span className={styles.compilerChoiceHeading}>Select a compiler</span>
                         <Select
                             className={styles.compilerChoiceSelect}
-                            options={Object.keys(platformCompilers).reduce((sum, id) => {
+                            options={Object.entries(platformCompilers).reduce((sum, [k, v]) => {
                                 return {
                                     ...sum,
-                                    [id]: t(`compilers:${id}`),
+                                    [k]: v.name,
                                 }
                             }, {})}
                             value={compilerId}

--- a/frontend/src/strings.json
+++ b/frontend/src/strings.json
@@ -1,0 +1,141 @@
+// WIP
+"clang_opt_level": "Optimization level"
+"clang_opt_level.-O0": "No optimization"
+"clang_opt_level.-O1": "Some optimization"
+"clang_opt_level.-O2": "Heavy optimization"
+"clang_opt_level.-O3": "Aggressive optimization at the expense of code size"
+"clang_opt_level.-Ofast": "All options from -O3 + optimizations that may violate strict compliance with language standards"
+"clang_opt_level.-Os": "Like -O2, but optimize for smallest code size"
+"clang_opt_level.-Oz": "Like -Os, but reduces code size further"
+"clang_debug_level": "Debug information"
+"clang_debug_level.-g0": "No debug info"
+"clang_debug_level.-g1": "Minimal trace info"
+"clang_debug_level.-g2": "Local variable tracking"
+"clang_debug_level.-g3": "Macro expansions"
+"clang_language": "Language"
+"clang_language.-x c++": "C++"
+"clang_language.-x c": "C"
+"clang_language_standard": "Language standard"
+"clang_language_standard.-std=c++98": "ISO C++ 1998 with amendments"
+"clang_language_standard.-std=c++03": "ISO C++ 1998 with amendments"
+"clang_language_standard.-std=gnu++98": "ISO C++ 1998 with amendments and GNU extensions"
+"clang_language_standard.-std=c++0x": "ISO C++ 2011 with amendments"
+"clang_language_standard.-std=c++11": "ISO C++ 2011 with amendments"
+"clang_language_standard.-std=gnu++0x": "ISO C++ 2011 with amendments and GNU extensions"
+"clang_language_standard.-std=gnu++11": "ISO C++ 2011 with amendments and GNU extensions"
+"clang_language_standard.-std=c++1y": "ISO C++ 2014 with amendments"
+"clang_language_standard.-std=c++14": "ISO C++ 2014 with amendments"
+"clang_language_standard.-std=gnu++1y": "ISO C++ 2014 with amendments and GNU extensions"
+"clang_language_standard.-std=gnu++14": "ISO C++ 2014 with amendments and GNU extensions"
+"clang_language_standard.-std=c++1z": "Working draft for ISO C++ 2017"
+"clang_language_standard.-std=gnu++1z": "Working draft for ISO C++ 2017 and GNU extensions"
+"clang_no_rtti": "Disable standard c++ runtime type information features"
+"clang_no_exceptions": "Disable exception handling"
+
+"gcc_opt_level": "Optimization level"
+"gcc_opt_level.-O0": "No optimization"
+"gcc_opt_level.-O1": "Some optimization"
+"gcc_opt_level.-O2": "Standard optimization"
+"gcc_opt_level.-O3": "Heavy optimization"
+"gcc_debug_level": "Debug information"
+"gcc_debug_level.-g0": "No debug info"
+"gcc_debug_level.-g1": "Minimal trace info"
+"gcc_debug_level.-g2": "Local variable tracking"
+"gcc_debug_level.-g3": "Macro expansions"
+
+"ido_opt_level": "Optimization level"
+"ido_opt_level.-O0": "No optimization"
+"ido_opt_level.-O1": "Some optimization"
+"ido_opt_level.-O2": "Standard optimization"
+"ido_opt_level.-O3": "Heavy optimization"
+"ido_debug_level": "Debug information"
+"ido_debug_level.-g0": "No debug info"
+"ido_debug_level.-g1": "Minimal trace info"
+"ido_debug_level.-g2": "Local variable tracking"
+"ido_debug_level.-g3": "Macro expansions"
+
+"mwcc_opt_level": "Optimization level"
+"mwcc_opt_level.-O0": "No optimization"
+"mwcc_opt_level.-O1": "Some optimization"
+"mwcc_opt_level.-O1,p": "Some optimization + speed"
+"mwcc_opt_level.-O1,s": "Some optimization + space"
+"mwcc_opt_level.-O2": "Standard optimization"
+"mwcc_opt_level.-O2,p": "Standard optimization + speed"
+"mwcc_opt_level.-O2,s": "Standard optimization + space"
+"mwcc_opt_level.-O3": "Heavy optimization"
+"mwcc_opt_level.-O3,p": "Heavy optimization + speed"
+"mwcc_opt_level.-O3,s": "Heavy optimization + space"
+"mwcc_opt_level.-O4": "Extreme optimization"
+"mwcc_opt_level.-O4,p": "Extreme optimization + speed"
+"mwcc_opt_level.-O4,s": "Extreme optimization + space"
+"mwcc_floating_point": "Floating point"
+"mwcc_floating_point.-fp soft": "Software emulation; default"
+"mwcc_floating_point.-fp off": "No floating point"
+"mwcc_floating_point.-fp hard": "Hardware"
+"mwcc_floating_point.-fp fmadd": "Hardware + -fp_contract"
+"mwcc_inline_options": "Inline options"
+"mwcc_inline_options.-inline on": "Turn on inlining for 'inline' functions; default"
+"mwcc_inline_options.-inline off": "Turn off inlining"
+"mwcc_inline_options.-inline auto": "Auto-inline small functions"
+"mwcc_inline_options.-inline noauto": "Do not auto-inline; default"
+"mwcc_inline_options.-inline all": "Turn on aggressive inlining: same as -inline on, auto'"
+"mwcc_inline_options.-inline deferred": "Defer inlining until end of compilation unit"
+// TODO this section
+<FlagSet name="String constant options">
+            <FlagOption flag="-str reuse" description="Equivalent strings are the same object; default" />
+            <FlagOption flag="-str pool" description="Pool strings into a single data object" />
+            <FlagOption flag="-str readonly" description="make all string constants read-only" />
+            <FlagOption flag="-str reuse,pool,readonly" description="Reuse + pool + readonly" />
+        </FlagSet>
+
+        <FlagSet name="Source language">
+            <FlagOption flag="-lang=c" description="C" />
+            <FlagOption flag="-lang=c++" description="C++" />
+            <FlagOption flag="-lang=c99" description="C99" />
+            <FlagOption flag="-lang=ec++" description="Embedded C++" />
+            <FlagOption flag="-lang=objc" description="Allow Objective C extensions" />
+        </FlagSet>
+
+        <Checkbox flag="-g" description="Enable debug info" />
+
+        <Checkbox flag="-align powerpc" description="PowerPC alignment; default" />
+        <Checkbox flag="-char unsigned" description="Chars are unsigned" />                 (ON/OFF)
+        <Checkbox flag="-Cpp_exceptions off" description="Disable C++ exceptions" />
+        <Checkbox flag="-enc SJIS" description="Specifies SJIS source encoding" />
+        <Checkbox flag="-enum int" description="Use int-sized enums" />
+        <Checkbox flag="-fp_contract on" description="Generate fused multiply-add instructions" />
+        <Checkbox flag="-maxerrors 1" description="Maximum number of errors to print (1)" />
+        <Checkbox flag="-msgstyle gcc" description="gcc error/warning message style" />
+        <Checkbox flag="-nodefaults" description="Equivalent to '-nostdinc'" />
+        <Checkbox flag="-rostr" description="Make string constants read-only" />
+        <Checkbox flag="-RTTI off" description="Disable run-time typing information (for C++)" />
+        <Checkbox flag="-use_lmw_stmw on" description="Use multiple-word load/store instructions for structure copies; default" />
+
+
+"psyq_opt_level": "Optimization level"
+"psyq_opt_level.-O0": "No optimization"
+"psyq_opt_level.-O1": "Some optimization"
+"psyq_opt_level.-O2": "Standard optimization"
+"psyq_opt_level.-O3": "Heavy optimization"
+"psyq_opt_level.-Os": "Size optimization"
+"psyq_debug_level": "Debug information"
+"psyq_debug_level.-g0": "No debug info"
+"psyq_debug_level.-g1": "Minimal trace info"
+"psyq_debug_level.-g2": "Local variable tracking"
+"psyq_debug_level.-g3": "Macro expansions"
+
+"char_type": "char type"
+"char_type.-fsigned-char": "char will be used as signed char"
+"char_type.-funsigned-char": "char will be used as unsigned char"
+
+"mips_version": "Mips version"
+"kpic": "-non_shared if unchecked"
+
+"endianness": "Endianness"
+"endianness.-mel": "Little endian"
+"endianness.-meb": "Big endian"
+
+"sdata_limit": "Small data limit"
+"sdata_limit.-G0": "0 bytes"
+"sdata_limit.-G4": "4 bytes"
+"sdata_limit.-G8": "8 bytes"


### PR DESCRIPTION
This adds a cross compiler from amd64 Linux to a PowerPC-based Mac OS X target, for decompiling some PowerPC-era Mac OS X games.
There may be some jank, and the code's a little spaghetti-ish, so testers and reviews are needed.

Note: I suck at rebasing, so the rebase commit on this branch accidentally undid some changes. That shouldn't be too hard to fix though.