### PR TITLE
Fix settings bugs

### DIFF
--- a/backend/coreapp/compiler_wrapper.py
+++ b/backend/coreapp/compiler_wrapper.py
@@ -58,14 +58,11 @@ class CompilerWrapper:
             "-I",
             "-D",
             "-U",
-            "-G",
         }
         skip_flags = {
             "-ffreestanding",
             "-non_shared",
             "-Xcpluscomm",
-            "-Xfullwarn",
-            "-fullwarn",
             "-Wab,-r4300_mul",
             "-c",
             "-w",

--- a/backend/coreapp/compiler_wrapper.py
+++ b/backend/coreapp/compiler_wrapper.py
@@ -54,7 +54,6 @@ class CompilerWrapper:
         # don't affect matching, but clutter the compiler settings field.
         # TODO: use cfg for this?
         skip_flags_with_args = {
-            "-woff",
             "-B",
             "-I",
             "-D",

--- a/backend/coreapp/serializers.py
+++ b/backend/coreapp/serializers.py
@@ -110,7 +110,7 @@ class ScratchCreateSerializer(serializers.Serializer[None]):
     compiler = serializers.CharField(allow_blank=True, required=True)
     platform = serializers.CharField(allow_blank=True, required=False)
     compiler_flags = serializers.CharField(allow_blank=True, required=False)
-    diff_flags = serializers.CharField(allow_blank=True, required=False)
+    diff_flags = serializers.JSONField(required=False)
     preset = serializers.CharField(allow_blank=True, required=False)
     source_code = serializers.CharField(allow_blank=True, required=False)
     target_asm = serializers.CharField(allow_blank=True)

--- a/backend/coreapp/tests.py
+++ b/backend/coreapp/tests.py
@@ -296,7 +296,6 @@ class ScratchForkTests(BaseTestCase):
         response = self.client.post(
             reverse("scratch-fork", kwargs={"pk": slug}), fork_dict
         )
-        print(response.json())
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         new_slug = response.json()["slug"]
@@ -418,7 +417,7 @@ class CompilationTests(BaseTestCase):
         scratch_dict = {
             "platform": N64.id,
             "compiler": IDO71.id,
-            "diff_flags": "[-Mreg-names=32]",
+            "diff_flags": '["-Mreg-names=32"]',
             "context": "",
             "target_asm": """
 glabel test
@@ -1098,7 +1097,6 @@ class ProjectTests(TestCase):
                     },
                     content_type="application/json",
                 )
-                print(response.json())
                 self.assertEqual(response.status_code, status.HTTP_200_OK)
 
                 p = Project.objects.first()

--- a/backend/coreapp/views/scratch.py
+++ b/backend/coreapp/views/scratch.py
@@ -221,7 +221,6 @@ def create_scratch(data: Dict[str, Any], allow_project=False) -> Scratch:
     compiler_flags = CompilerWrapper.filter_compiler_flags(compiler_flags)
 
     diff_flags = data.get("diff_flags", "")
-    diff_flags = DiffWrapper.filter_objdump_flags(diff_flags)
 
     preset = data.get("preset", "")
     if preset and not compilers.preset_from_name(preset):

--- a/frontend/src/pages/new.tsx
+++ b/frontend/src/pages/new.tsx
@@ -159,7 +159,7 @@ export default function NewScratch({ serverCompilers }: {
                 platform,
                 compiler: compilerId,
                 compiler_flags: compilerFlags,
-                diffFlags: diffFlags,
+                diff_flags: diffFlags,
                 preset: presetName,
                 diff_label: label || defaultLabel || "",
             })


### PR DESCRIPTION
-woff was being filtered out of compiler flags upon scratch creation
diff_flags was being passed incorrectly to the backend