### PR TITLE
Some rodata-related functionality

### DIFF
--- a/backend/asm_differ/.gitrepo
+++ b/backend/asm_differ/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/simonlindholm/asm-differ
 	branch = main
-	commit = 01a895630c8ec585f56ce79b36e6bfd82ef55c9f
-	parent = f38775de5452dda85507901949ef31a39f09365b
+	commit = 37ecd6bd5bfc039008be57a78bb588b7fcfd5f1f
+	parent = 52f327ca39cce5f76e47882d2771e2bcfea97d1b
 	method = merge
 	cmdver = 0.4.5

--- a/backend/asm_differ/.gitrepo
+++ b/backend/asm_differ/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/simonlindholm/asm-differ
 	branch = main
-	commit = 37ecd6bd5bfc039008be57a78bb588b7fcfd5f1f
-	parent = 52f327ca39cce5f76e47882d2771e2bcfea97d1b
+	commit = 175803580c30de3ac141f5df9540d9367e573caa
+	parent = 6af69dd846c9e2d2846619b7f75b3e25aeb87246
 	method = merge
 	cmdver = 0.4.5

--- a/backend/asm_differ/.gitrepo
+++ b/backend/asm_differ/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/simonlindholm/asm-differ
 	branch = main
-	commit = 175803580c30de3ac141f5df9540d9367e573caa
-	parent = 6af69dd846c9e2d2846619b7f75b3e25aeb87246
+	commit = 6ea3f697c10711e35d695449b84166c82fc466f8
+	parent = 6c2148cb41f3fcd71607e9956b5450fcb1d221cd
 	method = merge
 	cmdver = 0.4.5

--- a/backend/asm_differ/diff.py
+++ b/backend/asm_differ/diff.py
@@ -229,6 +229,13 @@ if __name__ == "__main__":
         help="Don't visualize branches/branch targets.",
     )
     parser.add_argument(
+        "-R",
+        "--no-show-rodata-refs",
+        dest="show_rodata_refs",
+        action="store_false",
+        help="Don't show .rodata -> .text references (typically from jump tables).",
+    )
+    parser.add_argument(
         "-S",
         "--base-shift",
         dest="base_shift",
@@ -414,6 +421,7 @@ class Config:
     base_shift: int
     skip_lines: int
     compress: Optional[Compress]
+    show_rodata_refs: bool
     show_branches: bool
     show_line_numbers: bool
     show_source: bool
@@ -504,6 +512,7 @@ def create_config(args: argparse.Namespace, project: ProjectSettings) -> Config:
         ),
         skip_lines=args.skip_lines,
         compress=compress,
+        show_rodata_refs=args.show_rodata_refs,
         show_branches=args.show_branches,
         show_line_numbers=show_line_numbers,
         show_source=args.show_source or args.source_old_binutils,
