### PR TITLE
Add TMPDIR=/tmp to compiler command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
       - run: cd backend && poetry install
-      - name: Add i386 architecture and install dependencies
+      - name: Install dependencies
         run: |-
           sudo apt -qq update
           sudo apt-get install \
@@ -55,7 +55,7 @@ jobs:
           sudo mv bin/arm* /usr/bin/
       - name: Install wibo
         run: |-
-          wget https://github.com/decompals/WiBo/releases/download/0.2.1/wibo && chmod +x wibo && sudo cp wibo /usr/bin/
+          wget https://github.com/decompals/WiBo/releases/download/0.2.3/wibo && chmod +x wibo && sudo cp wibo /usr/bin/
       - name: Run backend tests
         run: |-
           cd backend

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -57,7 +57,7 @@ RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/inst
 
 COPY --from=nsjail /nsjail/nsjail /bin/nsjail
 
-COPY --from=ghcr.io/decompals/wibo:0.2.1 /usr/local/sbin/wibo /usr/bin/
+COPY --from=ghcr.io/decompals/wibo:0.2.3 /usr/local/sbin/wibo /usr/bin/
 
 # gc/wii specifics
 COPY --from=devkitpro/devkitppc:20210726 /opt/devkitpro/devkitPPC/bin/powerpc* /usr/bin/

--- a/backend/coreapp/compiler_wrapper.py
+++ b/backend/coreapp/compiler_wrapper.py
@@ -159,6 +159,7 @@ class CompilerWrapper:
                         "COMPILER_FLAGS": sandbox.quote_options(compiler_flags),
                         "FUNCTION": function,
                         "MWCIncludes": "/tmp",
+                        "TMPDIR": "/tmp",
                     },
                 )
             except subprocess.CalledProcessError as e:

--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -183,7 +183,7 @@ GCC263_MIPSEL = GCCPS1Compiler(
     cc='mips-linux-gnu-cpp -Wall -lang-c -gstabs "$INPUT" | "${COMPILER_DIR}"/cc1 -mips1 -mcpu=3000 $COMPILER_FLAGS | mips-linux-gnu-as -march=r3000 -mtune=r3000 -no-pad-sections -O1 -o "$OUTPUT"',
 )
 
-PSYQ_CC = 'cpp -P "$INPUT" | unix2dos | ${WIBO} ${COMPILER_DIR}/CC1PSX.EXE -quiet ${COMPILER_FLAGS} -o "$OUTPUT".s && ${WIBO} ${COMPILER_DIR}/ASPSX.EXE "$OUTPUT".s -o "$OUTPUT".obj && ${COMPILER_DIR}/psyq-obj-parser "$OUTPUT".obj -o "$OUTPUT"'
+PSYQ_CC = 'cpp -P "$INPUT" | unix2dos | ${WIBO} ${COMPILER_DIR}/CC1PSX.EXE -quiet ${COMPILER_FLAGS} -o "$OUTPUT".s && ${WIBO} ${COMPILER_DIR}/ASPSX.EXE -quiet "$OUTPUT".s -o "$OUTPUT".obj && ${COMPILER_DIR}/psyq-obj-parser "$OUTPUT".obj -o "$OUTPUT"'
 PSYQ40 = GCCPS1Compiler(
     id="psyq4.0",
     platform=PS1,


### PR DESCRIPTION
1. $TMPDIR is only used by PSYQ with certain optimisation levels / codegen, hence why it's mostly been working
2. Updated wibo to latest version, this fixes a few missing functions
3. Added `-quiet` flag to the PSYQ assembler

Fixes #491 