### PR TITLE
Use nsjail release 3.1 now its been cut

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,7 +32,7 @@ jobs:
             protobuf-compiler
       - name: Install nsjail
         run: |-
-          git clone --recursive --branch=3.0 https://github.com/google/nsjail
+          git clone --recursive --branch=3.1 https://github.com/google/nsjail
           make -C nsjail
           sudo cp nsjail/nsjail /usr/bin/
       - name: Download compilers

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -25,11 +25,8 @@ RUN apt-get -y update && apt-get install -y \
     pkg-config \
     protobuf-compiler
 
-# TODO: change this when they tag a release (see https://github.com/google/nsjail/issues/190)
-RUN git clone --recursive --shallow-submodules "https://github.com/google/nsjail" /nsjail \
+RUN git clone "https://github.com/google/nsjail" --recursive --branch 3.1 /nsjail \
     && cd /nsjail \
-    && git checkout aa0becd547d835ac9b9d63a9536c23530c8d992e \
-    && git submodule update \
     && make
 
 


### PR DESCRIPTION
They just closed https://github.com/google/nsjail/issues/190 so updating the Dockerfile to use it!