@@ -1066,7 +1075,7 @@ def preprocess_objdump_out(
             out = out[out.find("\n") + 1 :]
         out = out.rstrip("\n")
 
-    if obj_data:
+    if obj_data and config.show_rodata_refs:
         out = (
             serialize_rodata_references(parse_elf_rodata_references(obj_data, config))
             + out

--- a/backend/asm_differ/diff.py
+++ b/backend/asm_differ/diff.py
@@ -1294,7 +1294,7 @@ def parse_elf_rodata_references(
                 # Skip section_name -> section_name references
                 continue
             sec_name = sec_names[s.sh_info].decode("latin1")
-            if sec_name != ".rodata":
+            if sec_name not in (".rodata", ".late_rodata"):
                 continue
             sec_base = sections[s.sh_info].sh_offset
             for i in range(0, s.sh_size, s.sh_entsize):

--- a/backend/coreapp/compiler_wrapper.py
+++ b/backend/coreapp/compiler_wrapper.py
@@ -233,6 +233,7 @@ class CompilerWrapper:
 
         with Sandbox() as sandbox:
             asm_path = sandbox.path / "asm.s"
+            asm.data.replace(".section .late_rodata", ".late_rodata")
             asm_path.write_text(platform.asm_prelude + asm.data)
 
             object_path = sandbox.path / "object.o"

--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -916,6 +916,18 @@ _all_presets = [
         diff_flags=["-Mreg-names=32"],
     ),
     Preset(
+        "IDO 5.3 cc",
+        IDO53,
+        "-O1 -KPIC -mips1",
+        diff_flags=["-Mreg-names=32"],
+    ),
+    Preset(
+        "IDO 5.3 libraries",
+        IDO53,
+        "-O2 -KPIC -mips1",
+        diff_flags=["-Mreg-names=32"],
+    ),
+    Preset(
         "IDO 7.1 cc",
         IDO71,
         "-O1 -KPIC -mips2",

--- a/backend/coreapp/flags.py
+++ b/backend/coreapp/flags.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 from typing import Dict, List, Union
 
+ASMDIFF_FLAG_PREFIX = "-DIFF"
+
 
 @dataclass(frozen=True)
 class Checkbox:
@@ -85,6 +87,7 @@ COMMON_IDO_FLAGS: Flags = [
 
 COMMON_MIPS_DIFF_FLAGS: Flags = [
     Checkbox("mreg_names=32", "-Mreg-names=32"),
+    Checkbox("no_show_rodata_refs", ASMDIFF_FLAG_PREFIX + "no_show_rodata_refs"),
 ]
 
 COMMON_MWCC_FLAGS: Flags = [

--- a/backend/coreapp/platforms.py
+++ b/backend/coreapp/platforms.py
@@ -65,6 +65,9 @@ N64 = Platform(
     .section .rodata
 .endm
 
+.macro .late_rodata_alignment align
+.endm
+
 .macro glabel label
     .global \label
     .type \label, @function

--- a/backend/m2c/.gitrepo
+++ b/backend/m2c/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/matt-kempster/mips_to_c
 	branch = master
-	commit = d49fe7c0be27079f34f247ce493c879c7af4462e
-	parent = 173389a310581473ca054054b90230f129e9762d
+	commit = eb5a48c6b76099a3d9584cbcce0f2c693a226e56
+	parent = d4479355a594070407cc18eb90f835e630e0a3b2
 	method = merge
 	cmdver = 0.4.5

--- a/backend/m2c/src/asm_file.py
+++ b/backend/m2c/src/asm_file.py
@@ -99,6 +99,21 @@ class AsmData:
         for label in self.mentioned_labels:
             other.mentioned_labels.add(label)
 
+    def is_likely_char(self, c: int) -> bool:
+        return 0x20 <= c < 0x7F or c in (0, 7, 8, 9, 10, 13, 27)
+
+    def detect_heuristic_strings(self) -> None:
+        for ent in self.values.values():
+            if (
+                ent.is_readonly
+                and len(ent.data) == 1
+                and isinstance(ent.data[0], bytes)
+                and len(ent.data[0]) > 1
+                and ent.data[0][0] != 0
+                and all(self.is_likely_char(x) for x in ent.data[0])
+            ):
+                ent.is_string = True
+
 
 @dataclass
 class AsmFile:

--- a/backend/m2c/src/flow_graph.py
+++ b/backend/m2c/src/flow_graph.py
@@ -215,7 +215,44 @@ def invert_branch_mnemonic(mnemonic: str) -> str:
     return inverses[mnemonic]
 
 
-def normalize_likely_branches(function: Function, arch: ArchFlowGraph) -> Function:
+def normalize_gcc_likely_branches(function: Function, arch: ArchFlowGraph) -> Function:
+    """GCC sometimes emits branch-likely instructions that cross just a single
+    instruction:
+    ```
+    beqzl $a0, .label
+     instr
+    .label:
+    ```
+    This acts as a one-instruction if statement, that runs the instruction only if
+    the branch is taken. Normalize this kind of branch-likely into
+    ```
+    bnez $a0, .label
+     nop
+    instr
+    .label:
+    ```
+    to reduce the amount of branch likelies we have to deal with: they make control
+    flow and block splitting more complex."""
+    new_function = function.bodyless_copy()
+    new_body = new_function.body
+    for i, item in enumerate(function.body):
+        if (
+            isinstance(item, Instruction)
+            and item.is_branch_likely
+            and isinstance(item.jump_target, JumpTarget)
+            and i + 2 < len(function.body)
+            and isinstance(function.body[i + 1], Instruction)
+            and function.body[i + 2] == Label(item.jump_target.target)
+        ):
+            mn_inverted = invert_branch_mnemonic(item.mnemonic[:-1])
+            new_body.append(arch.parse(mn_inverted, item.args, item.meta.derived()))
+            new_body.append(arch.parse("nop", [], item.meta.derived()))
+        else:
+            new_body.append(item)
+    return new_function
+
+
+def normalize_ido_likely_branches(function: Function, arch: ArchFlowGraph) -> Function:
     """Branch-likely instructions only evaluate their delay slots when they are
     taken, making control flow more complex. However, on the IDO compiler they
     only occur in a very specific pattern:
@@ -233,27 +270,23 @@ def normalize_likely_branches(function: Function, arch: ArchFlowGraph) -> Functi
 
     Branch-likely instructions that do not appear in this pattern are kept.
 
-    We also do this for b instructions, which sometimes occur in the same pattern,
-    and also fix up the pattern
-
-    <branch likely instr> .label
-     X
-    .label:
-
-    which GCC emits."""
+    We also do this for b instructions, which sometimes occur in the same pattern."""
+    seen_instrs: Set[Instruction] = set()
     label_prev_instr: Dict[str, Optional[Instruction]] = {}
-    label_before_instr: Dict[int, str] = {}
-    instr_before_instr: Dict[int, Instruction] = {}
+    label_before_instr: Dict[Instruction, str] = {}
+    instr_before_instr: Dict[Instruction, Instruction] = {}
     prev_instr: Optional[Instruction] = None
     prev_label: Optional[Label] = None
     prev_item: Union[Instruction, Label, None] = None
     for item in function.body:
         if isinstance(item, Instruction):
+            assert item not in seen_instrs
+            seen_instrs.add(item)
             if prev_label is not None:
-                label_before_instr[id(item)] = prev_label.name
+                label_before_instr[item] = prev_label.name
                 prev_label = None
             if isinstance(prev_item, Instruction):
-                instr_before_instr[id(item)] = prev_item
+                instr_before_instr[item] = prev_item
             prev_instr = item
         elif isinstance(item, Label):
             label_prev_instr[item.name] = prev_instr
@@ -261,7 +294,7 @@ def normalize_likely_branches(function: Function, arch: ArchFlowGraph) -> Functi
             prev_instr = None
         prev_item = item
 
-    insert_label_before: Dict[int, str] = {}
+    insert_label_before: Dict[Instruction, str] = {}
     new_body: List[Tuple[Union[Instruction, Label], Union[Instruction, Label]]] = []
 
     body_iter: Iterator[Union[Instruction, Label]] = iter(function.body)
@@ -278,7 +311,7 @@ def normalize_likely_branches(function: Function, arch: ArchFlowGraph) -> Functi
                 )
             before_target = label_prev_instr[old_label]
             before_before_target = (
-                instr_before_instr.get(id(before_target))
+                instr_before_instr.get(before_target)
                 if before_target is not None
                 else None
             )
@@ -295,30 +328,17 @@ def normalize_likely_branches(function: Function, arch: ArchFlowGraph) -> Functi
                 new_body.append((next_item, next_item))
             elif (
                 isinstance(next_item, Instruction)
-                and before_target is next_item
-                and item.mnemonic != "b"
-            ):
-                # Handle the GCC pattern where the branch likely crosses just a single
-                # instruction.
-                mn_inverted = invert_branch_mnemonic(item.mnemonic[:-1])
-                item = arch.parse(mn_inverted, item.args, item.meta.derived())
-                new_nop = arch.parse("nop", [], item.meta.derived())
-                new_body.append((orig_item, item))
-                new_body.append((new_nop, new_nop))
-                new_body.append((orig_next_item, next_item))
-            elif (
-                isinstance(next_item, Instruction)
                 and before_target is not None
                 and before_target is not next_item
                 and str(before_target) == str(next_item)
                 and (item.mnemonic != "b" or next_item.mnemonic != "nop")
             ):
                 # Handle the IDO pattern.
-                if id(before_target) not in label_before_instr:
+                if before_target not in label_before_instr:
                     new_label = f"_m2c_{old_label}_before"
-                    label_before_instr[id(before_target)] = new_label
-                    insert_label_before[id(before_target)] = new_label
-                new_target = JumpTarget(label_before_instr[id(before_target)])
+                    label_before_instr[before_target] = new_label
+                    insert_label_before[before_target] = new_label
+                new_target = JumpTarget(label_before_instr[before_target])
                 mn_unlikely = item.mnemonic[:-1] or "b"
                 item = arch.parse(
                     mn_unlikely, item.args[:-1] + [new_target], item.meta.derived()
@@ -335,8 +355,8 @@ def normalize_likely_branches(function: Function, arch: ArchFlowGraph) -> Functi
 
     new_function = function.bodyless_copy()
     for (orig_item, new_item) in new_body:
-        if id(orig_item) in insert_label_before:
-            new_function.new_label(insert_label_before[id(orig_item)])
+        if isinstance(orig_item, Instruction) and orig_item in insert_label_before:
+            new_function.new_label(insert_label_before[orig_item])
         new_function.body.append(new_item)
 
     return new_function
@@ -372,7 +392,9 @@ def build_blocks(
 ) -> List[Block]:
     if arch.arch == Target.ArchEnum.MIPS:
         verify_no_trailing_delay_slot(function)
-        function = normalize_likely_branches(function, arch)
+        function = prune_unreferenced_labels(function, asm_data)
+        function = normalize_gcc_likely_branches(function, arch)
+        function = normalize_ido_likely_branches(function, arch)
 
     function = prune_unreferenced_labels(function, asm_data)
     function = simplify_standard_patterns(function, arch)

--- a/backend/m2c/src/main.py
+++ b/backend/m2c/src/main.py
@@ -84,6 +84,8 @@ def run(options: Options) -> int:
             all_functions.update((fn.name, fn) for fn in asm_file.functions)
             asm_file.asm_data.merge_into(asm_data)
 
+        if options.heuristic_strings:
+            asm_data.detect_heuristic_strings()
         typemap = build_typemap(options.c_contexts, use_cache=options.use_cache)
     except Exception as e:
         print_exception_as_comment(

--- a/backend/m2c/src/options.py
+++ b/backend/m2c/src/options.py
@@ -145,7 +145,6 @@ class Options:
             self.coding_style,
             skip_casts=self.skip_casts,
             zfill_constants=self.zfill_constants,
-            heuristic_strings=self.heuristic_strings,
             valid_syntax=self.valid_syntax,
         )
 
@@ -173,7 +172,6 @@ class Formatter:
     valid_syntax: bool = False
     line_length: int = 80
     zfill_constants: bool = False
-    heuristic_strings: bool = False
 
     def indent(self, line: str, indent: int = 0) -> str:
         return self.indent_step * max(indent + self.extra_indent, 0) + line

--- a/frontend/locales/en/compilers.json
+++ b/frontend/locales/en/compilers.json
@@ -229,5 +229,6 @@
     "sdata_limit.-G0": "0 bytes",
     "sdata_limit.-G4": "4 bytes",
     "sdata_limit.-G8": "8 bytes",
-    "mreg_names=32": "ABI FPR names"
+    "mreg_names=32": "ABI FPR names",
+    "no_show_rodata_refs": "Hide rodata refs in diff, e.g. jtbl labels"
 }


### PR DESCRIPTION
- Pull latest versions of asm-differ and m2c, asm-differ now allows for viewing rodata labels for PIC as well.
- Add flag to hide these if not desired to view them. I'm not very happy with how this is implemented at the moment: as @simonlindholm notes it's a bit of a flaw in the current setup that the flag name has to agree with the display name, among other issues.
- Massage the asm handling a bit to make it easier to create a scratch for a function with late_rodata in its asm.
- Add some more IDO presets, for 5.3.