### PR TITLE
Set the correct march for PS2 assembler

### DIFF
--- a/backend/asm_differ/diff.py
+++ b/backend/asm_differ/diff.py
@@ -1951,7 +1951,11 @@ MIPS_SETTINGS = ArchSettings(
 
 MIPSEL_SETTINGS = replace(MIPS_SETTINGS, name="mipsel", big_endian=False)
 
-MIPS_ARCH_NAMES = {"mips", "mipsel"}
+MIPSEE_SETTINGS = replace(
+    MIPSEL_SETTINGS, name="mipsee", arch_flags=["-m", "mips:5900"]
+)
+
+MIPS_ARCH_NAMES = {"mips", "mipsel", "mipsee"}
 
 ARM32_SETTINGS = ArchSettings(
     name="arm32",
@@ -2045,6 +2049,7 @@ I686_SETTINGS = ArchSettings(
 ARCH_SETTINGS = [
     MIPS_SETTINGS,
     MIPSEL_SETTINGS,
+    MIPSEE_SETTINGS,
     ARM32_SETTINGS,
     ARMEL_SETTINGS,
     AARCH64_SETTINGS,

--- a/backend/coreapp/platforms.py
+++ b/backend/coreapp/platforms.py
@@ -148,7 +148,7 @@ PS2 = Platform(
     id="ps2",
     name="PlayStation 2",
     description="MIPS (little-endian)",
-    arch="mipsel",
+    arch="mipsee",
     assemble_cmd='mips-linux-gnu-as -march=r5900 -mabi=eabi -o "$OUTPUT" "$INPUT"',
     objdump_cmd="mips-linux-gnu-objdump",
     nm_cmd="mips-linux-gnu-nm",

--- a/backend/coreapp/platforms.py
+++ b/backend/coreapp/platforms.py
@@ -149,7 +149,7 @@ PS2 = Platform(
     name="PlayStation 2",
     description="MIPS (little-endian)",
     arch="mipsel",
-    assemble_cmd='mips-linux-gnu-as -march=mips64 -mabi=64 -o "$OUTPUT" "$INPUT"',
+    assemble_cmd='mips-linux-gnu-as -march=r5900 -mabi=eabi -o "$OUTPUT" "$INPUT"',
     objdump_cmd="mips-linux-gnu-objdump",
     nm_cmd="mips-linux-gnu-nm",
     asm_prelude="""


### PR DESCRIPTION
PS2's  Emotion Engine has some custom instructions like `mult rd,rs,rt` and `madd` which weren't recognized as instructions with `-march=mips64`, so this PR just switches to `-march=r5900` which correctly handles the new instructions