### PR TITLE
Open index page when middle-clicking on hamburger menu

### DIFF
--- a/frontend/src/components/Nav/Nav.tsx
+++ b/frontend/src/components/Nav/Nav.tsx
@@ -59,7 +59,13 @@ export default function Nav({ children }: Props) {
     >
         <ul className={styles.header}>
             <li className={styles.headerItemMenuToggle}>
-                <button id="navtoggle" onClick={toggleOpen} aria-label={toggleLabel} aria-expanded={isOpen}>
+                <button
+                    id="navtoggle"
+                    onClick={toggleOpen}
+                    onAuxClick={() => window.open("/", "_blank")}
+                    aria-label={toggleLabel}
+                    aria-expanded={isOpen}
+                >
                     {isOpen ? <XIcon size={24} /> : <ThreeBarsIcon size={18} />}
                 </button>
             </li>


### PR DESCRIPTION
On all pages except the scratch editor, middle-clicking the top-left corner (the frog icon) opens the
home page in a new tab. On the editor, doing the same action -- although with the hamburger menu icon
rather than the frog -- does nothing. This PR makes middle-clicking the hamburger menu icon open the
home page in a new tab, so muscle memory enjoyers like @Brotenko can use it on the editor too.