### PR TITLE
Fix rodata references not showing up on RHS

### DIFF
--- a/backend/coreapp/views/scratch.py
+++ b/backend/coreapp/views/scratch.py
@@ -73,7 +73,7 @@ def diff_compilation(
         scratch.target_assembly,
         platforms.from_id(scratch.platform),
         scratch.diff_label,
-        compilation.elf_object,
+        bytes(compilation.elf_object),
         allow_target_only=allow_target_only,
         diff_flags=scratch.diff_flags,
     )


### PR DESCRIPTION
It was hitting https://code.djangoproject.com/ticket/27813. Fixed by casting memoryview to bytes, just like at the other place `elf_object` is accessed.

(This fix is completely untested but I'm confident.)