### PR TITLE
Fix incorrect line numbers on NDS MWCC

### DIFF
--- a/backend/coreapp/compiler_wrapper.py
+++ b/backend/coreapp/compiler_wrapper.py
@@ -179,7 +179,7 @@ class CompilerWrapper:
                 if e.stdout:
                     msg = f"{e.stdout}\n{e.stderr}"
                 else:
-                    msg = e.stderr
+                    msg = f"{e.stderr}"
 
                 logging.debug("Compilation failed: %s", msg)
                 raise CompilationError(CompilerWrapper.filter_compile_errors(msg))
@@ -192,7 +192,7 @@ class CompilerWrapper:
                 if compile_proc.stdout:
                     msg = f"{compile_proc.stdout}\n{compile_proc.stderr}"
                 else:
-                    msg = compile_proc.stderr
+                    msg = f"{compile_proc.stderr}"
                 error_msg = "Compiler did not create an object file: %s" % msg
                 logging.debug(error_msg)
                 raise CompilationError(error_msg)
@@ -202,7 +202,7 @@ class CompilerWrapper:
             if not object_bytes:
                 raise CompilationError("Compiler created an empty object file")
 
-            compile_errors = CompilerWrapper.filter_compile_errors(compile_proc.stderr)
+            compile_errors = CompilerWrapper.filter_compile_errors(compile_proc.stdout)
 
             return CompilationResult(object_path.read_bytes(), compile_errors)
 

--- a/backend/coreapp/compiler_wrapper.py
+++ b/backend/coreapp/compiler_wrapper.py
@@ -176,10 +176,7 @@ class CompilerWrapper:
                 )
             except subprocess.CalledProcessError as e:
                 # Compilation failed
-                if e.stdout:
-                    msg = f"{e.stdout}\n{e.stderr}"
-                else:
-                    msg = f"{e.stderr}"
+                msg = e.stdout
 
                 logging.debug("Compilation failed: %s", msg)
                 raise CompilationError(CompilerWrapper.filter_compile_errors(msg))
@@ -189,11 +186,7 @@ class CompilerWrapper:
                 raise CompilationError(str(e))
 
             if not object_path.exists():
-                if compile_proc.stdout:
-                    msg = f"{compile_proc.stdout}\n{compile_proc.stderr}"
-                else:
-                    msg = f"{compile_proc.stderr}"
-                error_msg = "Compiler did not create an object file: %s" % msg
+                error_msg = "Compiler did not create an object file: %s" % compile_proc.stdout
                 logging.debug(error_msg)
                 raise CompilationError(error_msg)
 

--- a/backend/coreapp/compiler_wrapper.py
+++ b/backend/coreapp/compiler_wrapper.py
@@ -186,7 +186,9 @@ class CompilerWrapper:
                 raise CompilationError(str(e))
 
             if not object_path.exists():
-                error_msg = "Compiler did not create an object file: %s" % compile_proc.stdout
+                error_msg = (
+                    "Compiler did not create an object file: %s" % compile_proc.stdout
+                )
                 logging.debug(error_msg)
                 raise CompilationError(error_msg)
 

--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -415,7 +415,7 @@ MWCC_43_213 = MWCCCompiler(
 )
 
 # NDS_ARM9
-MWCCARM_CC = '${WINE} "${COMPILER_DIR}/mwccarm.exe" -c -proc arm946e -nostdinc -stderr ${COMPILER_FLAGS} -o "${OUTPUT}" "${INPUT}"'
+MWCCARM_CC = '${WINE} "${COMPILER_DIR}/mwccarm.exe" -pragma \"msg_show_realref off\" -c -proc arm946e -nostdinc -stderr ${COMPILER_FLAGS} -o "${OUTPUT}" "${INPUT}"'
 
 MWCC_20_72 = MWCCCompiler(
     id="mwcc_20_72",

--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -415,7 +415,7 @@ MWCC_43_213 = MWCCCompiler(
 )
 
 # NDS_ARM9
-MWCCARM_CC = '${WINE} "${COMPILER_DIR}/mwccarm.exe" -pragma \"msg_show_realref off\" -c -proc arm946e -nostdinc -stderr ${COMPILER_FLAGS} -o "${OUTPUT}" "${INPUT}"'
+MWCCARM_CC = '${WINE} "${COMPILER_DIR}/mwccarm.exe" -pragma "msg_show_realref off" -c -proc arm946e -nostdinc -stderr ${COMPILER_FLAGS} -o "${OUTPUT}" "${INPUT}"'
 
 MWCC_20_72 = MWCCCompiler(
     id="mwcc_20_72",

--- a/backend/coreapp/sandbox.py
+++ b/backend/coreapp/sandbox.py
@@ -122,10 +122,11 @@ class Sandbox(contextlib.AbstractContextManager["Sandbox"]):
         logger.debug(f"Sandbox Command: {debug_env_str} {shlex.join(command)}")
         return subprocess.run(
             command,
-            capture_output=True,
             text=True,
             env=env,
             cwd=self.path,
             check=True,
             shell=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
         )


### PR DESCRIPTION
NDS MWCC outputs correct line numbers to stdout in the following format
```
Z:\var\folders\mv\5b1057tx3pgbq60mm6p07y0h0000gn\T\tmpreq_0h7l\ctx.c:7: note:     (corresponding #line reference)
```

Usually this gets interleaved with stderr in the command line, 
```
Z:\var\folders\mv\5b1057tx3pgbq60mm6p07y0h0000gn\T\tmpreq_0h7l\code.c:13: warning: illegal implicit conversion from 'int' to
Z:\var\folders\mv\5b1057tx3pgbq60mm6p07y0h0000gn\T\tmpreq_0h7l\code.c:13: warning: 'struct asdf_struct *'
Z:\var\folders\mv\5b1057tx3pgbq60mm6p07y0h0000gn\T\tmpreq_0h7l\ctx.c:7: note:     (corresponding #line reference)
```

...but split stdout/stderr makes it unusable since all the notes get tacked onto the end.

This PR tries to take each `corresponding #line reference` and match it up with (usually multiple) stderr lines, so that the output is as expected:
```
ctx.c:7: warning: illegal implicit conversion from 'int' to
ctx.c:7: warning: 'struct asdf_struct *'
```