### PR TITLE
provide stdout/stderr to user if compilation succeeds but no .o is ge…

### DIFF
--- a/backend/coreapp/compiler_wrapper.py
+++ b/backend/coreapp/compiler_wrapper.py
@@ -179,7 +179,13 @@ class CompilerWrapper:
                 raise CompilationError(str(e))
 
             if not object_path.exists():
-                raise CompilationError("Compiler did not create an object file")
+                if compile_proc.stdout:
+                    msg = f"{compile_proc.stdout}\n{compile_proc.stderr}"
+                else:
+                    msg = compile_proc.stderr
+                error_msg = "Compiler did not create an object file: %s" % msg
+                logging.debug(error_msg)
+                raise CompilationError(error_msg)
 
             object_bytes = object_path.read_bytes()
 


### PR DESCRIPTION
…nerated

We seem to have a scenario where psyq object converter fails but doesnt exit with non-zero.. so on the frontend we see:

![image](https://user-images.githubusercontent.com/22226349/181895149-89989001-62f8-4435-bf2d-91e17bf78c04.png)


with this change, the output is given to the user so they can see what went wrong:
![image](https://user-images.githubusercontent.com/22226349/181895013-64e3bcb3-e275-4372-a166-756e7e310068.png)


Whilst this does give more junk messages (nsjail info, wine whining), this scenario should be rare (compilation succeeds but no object), so I feel it's better to be verbose about what happened -- otherwise we have to dig into the logs (which don't actually say anything - hence this change also spits out the same info to the logs).

**EDIT**
~~I will also push a PR to the pcsx-redux repo so that it returns non-zero exit when it fails...~~

PR raised https://github.com/grumpycoders/pcsx-redux/pull/945 - which should make this PR a little redundant for the psyq-obj-parser scenario.. but maybe still useful?

With the latest psyq-obj-parser which you can get via download.py, the program errors properly and thus the error message is printed:
```
:: Conversion failed: Two-part relocation missing its second part
```
![image](https://user-images.githubusercontent.com/22226349/181904836-925f190b-eabf-436d-873b-b9f7ec63b802.png)
