### PR TITLE
Fix scratch action icons having overflowing text on old Chrome

### DIFF
--- a/frontend/src/components/Scratch/ScratchToolbar.module.scss
+++ b/frontend/src/components/Scratch/ScratchToolbar.module.scss
@@ -117,8 +117,11 @@
 
             // On small widths, only show the icon
             @media (max-width: 600px) {
-                text-indent: -9999px; // Hide text
                 padding: 6px 2px;
+
+                // Hide text
+                text-indent: -9999px;
+                color: transparent;
 
                 svg {
                     width: 1.5em;

--- a/frontend/src/components/Scratch/ScratchToolbar.module.scss
+++ b/frontend/src/components/Scratch/ScratchToolbar.module.scss
@@ -125,6 +125,7 @@
 
                 svg {
                     width: 1.5em;
+                    color: var(--g1400);
                 }
             }
         }


### PR DESCRIPTION
Maybe

Chrome 83 Android before:
![image](https://user-images.githubusercontent.com/9429556/190296700-97de5e2f-7698-4c96-9292-a32c9709d9dd.png)
