### PR TITLE
Add prelude.inc with support for abi fpr names for Nintendo64 MIPS

### DIFF
--- a/backend/coreapp/platforms.py
+++ b/backend/coreapp/platforms.py
@@ -76,6 +76,42 @@ N64 = Platform(
 .set noreorder
 .set gp=64
 
+
+# Float register aliases (o32 ABI)
+
+.set $fv0,          $f0
+.set $fv0f,         $f1
+.set $fv1,          $f2
+.set $fv1f,         $f3
+.set $ft0,          $f4
+.set $ft0f,         $f5
+.set $ft1,          $f6
+.set $ft1f,         $f7
+.set $ft2,          $f8
+.set $ft2f,         $f9
+.set $ft3,          $f10
+.set $ft3f,         $f11
+.set $fa0,          $f12
+.set $fa0f,         $f13
+.set $fa1,          $f14
+.set $fa1f,         $f15
+.set $ft4,          $f16
+.set $ft4f,         $f17
+.set $ft5,          $f18
+.set $ft5f,         $f19
+.set $fs0,          $f20
+.set $fs0f,         $f21
+.set $fs1,          $f22
+.set $fs1f,         $f23
+.set $fs2,          $f24
+.set $fs2f,         $f25
+.set $fs3,          $f26
+.set $fs3f,         $f27
+.set $fs4,          $f28
+.set $fs4f,         $f29
+.set $fs5,          $f30
+.set $fs5f,         $f31
+
 """,
 )
 

--- a/backend/coreapp/tests.py
+++ b/backend/coreapp/tests.py
@@ -63,7 +63,7 @@ class ScratchCreationTests(BaseTestCase):
             "context": "",
             "target_asm": """.late_rodata
 glabel D_8092C224
-/* 000014 8092C224 3DCCCCCD */ .float 0.1
+.float 0.1
 
 .text
 glabel func_80929D04
@@ -93,6 +93,32 @@ sb  $t6, %lo(D_801D702C)($at)
         }
         self.create_scratch(scratch_dict)
 
+    @requiresCompiler(IDO71)
+    def test_fpr_reg_names(self):
+        """
+        Ensure that functions with O32 register names can be assembled.
+        """
+        scratch_dict = {
+            "platform": N64.id,
+            "compiler": IDO71.id,
+            "context": "",
+            "target_asm": """
+glabel test
+lui   $at, 0x3ff0
+mtc1  $at, $fv1f
+mtc1  $zero, $fv1
+beqz  $a0, .L00400194
+move  $v0, $a0
+andi  $a1, $a0, 3
+negu  $a1, $a1
+beqz  $a1, .L004000EC
+addu  $v1, $a1, $a0
+mtc1  $v0, $ft0
+nop
+""",
+        }
+        self.create_scratch(scratch_dict)
+
     def test_dummy_platform(self):
         """
         Ensure that we can create scratches with the dummy platform and compiler
@@ -100,7 +126,7 @@ sb  $t6, %lo(D_801D702C)($at)
         scratch_dict = {
             "compiler": compilers.DUMMY.id,
             "platform": platforms.DUMMY.id,
-            "context": "typedef unsigned char u8;",
+            "context": "",
             "target_asm": "this is some test asm",
         }
         self.create_scratch(scratch_dict)


### PR DESCRIPTION
Adds fpr register aliases for MIPS (specifically for the O32 ABI).
This should not affect negatively any code which does not use those aliases.

I didn't add them for PS1 because from what I understand the PS1 does not have a floating point processing unit