### PR TITLE
use grid instead of flex in PlatformSelect

### DIFF
--- a/frontend/src/components/PlatformSelect/PlatformSelect.module.scss
+++ b/frontend/src/components/PlatformSelect/PlatformSelect.module.scss
@@ -1,9 +1,8 @@
 .container {
     list-style: none;
 
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
     gap: 8px;
 }
 


### PR DESCRIPTION
Updates PlatformSelect to use a grid of three columns. This should prevent [whatever happened in #462](https://github.com/decompme/decomp.me/pull/462#issuecomment-1145940121), and also prevents the cells from growing to more than one column when there are less than three on a row (see: last cell width in image below).

<img width="795" alt="image" src="https://user-images.githubusercontent.com/9429556/171900743-c430929f-742b-4c2d-8ce8-8428010827c3.png">
