### PR TITLE
Switch PSYQ to use CCPSX instead of CC1PSX+ASPSX chain

### DIFF
--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -268,7 +268,7 @@ GCC263_MIPSEL = GCCPS1Compiler(
     cc='mips-linux-gnu-cpp -Wall -lang-c -gstabs "$INPUT" | "${COMPILER_DIR}"/cc1 -mips1 -mcpu=3000 $COMPILER_FLAGS | mips-linux-gnu-as -march=r3000 -mtune=r3000 -no-pad-sections -O1 -o "$OUTPUT"',
 )
 
-PSYQ_CC = 'cpp -P "$INPUT" | unix2dos | ${WINE} ${COMPILER_DIR}/CC1PSX.EXE -quiet ${COMPILER_FLAGS} -o "$OUTPUT".s && ${WINE} ${COMPILER_DIR}/ASPSX.EXE -quiet "$OUTPUT".s -o "$OUTPUT".obj && ${COMPILER_DIR}/psyq-obj-parser "$OUTPUT".obj -o "$OUTPUT"'
+PSYQ_CC = 'cd ${COMPILER_DIR} && export PSYQ_PATH=. && ${WINE} ${COMPILER_DIR}/CCPSX.EXE -c ${COMPILER_FLAGS} "${INPUT}" -o "${OUTPUT}".obj && ${COMPILER_DIR}/psyq-obj-parser "${OUTPUT}".obj -o "${OUTPUT}"'
 
 PSYQ40 = GCCPS1Compiler(
     id="psyq4.0",


### PR DESCRIPTION
This means I no longer need to worry about assembler flags...

e.g. (passing the `-v` flag in to show what programs were called + their args:
```
CCPSX 3.02 Build 0002 (Win32 version 3.01, PSX version 3.02)
cpppsx -undef -D__GNUC__=2 -v -D__OPTIMIZE__ -lang-c -Dmips -D__mips__ -D__mips -Dpsx -D__psx__ -D__psx -D_PSYQ -D__EXTENSIONS__ -D_MIPSEL -D__CHAR_UNSIGNED__ -D_LANGUAGE_C -DLANGUAGE_C /tmp/code.c /tmp/PQ2 
cc1psx -quiet -version -O2 -G0 /tmp/PQ2 -o /tmp/PQ3 
aspsx -q -G0 /tmp/PQ3 -o /tmp/object.o.obj 
```
.. and then setting `-G4`:
```
CCPSX 3.02 Build 0002 (Win32 version 3.01, PSX version 3.02)
cpppsx -undef -D__GNUC__=2 -v -D__OPTIMIZE__ -lang-c -Dmips -D__mips__ -D__mips -Dpsx -D__psx__ -D__psx -D_PSYQ -D__EXTENSIONS__ -D_MIPSEL -D__CHAR_UNSIGNED__ -D_LANGUAGE_C -DLANGUAGE_C /tmp/code.c /tmp/PQ2 
cc1psx -quiet -version -O2 -G4 /tmp/PQ2 -o /tmp/PQ3 
aspsx -q -G4 /tmp/PQ3 -o /tmp/object.o.obj 
```