### PR TITLE
(hopefully) fix macos9 compiler

### DIFF
--- a/backend/compilers/download.py
+++ b/backend/compilers/download.py
@@ -232,6 +232,11 @@ def download_codewarrior():
         dest_name="codewarrior",
         create_subdir=True,
     )
+    download_file(
+        url="https://gist.githubusercontent.com/ChrisNonyminus/e530faed7fb6b1af213ef6be3994b3a9/raw/4474a194aa42fd62c719c6b234a5f2b9bfaec817/convert_gas_syntax.py",
+        log_name="convert_gas_syntax.py",
+        dest_path=DOWNLOAD_CACHE / "convert_gas_syntax_macos9.py",
+    )
     compiler_dir = COMPILERS_DIR / "codewarrior" / "compilers"
     for ver in ["Pro5", "Pro6"]:
         lowercase_lmgr = compiler_dir / ver / "lmgr326b.dll"
@@ -244,6 +249,10 @@ def download_codewarrior():
 
         set_x(compiler_dir / ver / "MWCPPC.exe")
         set_x(compiler_dir / ver / "MWLinkPPC.exe")
+        shutil.copy(
+            DOWNLOAD_CACHE / "convert_gas_syntax_macos9.py",
+            compiler_dir / ver / "convert_gas_syntax.py",
+        )
 
     try:
         shutil.move(compiler_dir / "Pro5", COMPILERS_DIR / "mwcppc_23")

--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -145,10 +145,6 @@ def available_compilers() -> List[Compiler]:
 def available_platforms() -> List[Platform]:
     pset = set(compiler.platform for compiler in available_compilers())
 
-    # Disable MACOS9 for now, as it's not working properly
-    if MACOS9 in pset:
-        pset.remove(MACOS9)
-
     return sorted(pset, key=lambda p: p.name)
 
 
@@ -352,7 +348,7 @@ GCC281SNCXX = GCCCompiler(
 )
 
 # MACOS9
-MWCPPC_CC = 'printf "%s" "${COMPILER_FLAGS}" | xargs -x -- ${WINE} "${COMPILER_DIR}/MWCPPC.exe" -o object.o "${INPUT}" && printf "%s" "-dis -h -module ".${FUNCTION}" -nonames -nodata" | xargs -x -- ${WINE} "${COMPILER_DIR}/MWLinkPPC.exe" "${OUTPUT}" > "${OUTPUT}.s" && python3 ${COMPILER_DIR}/convert_gas_syntax.py "${OUTPUT}.s" ".${FUNCTION}" > "${OUTPUT}_new.s" && powerpc-linux-gnu-as "${OUTPUT}_new.s" -o "${OUTPUT}"'
+MWCPPC_CC = 'printf "%s" "${COMPILER_FLAGS}" | xargs -x -- ${WINE} "${COMPILER_DIR}/MWCPPC.exe" -o object.o "${INPUT}" && printf "%s" "-dis -h -module ".${FUNCTION}" -nonames -nodata" | xargs -x -- ${WINE} "${COMPILER_DIR}/MWLinkPPC.exe" "${OUTPUT}" > "${OUTPUT}.s" && python3 ${COMPILER_DIR}/convert_gas_syntax.py "${OUTPUT}.s" ".${FUNCTION}" > "${COMPILER_DIR}/_new.s" && powerpc-linux-gnu-as "${COMPILER_DIR}/_new.s" -o "${OUTPUT}"'
 
 MWCPPC_23 = MWCCCompiler(
     id="mwcppc_23",

--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -348,7 +348,7 @@ GCC281SNCXX = GCCCompiler(
 )
 
 # MACOS9
-MWCPPC_CC = 'printf "%s" "${COMPILER_FLAGS}" | xargs -x -- ${WINE} "${COMPILER_DIR}/MWCPPC.exe" -o object.o "${INPUT}" && printf "%s" "-dis -h -module ".${FUNCTION}" -nonames -nodata" | xargs -x -- ${WINE} "${COMPILER_DIR}/MWLinkPPC.exe" "${OUTPUT}" > "${OUTPUT}.s" && python3 ${COMPILER_DIR}/convert_gas_syntax.py "${OUTPUT}.s" ".${FUNCTION}" > "${COMPILER_DIR}/_new.s" && powerpc-linux-gnu-as "${COMPILER_DIR}/_new.s" -o "${OUTPUT}"'
+MWCPPC_CC = 'printf "%s" "${COMPILER_FLAGS}" | xargs -x -- ${WINE} "${COMPILER_DIR}/MWCPPC.exe" -o object.o "${INPUT}" && printf "%s" "-dis -h -module ".${FUNCTION}" -nonames -nodata" | xargs -x -- ${WINE} "${COMPILER_DIR}/MWLinkPPC.exe" "${OUTPUT}" > "${OUTPUT}.s" && python3 ${COMPILER_DIR}/convert_gas_syntax.py "${OUTPUT}.s" ".${FUNCTION}" > "${OUTPUT}_new.s" && powerpc-linux-gnu-as "${OUTPUT}_new.s" -o "${OUTPUT}"'
 
 MWCPPC_23 = MWCCCompiler(
     id="mwcppc_23",

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -29,7 +29,7 @@ const removeImports = require("next-remove-imports")({
 })
 const nextTranslate = require("next-translate")
 
-const mediaUrl = new URL(process.env.MEDIA_URL != null ? process.env.MEDIA_URL : "http://localhost")
+const mediaUrl = new URL(process.env.MEDIA_URL ?? "http://localhost")
 
 let app = withPlausibleProxy({
     customDomain: "https://stats.decomp.me",

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -29,7 +29,7 @@ const removeImports = require("next-remove-imports")({
 })
 const nextTranslate = require("next-translate")
 
-const mediaUrl = new URL(process.env.MEDIA_URL ?? "http://localhost")
+const mediaUrl = new URL(process.env.MEDIA_URL != null ? process.env.MEDIA_URL : "http://localhost")
 
 let app = withPlausibleProxy({
     customDomain: "https://stats.decomp.me",


### PR DESCRIPTION
This should probably fix the issues that were going on with getting it to work.
What I had to do was update the assembler syntax converter, as its detection of branches wasn't working right (the regex was expecting 2 tabs when there was only one).