### PR TITLE
Update psyq-obj-parser for psyq compilers

### DIFF
--- a/backend/compilers/download.py
+++ b/backend/compilers/download.py
@@ -432,6 +432,8 @@ def download_ps1():
         print("ps1 compilers unsupported on " + host_os.name)
         return
 
+    compilers_path = COMPILERS_DIR / "psyq-compilers"
+
     download_zip(
         url="https://github.com/decompals/old-gcc/releases/download/release/gcc-2.6.3.zip",
         dl_name="gcc2.6.3-mispel.zip",
@@ -444,6 +446,13 @@ def download_ps1():
         dest_name="psyq-compilers",
     )
 
+    # TODO: remove psyq-obj-parser from psyq-compilers.tar.gz
+    download_file(
+        url="https://github.com/mkst/pcsx-redux/releases/download/matching-relocs/psyq-obj-parser",
+        log_name="psyq-obj-parser",
+        dest_path=compilers_path / "psyq",
+    )
+
     psyq_to_gcc = {
         "4.0": "2.7.2",
         "4.1": "2.7.2",
@@ -452,14 +461,18 @@ def download_ps1():
     }
 
     for version in psyq_to_gcc.keys():
-        compilers_path = COMPILERS_DIR / "psyq-compilers"
         dest = COMPILERS_DIR / f"psyq{version}"
         if not dest.exists():
             shutil.move(compilers_path / f"psyq{version}", COMPILERS_DIR)
+        psyq_obj_parser = dest / "psyq-obj-parser"
         shutil.copy(
-            compilers_path / "psyq-obj-parser",
-            dest / "psyq-obj-parser",
+            compilers_path / "psyq",
+            psyq_obj_parser,
         )
+        psyq_obj_parser.chmod(
+            psyq_obj_parser.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+        )
+        set_x(psyq_obj_parser)
 
         # +x exes
         for file in dest.glob("*.exe"):


### PR DESCRIPTION
I think github strips the +x flag from the binary - kinda irritating.