### PR TITLE
MWCC line number fix

### DIFF
--- a/backend/coreapp/compiler_wrapper.py
+++ b/backend/coreapp/compiler_wrapper.py
@@ -140,8 +140,7 @@ class CompilerWrapper:
             # Fix for MWCC line numbers in GC 3.0+
             if compiler.is_mwcc:
                 ctx_path = sandbox.path / "ctx.c"
-                with ctx_path.open("w") as f:
-                    pass
+                ctx_path.touch()
 
             # IDO hack to support -KPIC
             if compiler.is_ido and "-KPIC" in compiler_flags:

--- a/backend/coreapp/compiler_wrapper.py
+++ b/backend/coreapp/compiler_wrapper.py
@@ -131,11 +131,17 @@ class CompilerWrapper:
                 f.write(context)
                 f.write("\n")
 
-                f.write('#line 1 "src.c"\n')
+                f.write('#line 1 "code.c"\n')
                 f.write(code)
                 f.write("\n")
 
             cc_cmd = compiler.cc
+
+            # Fix for MWCC line numbers in GC 3.0+
+            if compiler.is_mwcc:
+                ctx_path = sandbox.path / "ctx.c"
+                with ctx_path.open("w") as f:
+                    pass
 
             # IDO hack to support -KPIC
             if compiler.is_ido and "-KPIC" in compiler_flags:


### PR DESCRIPTION
In MWCC versions 3.0+, using `#line` directives to override line numbers in the dwarf output won't work unless the file given in the directive exists (the contents of it don't matter). This PR changes the second directive from `src.c` to `code.c` since that file already exists, and creates an empty `ctx.c` file to fix the first directive.