### PR TITLE
Highlight tokens in the diff view on click

### DIFF
--- a/frontend/src/components/Diff/Diff.module.scss
+++ b/frontend/src/components/Diff/Diff.module.scss
@@ -6,11 +6,6 @@
     flex-direction: column;
 }
 
-.highlighted {
-    background-color: #777 !important;
-    box-shadow: 0 0 2px #fff;
-}
-
 .bodyContainer {
     flex-grow: 1;
 }
@@ -133,3 +128,12 @@
 .rotation6 { color: lightcyan; }
 .rotation7 { color: lightgreen; }
 .rotation8 { color: grey; }
+
+.highlighted {
+    color: white;
+    background-color: #aa8b00;
+}
+
+.highlightable {
+    cursor: pointer;
+}

--- a/frontend/src/components/Diff/Diff.module.scss
+++ b/frontend/src/components/Diff/Diff.module.scss
@@ -72,6 +72,8 @@
 
         padding: 0 1em;
 
+        cursor: default;
+
         &.highlight {
             background-color: rgba(255, 255, 255, 0.05);
 

--- a/frontend/src/components/Diff/Diff.module.scss
+++ b/frontend/src/components/Diff/Diff.module.scss
@@ -6,6 +6,11 @@
     flex-direction: column;
 }
 
+.highlighted {
+    background-color: #777 !important;
+    box-shadow: 0 0 2px #fff;
+}
+
 .bodyContainer {
     flex-grow: 1;
 }

--- a/frontend/src/components/Diff/Diff.tsx
+++ b/frontend/src/components/Diff/Diff.tsx
@@ -51,13 +51,11 @@ function FormatDiffText({ texts, highlighter }: {
     texts: api.DiffText[]
     highlighter: Highlighter
 }) {
-    let index = 0
-    return <>{
+    return <> {
         texts.map(t =>
-            Array.from(t.text.matchAll(RE_TOKEN)).map(match => {
+            Array.from(t.text.matchAll(RE_TOKEN)).map((match, index) => {
                 const text = match[0]
                 const isToken = !match[1]
-                const key = index++ // FIXME: using index as key is an antipattern
 
                 let className: string
                 if (t.format == "rotation") {
@@ -67,7 +65,7 @@ function FormatDiffText({ texts, highlighter }: {
                 }
 
                 return <span
-                    key={key}
+                    key={index}
                     className={classNames(className, {
                         [styles.highlightable]: isToken,
                         [styles.highlighted]: (highlighter.value === text),

--- a/frontend/src/components/Diff/Diff.tsx
+++ b/frontend/src/components/Diff/Diff.tsx
@@ -30,7 +30,7 @@ type Highlighter = {
     select: (value: string) => void
 }
 
-function useHighlighter(setAll: (string) => void): Highlighter {
+function useHighlighter(setAll: Highlighter["setValue"]): Highlighter {
     const [value, setValue] = useState(null)
     return {
         value,
@@ -142,7 +142,7 @@ const innerElementType = forwardRef<HTMLUListElement, HTMLAttributes<HTMLUListEl
 innerElementType.displayName = "innerElementType"
 
 function DiffBody({ diff, fontSize }: { diff: api.DiffOutput, fontSize: number | undefined }) {
-    const setHighlightAll = value => {
+    const setHighlightAll: Highlighter["setValue"] = value => {
         highlighter1.setValue(value)
         highlighter2.setValue(value)
         highlighter3.setValue(value)
@@ -150,7 +150,14 @@ function DiffBody({ diff, fontSize }: { diff: api.DiffOutput, fontSize: number |
     const highlighter1 = useHighlighter(setHighlightAll)
     const highlighter2 = useHighlighter(setHighlightAll)
     const highlighter3 = useHighlighter(setHighlightAll)
-    return <div className={styles.bodyContainer} onClick={() => setHighlightAll(null)}>
+
+    return <div
+        className={styles.bodyContainer}
+        onClick={() => {
+            // If clicks propagate to the container, clear all
+            setHighlightAll(null)
+        }}
+    >
         {diff?.rows && <AutoSizer>
             {({ height, width }) => (
                 <FixedSizeList

--- a/frontend/src/components/Diff/Diff.tsx
+++ b/frontend/src/components/Diff/Diff.tsx
@@ -52,23 +52,24 @@ function FormatDiffText({ texts, highlighter }: {
     highlighter: Highlighter
 }) {
     let index = 0
-    return <> {
+    return <>{
         texts.map(t =>
             Array.from(t.text.matchAll(RE_TOKEN)).map(match => {
-                const text = match[0], isToken = !match[1]
-                const key = index++
-                let className = undefined
+                const text = match[0]
+                const isToken = !match[1]
+                const key = index++ // FIXME: using index as key is an antipattern
+
+                let className: string
                 if (t.format == "rotation") {
                     className = styles[`rotation${t.index % 9}`]
                 } else if (t.format) {
                     className = styles[t.format]
                 }
-                if (!isToken && !className) {
-                    return <Fragment key={key}>{text}</Fragment>
-                }
+
                 return <span
                     key={key}
                     className={classNames(className, {
+                        [styles.highlightable]: isToken,
                         [styles.highlighted]: (highlighter.value === text),
                     })}
                     onClick={e => {
@@ -77,7 +78,9 @@ function FormatDiffText({ texts, highlighter }: {
                             e.stopPropagation()
                         }
                     }}
-                >{text}</span>
+                >
+                    {text}
+                </span>
             })
         )
     }</>

--- a/frontend/src/components/Diff/Diff.tsx
+++ b/frontend/src/components/Diff/Diff.tsx
@@ -52,10 +52,11 @@ function FormatDiffText({ texts, highlighter }: {
     highlighter: Highlighter
 }) {
     return <> {
-        texts.map(t =>
-            Array.from(t.text.matchAll(RE_TOKEN)).map((match, index) => {
+        texts.map((t, index1) =>
+            Array.from(t.text.matchAll(RE_TOKEN)).map((match, index2) => {
                 const text = match[0]
                 const isToken = !match[1]
+                const key = index1 + "," + index2
 
                 let className: string
                 if (t.format == "rotation") {
@@ -65,7 +66,7 @@ function FormatDiffText({ texts, highlighter }: {
                 }
 
                 return <span
-                    key={index}
+                    key={key}
                     className={classNames(className, {
                         [styles.highlightable]: isToken,
                         [styles.highlighted]: (highlighter.value === text),


### PR DESCRIPTION
Poor man's register highlighting: run a regex client side to tokenize lines and make it possible to click tokens to highlight them on that side of the diff. (You can highlight different tokens on both sides, in order to trace register diffs.) Double-clicking highlights a token on both sides. Only one token can be highlighted at a time, and clicking a non-token clears all highlighting.

(The double-click behavior is kinda undiscoverable and unideal... I could imagine selecting the corresponding token on the other side automatically when the lines match up completely, or showing a help message about the double click functionality when the user highlights the same thing on both sides manually, or moving the highlight-only-on-one-side functionality to under a modifier key.)