### PR TITLE
Add MWCPPC (Mac OS 9 cross compiler ran on windows)

### DIFF
--- a/backend/compilers/download.py
+++ b/backend/compilers/download.py
@@ -163,7 +163,7 @@ def download_zip(
 
 def download_codewarrior():
     download_zip(
-        url="https://github.com/ChrisNonyminus/sims1_mac_decomp/files/8735152/compilers.zip",
+        url="https://github.com/ChrisNonyminus/sims1_mac_decomp/files/8748510/compilers.zip",
         dl_name="codewarrior_compilers.zip",
         dest_name="codewarrior",
         create_subdir=True,

--- a/backend/compilers/download.py
+++ b/backend/compilers/download.py
@@ -177,7 +177,9 @@ def download_codewarrior():
         lowercase_lmgr = compiler_dir / ver / "lmgr8c.dll"
         if lowercase_lmgr.exists():
             shutil.move(lowercase_lmgr, compiler_dir / ver / "LMGR8C.dll")
-
+        # Set +x to allow WSL without wine
+        exe_path = compiler_dir / ver / "MWCPPC.exe"
+        exe_path.chmod(exe_path.stat().st_mode | stat.S_IEXEC)
         shutil.move(compiler_dir / ver, COMPILERS_DIR / "mwcppc_23")
 
 

--- a/backend/compilers/download.py
+++ b/backend/compilers/download.py
@@ -160,6 +160,7 @@ def download_zip(
         ):
             f.extract(member=file, path=dest_path)
 
+
 def download_codewarrior():
     download_zip(
         url="https://github.com/ChrisNonyminus/sims1_mac_decomp/files/8735152/compilers.zip",
@@ -170,11 +171,11 @@ def download_codewarrior():
     compiler_dir = COMPILERS_DIR / "codewarrior" / "compilers"
     lowercase_lmgr = compiler_dir / "Pro5" / "lmgr326b.dll"
     if lowercase_lmgr.exists():
-        shutil.move(lowercase_lmgr, compiler_dir / "Pro5"/ "LMGR326B.dll")
+        shutil.move(lowercase_lmgr, compiler_dir / "Pro5" / "LMGR326B.dll")
 
     lowercase_lmgr = compiler_dir / "Pro5" / "lmgr8c.dll"
     if lowercase_lmgr.exists():
-        shutil.move(lowercase_lmgr, compiler_dir/ "Pro5" / "LMGR8C.dll")
+        shutil.move(lowercase_lmgr, compiler_dir / "Pro5" / "LMGR8C.dll")
 
     # Set +x to allow WSL without wine
     exe_path = compiler_dir / "Pro5" / "MWCPPC.exe"
@@ -183,11 +184,11 @@ def download_codewarrior():
     compiler_dir = COMPILERS_DIR / "codewarrior" / "compilers"
     lowercase_lmgr = compiler_dir / "Pro6" / "lmgr326b.dll"
     if lowercase_lmgr.exists():
-        shutil.move(lowercase_lmgr, compiler_dir / "Pro6"/ "LMGR326B.dll")
+        shutil.move(lowercase_lmgr, compiler_dir / "Pro6" / "LMGR326B.dll")
 
     lowercase_lmgr = compiler_dir / "Pro6" / "lmgr8c.dll"
     if lowercase_lmgr.exists():
-        shutil.move(lowercase_lmgr, compiler_dir/ "Pro6" / "LMGR8C.dll")
+        shutil.move(lowercase_lmgr, compiler_dir / "Pro6" / "LMGR8C.dll")
 
     # Set +x to allow WSL without wine
     exe_path = compiler_dir / "Pro6" / "MWCPPC.exe"
@@ -195,6 +196,7 @@ def download_codewarrior():
 
     shutil.move(compiler_dir / "Pro5", COMPILERS_DIR / "mwcppc_23")
     shutil.move(compiler_dir / "Pro6", COMPILERS_DIR / "mwcppc_24")
+
 
 def download_gba():
     if host_os != LINUX:

--- a/backend/compilers/download.py
+++ b/backend/compilers/download.py
@@ -180,7 +180,10 @@ def download_codewarrior():
         # Set +x to allow WSL without wine
         exe_path = compiler_dir / ver / "MWCPPC.exe"
         exe_path.chmod(exe_path.stat().st_mode | stat.S_IEXEC)
-        shutil.move(compiler_dir / ver, COMPILERS_DIR / "mwcppc_23")
+        exe_path = compiler_dir / ver / "MWLinkPPC.exe"
+        exe_path.chmod(exe_path.stat().st_mode | stat.S_IEXEC)
+    shutil.move(compiler_dir / "Pro5", COMPILERS_DIR / "mwcppc_23")
+    shutil.move(compiler_dir / "Pro6", COMPILERS_DIR / "mwcppc_24")
 
 
 def download_gba():

--- a/backend/compilers/download.py
+++ b/backend/compilers/download.py
@@ -169,33 +169,16 @@ def download_codewarrior():
         create_subdir=True,
     )
     compiler_dir = COMPILERS_DIR / "codewarrior" / "compilers"
-    lowercase_lmgr = compiler_dir / "Pro5" / "lmgr326b.dll"
-    if lowercase_lmgr.exists():
-        shutil.move(lowercase_lmgr, compiler_dir / "Pro5" / "LMGR326B.dll")
+    for ver in ["Pro5", "Pro6"]:
+        lowercase_lmgr = compiler_dir / ver / "lmgr326b.dll"
+        if lowercase_lmgr.exists():
+            shutil.move(lowercase_lmgr, compiler_dir / ver / "LMGR326B.dll")
 
-    lowercase_lmgr = compiler_dir / "Pro5" / "lmgr8c.dll"
-    if lowercase_lmgr.exists():
-        shutil.move(lowercase_lmgr, compiler_dir / "Pro5" / "LMGR8C.dll")
+        lowercase_lmgr = compiler_dir / ver / "lmgr8c.dll"
+        if lowercase_lmgr.exists():
+            shutil.move(lowercase_lmgr, compiler_dir / ver / "LMGR8C.dll")
 
-    # Set +x to allow WSL without wine
-    exe_path = compiler_dir / "Pro5" / "MWCPPC.exe"
-    exe_path.chmod(exe_path.stat().st_mode | stat.S_IEXEC)
-
-    compiler_dir = COMPILERS_DIR / "codewarrior" / "compilers"
-    lowercase_lmgr = compiler_dir / "Pro6" / "lmgr326b.dll"
-    if lowercase_lmgr.exists():
-        shutil.move(lowercase_lmgr, compiler_dir / "Pro6" / "LMGR326B.dll")
-
-    lowercase_lmgr = compiler_dir / "Pro6" / "lmgr8c.dll"
-    if lowercase_lmgr.exists():
-        shutil.move(lowercase_lmgr, compiler_dir / "Pro6" / "LMGR8C.dll")
-
-    # Set +x to allow WSL without wine
-    exe_path = compiler_dir / "Pro6" / "MWCPPC.exe"
-    exe_path.chmod(exe_path.stat().st_mode | stat.S_IEXEC)
-
-    shutil.move(compiler_dir / "Pro5", COMPILERS_DIR / "mwcppc_23")
-    shutil.move(compiler_dir / "Pro6", COMPILERS_DIR / "mwcppc_24")
+        shutil.move(compiler_dir / ver, COMPILERS_DIR / "mwcppc_23")
 
 
 def download_gba():

--- a/backend/compilers/download.py
+++ b/backend/compilers/download.py
@@ -160,6 +160,41 @@ def download_zip(
         ):
             f.extract(member=file, path=dest_path)
 
+def download_codewarrior():
+    download_zip(
+        url="https://github.com/ChrisNonyminus/sims1_mac_decomp/files/8735152/compilers.zip",
+        dl_name="codewarrior_compilers.zip",
+        dest_name="codewarrior",
+        create_subdir=True,
+    )
+    compiler_dir = COMPILERS_DIR / "codewarrior" / "compilers"
+    lowercase_lmgr = compiler_dir / "Pro5" / "lmgr326b.dll"
+    if lowercase_lmgr.exists():
+        shutil.move(lowercase_lmgr, compiler_dir / "Pro5"/ "LMGR326B.dll")
+
+    lowercase_lmgr = compiler_dir / "Pro5" / "lmgr8c.dll"
+    if lowercase_lmgr.exists():
+        shutil.move(lowercase_lmgr, compiler_dir/ "Pro5" / "LMGR8C.dll")
+
+    # Set +x to allow WSL without wine
+    exe_path = compiler_dir / "Pro5" / "MWCPPC.exe"
+    exe_path.chmod(exe_path.stat().st_mode | stat.S_IEXEC)
+
+    compiler_dir = COMPILERS_DIR / "codewarrior" / "compilers"
+    lowercase_lmgr = compiler_dir / "Pro6" / "lmgr326b.dll"
+    if lowercase_lmgr.exists():
+        shutil.move(lowercase_lmgr, compiler_dir / "Pro6"/ "LMGR326B.dll")
+
+    lowercase_lmgr = compiler_dir / "Pro6" / "lmgr8c.dll"
+    if lowercase_lmgr.exists():
+        shutil.move(lowercase_lmgr, compiler_dir/ "Pro6" / "LMGR8C.dll")
+
+    # Set +x to allow WSL without wine
+    exe_path = compiler_dir / "Pro6" / "MWCPPC.exe"
+    exe_path.chmod(exe_path.stat().st_mode | stat.S_IEXEC)
+
+    shutil.move(compiler_dir / "Pro5", COMPILERS_DIR / "mwcppc_23")
+    shutil.move(compiler_dir / "Pro6", COMPILERS_DIR / "mwcppc_24")
 
 def download_gba():
     if host_os != LINUX:
@@ -504,6 +539,8 @@ def main(args):
             os.environ.get(f"ENABLE_{platform.upper()}_SUPPORT", "YES").upper() != "NO"
         )
 
+    if should_download("macos9"):
+        download_codewarrior()
     if should_download("gba"):
         download_gba()
     if should_download("n64"):

--- a/backend/coreapp/compiler_wrapper.py
+++ b/backend/coreapp/compiler_wrapper.py
@@ -100,7 +100,11 @@ class CompilerWrapper:
     @staticmethod
     @lru_cache(maxsize=settings.COMPILATION_CACHE_SIZE)  # type: ignore
     def compile_code(
-        compiler: Compiler, compiler_flags: str, code: str, context: str, function: str
+        compiler: Compiler,
+        compiler_flags: str,
+        code: str,
+        context: str,
+        function: str = "",
     ) -> CompilationResult:
         if compiler == compilers.DUMMY:
             return CompilationResult(f"compiled({context}\n{code}".encode("UTF-8"), "")

--- a/backend/coreapp/compiler_wrapper.py
+++ b/backend/coreapp/compiler_wrapper.py
@@ -169,7 +169,7 @@ class CompilerWrapper:
                             "PATH": PATH,
                             "WINE": WINE,
                             "INPUT": sandbox.rewrite_path(object_path),
-                            "ASM_DUMP": sandbox.rewrite_path(sandbox.path / "c_asm.s"),
+                            "OUTPUT": sandbox.rewrite_path(sandbox.path / "c_asm.s"),
                             "COMPILER_DIR": sandbox.rewrite_path(compiler.path),
                             "FUNCTION": function,
                             "MWCIncludes": "/tmp",
@@ -216,7 +216,10 @@ class CompilerWrapper:
                     # Shlex issue?
                     logging.debug("Compilation failed: %s", e)
                     raise CompilationError(str(e))
-                pass
+
+            with open(sandbox.path / "c_asm.s", "r") as file:
+                for line in file:
+                    print("# %s" % line)
 
             if not object_path.exists():
                 raise CompilationError("Compiler did not create an object file")

--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -267,7 +267,7 @@ GCC272SN = GCCCompiler(
 )
 
 # MACOS9
-MWCPPC_CC = 'printf "%s" "${COMPILER_FLAGS}" | xargs -x -- ${WINE} "${COMPILER_DIR}/MWCPPC.exe" -o object.o "${INPUT}"; printf "%s" "-dis -h -module ".${FUNCTION}" -nonames -nodata" | xargs -x -- ${WINE} "${COMPILER_DIR}/MWLinkPPC.exe" "${OUTPUT}" > "${COMPILER_DIR}/code.s"; python3 ${COMPILER_DIR}/convert_gas_syntax.py "${COMPILER_DIR}/code.s" ".${FUNCTION}" > "${COMPILER_DIR}/code_new.s"; powerpc-linux-gnu-as "${COMPILER_DIR}/code_new.s" -o "${OUTPUT}"; rm "${COMPILER_DIR}/code.s"; rm "${COMPILER_DIR}/code_new.s"'
+MWCPPC_CC = 'printf "%s" "${COMPILER_FLAGS}" | xargs -x -- ${WINE} "${COMPILER_DIR}/MWCPPC.exe" -o object.o "${INPUT}" && printf "%s" "-dis -h -module ".${FUNCTION}" -nonames -nodata" | xargs -x -- ${WINE} "${COMPILER_DIR}/MWLinkPPC.exe" "${OUTPUT}" > "${COMPILER_DIR}/code.s" && python3 ${COMPILER_DIR}/convert_gas_syntax.py "${COMPILER_DIR}/code.s" ".${FUNCTION}" > "${COMPILER_DIR}/code_new.s" && powerpc-linux-gnu-as "${COMPILER_DIR}/code_new.s" -o "${OUTPUT}" && rm "${COMPILER_DIR}/code.s" && rm "${COMPILER_DIR}/code_new.s"'
 
 MWCPPC_23 = MWCCCompiler(
     id="mwcppc_23",

--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -265,9 +265,9 @@ GCC272SN = GCCCompiler(
 )
 
 # MACOS9
-MWCPPC_CC = 'printf "%s" "${COMPILER_FLAGS}" | xargs -x -- ${WINE} "${COMPILER_DIR}/MWCPPC.exe" -o "${OUTPUT}" "${INPUT}"'
-MWCPPC_AS = 'printf "%s" "-S -h -module ${FUNCTION} -nonames -nodata" | xargs -x -- ${WINE} "${COMPILER_DIR}/MWLinkPPC.exe" "${INPUT}" > ${ASM_DUMP}'
-MWCPPC_CONVERT_GAS_SYNTAX = 'python3 "${COMPILER_DIR}/convert_gas_syntax.py" ${INPUT} ${FUNCTION} > ${INPUT}; powerpc-linux-gnu-as ${INPUT} -o ${OUTPUT}'
+MWCPPC_CC = 'printf "%s" "${COMPILER_FLAGS}" | xargs -x -- ${WINE} "${COMPILER_DIR}/MWCPPC.exe" -o object.o "${INPUT}"'
+MWCPPC_AS = 'printf "%s" "-dis -h -module ".${FUNCTION}" -nonames -nodata" | xargs -x -- ${WINE} "${COMPILER_DIR}/MWLinkPPC.exe" "${INPUT}" > ${COMPILER_DIR}/code.s'
+MWCPPC_CONVERT_GAS_SYNTAX = 'python3 ${COMPILER_DIR}/convert_gas_syntax.py "${COMPILER_DIR}/code.s" ".${FUNCTION}" > "${INPUT}"; rm ${COMPILER_DIR}/code.s; powerpc-linux-gnu-as "${INPUT}" -o "${OUTPUT}"'
 
 MWCPPC_23 = MWCCMacCompiler(
     id="mwcppc_23",

--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -779,6 +779,12 @@ _all_presets = [
         MWCC_30_137,
         "-O4,p -enum int -lang c99 -Cpp_exceptions off -gccext,on -gccinc -interworking -gccdep -MD",
     ),
+    # MACOS9
+    Preset(
+        "The Sims 1",
+        MWCPPC_24,
+        "-lang=c++ -O3 -str pool -g"
+    )
 ]
 
 

--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -16,7 +16,17 @@ from coreapp.flags import (
 
 from coreapp import platforms
 
-from coreapp.platforms import GBA, GC_WII, N64, NDS_ARM9, Platform, PS1, PS2, SWITCH, MACOS9
+from coreapp.platforms import (
+    GBA,
+    GC_WII,
+    N64,
+    NDS_ARM9,
+    Platform,
+    PS1,
+    PS2,
+    SWITCH,
+    MACOS9,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -35,8 +45,8 @@ class Compiler:
     is_ido: ClassVar[bool] = False
     is_mwcc: ClassVar[bool] = False
     is_mac_compiler: ClassVar[bool] = False
-    asm_dump: str = "" # Hack for compilers of mac apps
-    assemble_cmd: str = "" # Ditto
+    asm_dump: str = ""  # Hack for compilers of mac apps
+    assemble_cmd: str = ""  # Ditto
     needs_wine = False
 
     @property
@@ -71,6 +81,7 @@ class DummyCompiler(Compiler):
     def available(self) -> bool:
         return settings.DUMMY_COMPILER
 
+
 @dataclass(frozen=True)
 class ClangCompiler(Compiler):
     flags: ClassVar[Flags] = COMMON_CLANG_FLAGS
@@ -97,6 +108,7 @@ class IDOCompiler(Compiler):
 class MWCCCompiler(Compiler):
     is_mwcc: ClassVar[bool] = True
     flags: ClassVar[Flags] = COMMON_MWCC_FLAGS
+
 
 @dataclass(frozen=True)
 class MWCCMacCompiler(Compiler):
@@ -274,7 +286,7 @@ MWCPPC_23 = MWCCMacCompiler(
     platform=MACOS9,
     cc=MWCPPC_CC,
     asm_dump=MWCPPC_AS,
-    assemble_cmd=MWCPPC_CONVERT_GAS_SYNTAX
+    assemble_cmd=MWCPPC_CONVERT_GAS_SYNTAX,
 )
 
 MWCPPC_24 = MWCCMacCompiler(
@@ -282,7 +294,7 @@ MWCPPC_24 = MWCCMacCompiler(
     platform=MACOS9,
     cc=MWCPPC_CC,
     asm_dump=MWCPPC_AS,
-    assemble_cmd=MWCPPC_CONVERT_GAS_SYNTAX
+    assemble_cmd=MWCPPC_CONVERT_GAS_SYNTAX,
 )
 
 # GC_WII
@@ -780,11 +792,7 @@ _all_presets = [
         "-O4,p -enum int -lang c99 -Cpp_exceptions off -gccext,on -gccinc -interworking -gccdep -MD",
     ),
     # MACOS9
-    Preset(
-        "The Sims 1",
-        MWCPPC_24,
-        "-lang=c++ -O3 -str pool -g"
-    )
+    Preset("The Sims 1", MWCPPC_24, "-lang=c++ -O3 -str pool -g"),
 ]
 
 

--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -792,7 +792,7 @@ _all_presets = [
         "-O4,p -enum int -lang c99 -Cpp_exceptions off -gccext,on -gccinc -interworking -gccdep -MD",
     ),
     # MACOS9
-    Preset("The Sims 1", MWCPPC_24, "-lang=c++ -O3 -str pool -g"),
+    Preset("The Sims 1", MWCPPC_24, "-lang=c++ -O2 -str pool -g"),
 ]
 
 

--- a/backend/coreapp/platforms.py
+++ b/backend/coreapp/platforms.py
@@ -169,6 +169,98 @@ PS2 = Platform(
 """,
 )
 
+MACOS9 = Platform(
+    id="macos9",
+    name="Mac OS 9",
+    description="PowerPC",
+    arch="ppc",
+    assemble_cmd='powerpc-linux-gnu-as -o "$OUTPUT" "$INPUT"',
+    objdump_cmd='powerpc-linux-gnu-objdump',
+    nm_cmd="powerpc-linux-gnu-nm",
+    asm_prelude="""
+.macro glabel label
+    .global \label
+    .type \label, @function
+    \label:
+.endm
+
+.set r0, 0
+.set r1, 1
+.set r2, 2
+.set r3, 3
+.set r4, 4
+.set r5, 5
+.set r6, 6
+.set r7, 7
+.set r8, 8
+.set r9, 9
+.set r10, 10
+.set r11, 11
+.set r12, 12
+.set r13, 13
+.set r14, 14
+.set r15, 15
+.set r16, 16
+.set r17, 17
+.set r18, 18
+.set r19, 19
+.set r20, 20
+.set r21, 21
+.set r22, 22
+.set r23, 23
+.set r24, 24
+.set r25, 25
+.set r26, 26
+.set r27, 27
+.set r28, 28
+.set r29, 29
+.set r30, 30
+.set r31, 31
+.set f0, 0
+.set f1, 1
+.set f2, 2
+.set f3, 3
+.set f4, 4
+.set f5, 5
+.set f6, 6
+.set f7, 7
+.set f8, 8
+.set f9, 9
+.set f10, 10
+.set f11, 11
+.set f12, 12
+.set f13, 13
+.set f14, 14
+.set f15, 15
+.set f16, 16
+.set f17, 17
+.set f18, 18
+.set f19, 19
+.set f20, 20
+.set f21, 21
+.set f22, 22
+.set f23, 23
+.set f24, 24
+.set f25, 25
+.set f26, 26
+.set f27, 27
+.set f28, 28
+.set f29, 29
+.set f30, 30
+.set f31, 31
+.set qr0, 0
+.set qr1, 1
+.set qr2, 2
+.set qr3, 3
+.set qr4, 4
+.set qr5, 5
+.set qr6, 6
+.set qr7, 7
+.set RTOC,r2
+.set SP,r1
+""",
+)
+
 GC_WII = Platform(
     id="gc_wii",
     name="GameCube / Wii",
@@ -338,5 +430,6 @@ _platforms: OrderedDict[str, Platform] = OrderedDict(
         "gc_wii": GC_WII,
         "nds_arm9": NDS_ARM9,
         "gba": GBA,
+        "macos9": MACOS9,
     }
 )

--- a/backend/coreapp/platforms.py
+++ b/backend/coreapp/platforms.py
@@ -175,7 +175,7 @@ MACOS9 = Platform(
     description="PowerPC",
     arch="ppc",
     assemble_cmd='powerpc-linux-gnu-as -o "$OUTPUT" "$INPUT"',
-    objdump_cmd='powerpc-linux-gnu-objdump',
+    objdump_cmd="powerpc-linux-gnu-objdump",
     nm_cmd="powerpc-linux-gnu-nm",
     asm_prelude="""
 .macro glabel label

--- a/backend/coreapp/views/scratch.py
+++ b/backend/coreapp/views/scratch.py
@@ -62,7 +62,7 @@ def compile_scratch(scratch: Scratch) -> CompilationResult:
         scratch.compiler_flags,
         scratch.source_code,
         scratch.context,
-        scratch.diff_label
+        scratch.diff_label,
     )
 
 

--- a/backend/coreapp/views/scratch.py
+++ b/backend/coreapp/views/scratch.py
@@ -62,6 +62,7 @@ def compile_scratch(scratch: Scratch) -> CompilationResult:
         scratch.compiler_flags,
         scratch.source_code,
         scratch.context,
+        scratch.diff_label
     )
 
 

--- a/frontend/locales/en/compilers.json
+++ b/frontend/locales/en/compilers.json
@@ -53,6 +53,8 @@
     "mwcc_43_151": "4.3 build 151 (Wii MW 1.1)",
     "mwcc_43_172": "4.3 build 172 (Wii MW 1.3)",
     "mwcc_43_213": "4.3 build 213 (Wii MW 1.7)",
+    "mwcppc_23": "MWCPPC 2.3 (CodeWarrior Pro 5)",
+    "mwcppc_24": "MWCPPC 2.4 (CodeWarrior Pro 6)",
     "old_agbcc": "old_agbcc",
     "psyq4.0": "PSYQ4.0 (gcc 2.7.2)",
     "psyq4.1": "PSYQ4.1 (gcc 2.7.2)",

--- a/frontend/src/components/PlatformSelect/PlatformIcon.tsx
+++ b/frontend/src/components/PlatformSelect/PlatformIcon.tsx
@@ -1,11 +1,11 @@
 import LogoGBA from "./gba.svg"
 import LogoGCWii from "./gc_wii.svg"
+import LogoMacOS from "./macos9.svg"
 import LogoN64 from "./n64.svg"
 import LogoNDS from "./nds.svg"
 import LogoPS1 from "./ps1.svg"
 import LogoPS2 from "./ps2.svg"
 import LogoSwitch from "./switch.svg"
-import LogoMacOS from "./macos9.svg"
 import UnknownIcon from "./unknown.svg"
 
 const ICONS = {

--- a/frontend/src/components/PlatformSelect/PlatformIcon.tsx
+++ b/frontend/src/components/PlatformSelect/PlatformIcon.tsx
@@ -5,6 +5,7 @@ import LogoNDS from "./nds.svg"
 import LogoPS1 from "./ps1.svg"
 import LogoPS2 from "./ps2.svg"
 import LogoSwitch from "./switch.svg"
+import LogoMacOS from "./macos9.svg"
 import UnknownIcon from "./unknown.svg"
 
 const ICONS = {
@@ -15,6 +16,7 @@ const ICONS = {
     "ps1": LogoPS1,
     "ps2": LogoPS2,
     "switch": LogoSwitch,
+    "macos9": LogoMacOS,
 }
 
 export type Props = {

--- a/frontend/src/components/PlatformSelect/macos9.svg
+++ b/frontend/src/components/PlatformSelect/macos9.svg
@@ -1,0 +1,204 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="8.4710464mm"
+   height="10.9614mm"
+   viewBox="0 0 8.4710464 10.9614"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.1 r15371"
+   sodipodi:docname="Happy Mac.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="8"
+     inkscape:cx="4.1053318"
+     inkscape:cy="14.867275"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:measure-start="0,0"
+     inkscape:measure-end="0,0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:window-width="1600"
+     inkscape:window-height="838"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Livello 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-5.3090212,-4.3002038)">
+    <g
+       id="g4959"
+       transform="matrix(0.06455006,0,0,0.06455006,7.6050574,7.0900779)">
+      <path
+         id="rect43-8"
+         d="m -30.937651,99.78759 h 122 v 26.80449 h -122 z"
+         style="fill:#000000;fill-opacity:1;stroke-width:2.38412714"
+         inkscape:connector-curvature="0" />
+      <g
+         transform="translate(-56.456402,-31.41017)"
+         id="g4916">
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:#555555;fill-opacity:1;stroke:none;stroke-width:0.17674622"
+           d="m 33.668747,136.75006 v 4.69998 h 31.950504 v -4.69998 z m 41.740088,4.69998 V 146.15 h 11.145573 v -4.69996 z M 91.152059,146.15 v 6.29987 H 102.47075 V 146.15 Z"
+           id="rect57-8-2" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:#444444;fill-opacity:1;stroke:none;stroke-width:0.15800072"
+           d="m 65.619251,136.75006 v 4.69998 H 86.554408 V 146.15 h 15.916342 v 6.29987 h 20.86023 V 146.15 h -15.87449 v -4.69996 H 91.152059 v -4.69998 z"
+           id="rect57-8-0-6" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:#222222;fill-opacity:1;stroke:none;stroke-width:0.21712606"
+           d="m 91.152059,136.75006 v 4.69998 H 107.45649 V 146.15 h 15.87449 v 6.29987 h 16.03777 v -6.29987 -4.69996 -4.69998 z"
+           id="rect57-8-0-8-8" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:#777777;fill-opacity:1;stroke:none;stroke-width:0.20201708"
+           d="M 33.668747,141.45004 V 146.15 h 41.740088 v -4.69996 z M 75.408835,146.15 v 6.29987 H 91.152059 V 146.15 Z"
+           id="rect57-8-4-4" />
+        <path
+           id="rect57-1-3-5-6"
+           d="m 33.668823,146.14999 h 41.74001 v 6.3 h -41.74001 z"
+           style="fill:#888888;fill-opacity:1;stroke:none;stroke-width:0.23388879"
+           inkscape:connector-curvature="0" />
+      </g>
+      <path
+         id="rect325"
+         d="M -30.969854,-37.120319 H 91.062349 V 99.787579 H -30.969854 Z"
+         style="fill:#cccccc;fill-opacity:1;stroke-width:0.26458332"
+         inkscape:connector-curvature="0" />
+      <path
+         id="rect327"
+         d="M -15.075892,-21.040775 H 74.98512 v 67.75 h -90.061012 z"
+         style="fill:#ccccff;fill-opacity:1;stroke-width:0.26458332"
+         inkscape:connector-curvature="0" />
+      <path
+         id="rect237-98"
+         transform="scale(0.26458333)"
+         d="M 102.17383,-23.402344 V 59.882812 H 83.148438 V 78.779297 H 102.17383 120 120.0508 V -23.402344 Z"
+         style="fill:#000000;fill-opacity:1;stroke-width:0.93718952"
+         inkscape:connector-curvature="0" />
+      <path
+         id="rect43"
+         d="M -30.969856,-43.220318 H 91.062347 v 6.1 H -30.969856 Z"
+         style="fill:#000000;fill-opacity:1;stroke-width:1.13749063"
+         inkscape:connector-curvature="0" />
+      <path
+         id="rect43-1"
+         d="M -15.075892,-27.140776 H 74.98512 v 6.1 h -90.061012 z"
+         style="fill:#444444;fill-opacity:1;stroke-width:0.97719014"
+         inkscape:connector-curvature="0" />
+      <path
+         id="rect43-1-2"
+         d="m -21.040775,15.075892 h 67.75 v 6.1 h -67.75 z"
+         style="fill:#444444;fill-opacity:1;stroke-width:0.84755003"
+         transform="rotate(90)"
+         inkscape:connector-curvature="0" />
+      <path
+         id="rect43-1-2-1"
+         d="m -21.040775,-81.085121 h 67.75 v 6.1 h -67.75 z"
+         style="fill:#ffffff;fill-opacity:1;stroke-width:0.84755009"
+         transform="rotate(90)"
+         inkscape:connector-curvature="0" />
+      <path
+         id="rect43-1-7"
+         d="m -15.07589,46.709225 h 90.061013 v 6.1 H -15.07589 Z"
+         style="fill:#ffffff;fill-opacity:1;stroke-width:0.9771902"
+         inkscape:connector-curvature="0" />
+      <path
+         id="rect169"
+         d="m 31.655506,73.81324 h 43.400002 v 5 H 31.655506 Z"
+         style="fill:#000000;fill-opacity:1;stroke-width:0.26445001"
+         inkscape:connector-curvature="0" />
+      <path
+         id="rect169-1"
+         d="m 31.655506,78.81324 h 43.400005 v 6 H 31.655506 Z"
+         style="fill:#ffffff;fill-opacity:1;stroke-width:0.28969046"
+         inkscape:connector-curvature="0" />
+      <path
+         id="rect169-9"
+         d="m -21.133041,73.785721 h 11.060395 v 5 h -11.060395 z"
+         style="fill:#00bb00;fill-opacity:1;stroke-width:0.13350084"
+         inkscape:connector-curvature="0" />
+      <path
+         id="rect169-1-3"
+         d="m -21.133041,78.785721 h 11.060396 v 6 h -11.060396 z"
+         style="fill:#dd0000;fill-opacity:1;stroke-width:0.14624284"
+         inkscape:connector-curvature="0" />
+      <path
+         id="rect237"
+         d="M 5.8799295,-6.1919641 H 10.87993 V 5.0080357 H 5.8799295 Z"
+         style="fill:#000000;fill-opacity:1;stroke-width:0.26576424"
+         inkscape:connector-curvature="0" />
+      <path
+         id="rect237-9"
+         d="m 47.880306,-6.1919641 h 6.1 V 5.0080357 h -6.1 z"
+         style="fill:#000000;fill-opacity:1;stroke-width:0.29354623"
+         inkscape:connector-curvature="0" />
+      <path
+         id="rect237-0"
+         d="m 10.8871,25.947487 h 5 v 6 h -5 z"
+         style="fill:#000000;fill-opacity:1;stroke-width:0.19451953"
+         inkscape:connector-curvature="0" />
+      <path
+         id="rect237-0-7"
+         d="m 38.149635,25.944651 h 4.75 v 6.002836 h -4.75 z"
+         style="fill:#000000;fill-opacity:1;stroke-width:0.18963902"
+         inkscape:connector-curvature="0" />
+      <path
+         id="rect319"
+         d="m 15.8871,31.947487 h 22.262533 v 5.011021 H 15.8871 Z"
+         style="fill:#000000;fill-opacity:1;stroke-width:11.12128639"
+         inkscape:connector-curvature="0" />
+      <path
+         id="rect43-5-3-4"
+         d="M -37.120319,30.969854 H 99.787579 v 4.6 H -37.120319 Z"
+         style="fill:#000000;fill-opacity:1;stroke-width:1.04625833"
+         transform="rotate(90)"
+         inkscape:connector-curvature="0" />
+      <path
+         id="rect43-5-3-4-9"
+         d="M -37.120331,-95.662346 H 99.787582 v 4.6 H -37.120331 Z"
+         style="fill:#000000;fill-opacity:1;stroke-width:1.04625833"
+         transform="rotate(90)"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/frontend/src/components/PlatformSelect/macos9.svg
+++ b/frontend/src/components/PlatformSelect/macos9.svg
@@ -1,204 +1,36 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="8.4710464mm"
-   height="10.9614mm"
-   viewBox="0 0 8.4710464 10.9614"
-   version="1.1"
-   id="svg8"
-   inkscape:version="0.92.1 r15371"
-   sodipodi:docname="Happy Mac.svg">
-  <defs
-     id="defs2" />
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="8"
-     inkscape:cx="4.1053318"
-     inkscape:cy="14.867275"
-     inkscape:document-units="mm"
-     inkscape:current-layer="layer1"
-     showgrid="false"
-     inkscape:measure-start="0,0"
-     inkscape:measure-end="0,0"
-     showguides="true"
-     inkscape:guide-bbox="true"
-     inkscape:window-width="1600"
-     inkscape:window-height="838"
-     inkscape:window-x="-8"
-     inkscape:window-y="-8"
-     inkscape:window-maximized="1"
-     inkscape:pagecheckerboard="true"
-     fit-margin-top="0"
-     fit-margin-left="0"
-     fit-margin-right="0"
-     fit-margin-bottom="0" />
-  <metadata
-     id="metadata5">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <g
-     inkscape:label="Livello 1"
-     inkscape:groupmode="layer"
-     id="layer1"
-     transform="translate(-5.3090212,-4.3002038)">
-    <g
-       id="g4959"
-       transform="matrix(0.06455006,0,0,0.06455006,7.6050574,7.0900779)">
-      <path
-         id="rect43-8"
-         d="m -30.937651,99.78759 h 122 v 26.80449 h -122 z"
-         style="fill:#000000;fill-opacity:1;stroke-width:2.38412714"
-         inkscape:connector-curvature="0" />
-      <g
-         transform="translate(-56.456402,-31.41017)"
-         id="g4916">
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:#555555;fill-opacity:1;stroke:none;stroke-width:0.17674622"
-           d="m 33.668747,136.75006 v 4.69998 h 31.950504 v -4.69998 z m 41.740088,4.69998 V 146.15 h 11.145573 v -4.69996 z M 91.152059,146.15 v 6.29987 H 102.47075 V 146.15 Z"
-           id="rect57-8-2" />
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:#444444;fill-opacity:1;stroke:none;stroke-width:0.15800072"
-           d="m 65.619251,136.75006 v 4.69998 H 86.554408 V 146.15 h 15.916342 v 6.29987 h 20.86023 V 146.15 h -15.87449 v -4.69996 H 91.152059 v -4.69998 z"
-           id="rect57-8-0-6" />
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:#222222;fill-opacity:1;stroke:none;stroke-width:0.21712606"
-           d="m 91.152059,136.75006 v 4.69998 H 107.45649 V 146.15 h 15.87449 v 6.29987 h 16.03777 v -6.29987 -4.69996 -4.69998 z"
-           id="rect57-8-0-8-8" />
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:#777777;fill-opacity:1;stroke:none;stroke-width:0.20201708"
-           d="M 33.668747,141.45004 V 146.15 h 41.740088 v -4.69996 z M 75.408835,146.15 v 6.29987 H 91.152059 V 146.15 Z"
-           id="rect57-8-4-4" />
-        <path
-           id="rect57-1-3-5-6"
-           d="m 33.668823,146.14999 h 41.74001 v 6.3 h -41.74001 z"
-           style="fill:#888888;fill-opacity:1;stroke:none;stroke-width:0.23388879"
-           inkscape:connector-curvature="0" />
-      </g>
-      <path
-         id="rect325"
-         d="M -30.969854,-37.120319 H 91.062349 V 99.787579 H -30.969854 Z"
-         style="fill:#cccccc;fill-opacity:1;stroke-width:0.26458332"
-         inkscape:connector-curvature="0" />
-      <path
-         id="rect327"
-         d="M -15.075892,-21.040775 H 74.98512 v 67.75 h -90.061012 z"
-         style="fill:#ccccff;fill-opacity:1;stroke-width:0.26458332"
-         inkscape:connector-curvature="0" />
-      <path
-         id="rect237-98"
-         transform="scale(0.26458333)"
-         d="M 102.17383,-23.402344 V 59.882812 H 83.148438 V 78.779297 H 102.17383 120 120.0508 V -23.402344 Z"
-         style="fill:#000000;fill-opacity:1;stroke-width:0.93718952"
-         inkscape:connector-curvature="0" />
-      <path
-         id="rect43"
-         d="M -30.969856,-43.220318 H 91.062347 v 6.1 H -30.969856 Z"
-         style="fill:#000000;fill-opacity:1;stroke-width:1.13749063"
-         inkscape:connector-curvature="0" />
-      <path
-         id="rect43-1"
-         d="M -15.075892,-27.140776 H 74.98512 v 6.1 h -90.061012 z"
-         style="fill:#444444;fill-opacity:1;stroke-width:0.97719014"
-         inkscape:connector-curvature="0" />
-      <path
-         id="rect43-1-2"
-         d="m -21.040775,15.075892 h 67.75 v 6.1 h -67.75 z"
-         style="fill:#444444;fill-opacity:1;stroke-width:0.84755003"
-         transform="rotate(90)"
-         inkscape:connector-curvature="0" />
-      <path
-         id="rect43-1-2-1"
-         d="m -21.040775,-81.085121 h 67.75 v 6.1 h -67.75 z"
-         style="fill:#ffffff;fill-opacity:1;stroke-width:0.84755009"
-         transform="rotate(90)"
-         inkscape:connector-curvature="0" />
-      <path
-         id="rect43-1-7"
-         d="m -15.07589,46.709225 h 90.061013 v 6.1 H -15.07589 Z"
-         style="fill:#ffffff;fill-opacity:1;stroke-width:0.9771902"
-         inkscape:connector-curvature="0" />
-      <path
-         id="rect169"
-         d="m 31.655506,73.81324 h 43.400002 v 5 H 31.655506 Z"
-         style="fill:#000000;fill-opacity:1;stroke-width:0.26445001"
-         inkscape:connector-curvature="0" />
-      <path
-         id="rect169-1"
-         d="m 31.655506,78.81324 h 43.400005 v 6 H 31.655506 Z"
-         style="fill:#ffffff;fill-opacity:1;stroke-width:0.28969046"
-         inkscape:connector-curvature="0" />
-      <path
-         id="rect169-9"
-         d="m -21.133041,73.785721 h 11.060395 v 5 h -11.060395 z"
-         style="fill:#00bb00;fill-opacity:1;stroke-width:0.13350084"
-         inkscape:connector-curvature="0" />
-      <path
-         id="rect169-1-3"
-         d="m -21.133041,78.785721 h 11.060396 v 6 h -11.060396 z"
-         style="fill:#dd0000;fill-opacity:1;stroke-width:0.14624284"
-         inkscape:connector-curvature="0" />
-      <path
-         id="rect237"
-         d="M 5.8799295,-6.1919641 H 10.87993 V 5.0080357 H 5.8799295 Z"
-         style="fill:#000000;fill-opacity:1;stroke-width:0.26576424"
-         inkscape:connector-curvature="0" />
-      <path
-         id="rect237-9"
-         d="m 47.880306,-6.1919641 h 6.1 V 5.0080357 h -6.1 z"
-         style="fill:#000000;fill-opacity:1;stroke-width:0.29354623"
-         inkscape:connector-curvature="0" />
-      <path
-         id="rect237-0"
-         d="m 10.8871,25.947487 h 5 v 6 h -5 z"
-         style="fill:#000000;fill-opacity:1;stroke-width:0.19451953"
-         inkscape:connector-curvature="0" />
-      <path
-         id="rect237-0-7"
-         d="m 38.149635,25.944651 h 4.75 v 6.002836 h -4.75 z"
-         style="fill:#000000;fill-opacity:1;stroke-width:0.18963902"
-         inkscape:connector-curvature="0" />
-      <path
-         id="rect319"
-         d="m 15.8871,31.947487 h 22.262533 v 5.011021 H 15.8871 Z"
-         style="fill:#000000;fill-opacity:1;stroke-width:11.12128639"
-         inkscape:connector-curvature="0" />
-      <path
-         id="rect43-5-3-4"
-         d="M -37.120319,30.969854 H 99.787579 v 4.6 H -37.120319 Z"
-         style="fill:#000000;fill-opacity:1;stroke-width:1.04625833"
-         transform="rotate(90)"
-         inkscape:connector-curvature="0" />
-      <path
-         id="rect43-5-3-4-9"
-         d="M -37.120331,-95.662346 H 99.787582 v 4.6 H -37.120331 Z"
-         style="fill:#000000;fill-opacity:1;stroke-width:1.04625833"
-         transform="rotate(90)"
-         inkscape:connector-curvature="0" />
-    </g>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="8.471mm" height="10.961mm" version="1.1" xmlns="http://www.w3.org/2000/svg">
+ <g transform="translate(-5.309 -4.3002)">
+  <g transform="matrix(.06455 0 0 .06455 7.6051 7.0901)">
+   <path d="m-30.938 99.788h122v26.804h-122z" stroke-width="2.3841"/>
+   <g transform="translate(-56.456 -31.41)">
+    <path d="m33.669 136.75v4.7h31.951v-4.7zm41.74 4.7v4.7h11.146v-4.7zm15.743 4.7v6.2999h11.319v-6.2999z" fill="#555"/>
+    <path d="m65.619 136.75v4.7h20.935v4.7h15.916v6.2999h20.86v-6.2999h-15.874v-4.7h-16.304v-4.7z" fill="#444"/>
+    <path d="m91.152 136.75v4.7h16.304v4.7h15.874v6.2999h16.038v-15.7z" fill="#222"/>
+    <path d="m33.669 141.45v4.7h41.74v-4.7zm41.74 4.7v6.2999h15.743v-6.2999z" fill="#777"/>
+    <path d="m33.669 146.15h41.74v6.3h-41.74z" fill="#888"/>
+   </g>
+   <path d="m-30.97-37.12h122.03v136.91h-122.03z" fill="#ccc" stroke-width=".26458"/>
+   <path d="m-15.076-21.041h90.061v67.75h-90.061z" fill="#ccf" stroke-width=".26458"/>
+   <path transform="scale(.26458)" d="m102.17-23.402v83.285h-19.025v18.896h36.902v-102.18z" stroke-width=".93719"/>
+   <path d="m-30.97-43.22h122.03v6.1h-122.03z" stroke-width="1.1375"/>
+   <path d="m-15.076-27.141h90.061v6.1h-90.061z" fill="#444" stroke-width=".97719"/>
+   <path transform="rotate(90)" d="m-21.041 15.076h67.75v6.1h-67.75z" fill="#444" stroke-width=".84755"/>
+   <path transform="rotate(90)" d="m-21.041-81.085h67.75v6.1h-67.75z" fill="#fff" stroke-width=".84755"/>
+   <path d="m-15.076 46.709h90.061v6.1h-90.061z" fill="#fff" stroke-width=".97719"/>
+   <path d="m31.656 73.813h43.4v5h-43.4z" stroke-width=".26445"/>
+   <path d="m31.656 78.813h43.4v6h-43.4z" fill="#fff" stroke-width=".28969"/>
+   <path d="m-21.133 73.786h11.06v5h-11.06z" fill="#0b0" stroke-width=".1335"/>
+   <path d="m-21.133 78.786h11.06v6h-11.06z" fill="#d00" stroke-width=".14624"/>
+   <g>
+    <path d="m5.8799-6.192h5v11.2h-5z" stroke-width=".26576"/>
+    <path d="m47.88-6.192h6.1v11.2h-6.1z" stroke-width=".29355"/>
+    <path d="m10.887 25.947h5v6h-5z" stroke-width=".19452"/>
+    <path d="m38.15 25.945h4.75v6.0028h-4.75z" stroke-width=".18964"/>
+    <path d="m15.887 31.947h22.263v5.011h-22.263z" stroke-width="11.121"/>
+    <path transform="rotate(90)" d="m-37.12 30.97h136.91v4.6h-136.91z" stroke-width="1.0463"/>
+    <path transform="rotate(90)" d="m-37.12-95.662h136.91v4.6h-136.91z" stroke-width="1.0463"/>
+   </g>
   </g>
+ </g>
 </svg>

--- a/frontend/src/pages/credits.tsx
+++ b/frontend/src/pages/credits.tsx
@@ -154,6 +154,11 @@ export default function CreditsPage({ maintainers, contributors }: {
                             <a>GBA SVG by Andrew Vester from NounProject.com</a>
                         </Link>
                     </li>
+                    <li>
+                        <Link href="https://commons.wikimedia.org/wiki/File:Happy_Mac.svg">
+                            <a>Happy Mac by NiloGlock</a>
+                        </Link>
+                    </li>
                 </ul>
             </div>
         </main>


### PR DESCRIPTION
Adds:
-The cross-compiler (target is Mac OS 9 (PowerPC), and host is Win32) and linker from Metrowerks CodeWarrior Pro 5 and 6.
-Some changes to work around the compilers' jank and work around the proprietary format used for the object files by dumping the assembly, converting it to a format binutils can assemble, and assembling a linux elf that can be dumped with objdump
-A preset for the aforementioned cross-compiler: The Sims 1, with flags "-lang=c++ -O3 -str pool -g"

As there is no version of doldisasm.py but for PEF files instead of DOLs (due to PEFs not only being proprietary, but also poorly documented and having no existing python library to use; I'm too lazy to implement an entire PEF reader in python myself as PEFs are really complex), scratches need to have the input asm be asm generated from IDA Pro, that has to be manually reformatted (a script to automate this should probably be made) into the GNU Assembler Syntax, in a way that can be assembled by binutils. [Here's an example of a reformatted assembly.](https://github.com/ChrisNonyminus/sims1_mac_decomp/blob/master/asm/split/CSimsApp.s)

Note: Asm diffing a scratch requires you to define a function in the scratch that has the same symbol as the diff label in the input asm.

Needs some cleaning, and a better solution for MWCPPC's jank and the object file format jank; we can't just have MWCPPC make an ELF; it doesn't do that as Mac OS 9 uses PEFs instead of ELFs.