### PR TITLE
Cache CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           cache-dependency-path: backend/poetry.lock
       - name: Install backend Python dependencies
         run: cd backend && poetry install
-      - name: Install apt dependencies
+      - name: Install apt dependencies (initial)
         run: |-
           sudo dpkg --add-architecture i386
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
@@ -39,18 +39,21 @@ jobs:
             "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
             $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
           sudo apt-get update -qq
-          sudo apt-get install docker-ce docker-ce-cli containerd.io docker-compose-plugin
-
-          sudo apt-get install \
-            binutils-aarch64-linux-gnu \
-            binutils-mips-linux-gnu \
-            binutils-powerpc-linux-gnu \
-            dos2unix \
-            libprotobuf-dev \
-            libnl-route-3-dev \
-            libncurses5 \
-            protobuf-compiler \
+      - name: Install apt dependencies (cached)
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: |
+            docker-ce docker-ce-cli containerd.io docker-compose-plugin
+            binutils-aarch64-linux-gnu
+            binutils-mips-linux-gnu
+            binutils-powerpc-linux-gnu
+            dos2unix
+            libprotobuf-dev
+            libnl-route-3-dev
+            libncurses5
+            protobuf-compiler
             wine
+          version: 1.0
       - name: Install nsjail
         run: |-
           git clone --recursive --branch=3.1 https://github.com/google/nsjail

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,19 +39,31 @@ jobs:
             "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
             $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
           sudo apt-get update -qq
+          sudo apt-get install docker-ce docker-ce-cli containerd.io docker-compose-plugin
+
+          sudo apt-get install \
+            binutils-aarch64-linux-gnu \
+            binutils-mips-linux-gnu \
+            binutils-powerpc-linux-gnu \
+            dos2unix \
+            libprotobuf-dev \
+            libnl-route-3-dev \
+            libncurses5 \
+            protobuf-compiler \
+            wine
       - name: Install apt dependencies (cached)
         uses: awalsh128/cache-apt-pkgs-action@v1
         with:
           packages: |
-            docker-ce docker-ce-cli containerd.io docker-compose-plugin
-            binutils-aarch64-linux-gnu
-            binutils-mips-linux-gnu
-            binutils-powerpc-linux-gnu
-            dos2unix
-            libprotobuf-dev
-            libnl-route-3-dev
-            libncurses5
-            protobuf-compiler
+            docker-ce docker-ce-cli containerd.io docker-compose-plugin \
+            binutils-aarch64-linux-gnu \
+            binutils-mips-linux-gnu \
+            binutils-powerpc-linux-gnu \
+            dos2unix \
+            libprotobuf-dev \
+            libnl-route-3-dev \
+            libncurses5 \
+            protobuf-compiler \
             wine
           version: 1.0
       - name: Install nsjail

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,11 @@ jobs:
           git clone --recursive --branch=3.1 https://github.com/google/nsjail
           make -C nsjail
           sudo cp nsjail/nsjail /usr/bin/
+      - name: Cache compilers
+        uses: actions/cache@v3
+        with:
+          path: backend/compilers/download_cache
+          key: ${{ runner.os }}-compilers
       - name: Download compilers
         run: |-
           cd backend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install poetry
         run: pipx install poetry
       - name: Setup Python 3.9
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
           cache: poetry
@@ -99,7 +99,7 @@ jobs:
         run: cd backend && poetry run python3 ./manage.py runserver > /dev/null 2>&1 &
 
       - name: Setup Node.js 18
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 18
           cache: yarn
@@ -120,7 +120,7 @@ jobs:
       - name: Install poetry
         run: pipx install poetry
       - name: Setup Python 3.9
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
           cache: poetry
@@ -171,7 +171,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup Node.js 18
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 18
           cache: yarn
@@ -188,7 +188,7 @@ jobs:
       - name: Install poetry
         run: pipx install poetry
       - name: Setup Python 3.9
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
           cache: poetry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
+
+      - name: Install poetry
+        run: pipx install poetry
+      - name: Setup Python 3.9
+        uses: actions/setup-python@v1
         with:
           python-version: 3.9
-      - name: Install Poetry
-        uses: snok/install-poetry@v1
-      - run: cd backend && poetry install
-      - name: Install dependencies
+          cache: poetry
+          cache-dependency-path: backend/poetry.lock
+      - name: Install backend Python dependencies
+        run: cd backend && poetry install
+      - name: Install apt dependencies
         run: |-
           sudo dpkg --add-architecture i386
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
@@ -76,6 +81,7 @@ jobs:
       - name: Install wibo
         run: |-
           wget https://github.com/decompals/WiBo/releases/download/0.2.4/wibo && chmod +x wibo && sudo cp wibo /usr/bin/
+
       - name: Run backend tests
         run: |-
           mkdir -p "${WINEPREFIX}"
@@ -92,9 +98,14 @@ jobs:
       - name: Start backend
         run: cd backend && poetry run python3 ./manage.py runserver > /dev/null 2>&1 &
 
+      - name: Setup Node.js 18
+        uses: actions/setup-node@v1
+        with:
+          node-version: 18
+          cache: yarn
+          cache-dependency-path: frontend/yarn.lock
       - name: Install frontend dependencies
         run: cd frontend && yarn --frozen-lockfile
-
       - name: Build frontend
         run: cd frontend && yarn build
 
@@ -106,9 +117,14 @@ jobs:
         shell: bash
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
+      - name: Install poetry
+        run: pipx install poetry
+      - name: Setup Python 3.9
+        uses: actions/setup-python@v1
         with:
           python-version: 3.9
+          cache: poetry
+          cache-dependency-path: backend/poetry.lock
       - name: Install Poetry
         run: pip install --user poetry
       - run: cd backend && poetry install
@@ -149,40 +165,39 @@ jobs:
             poetry install && \
             poetry run python manage.py test'
 
-  reviewdog:
-    name: reviewdog
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: reviewdog/action-setup@v1
-      - run: cd frontend && yarn --frozen-lockfile
-      - run: reviewdog -reporter=github-check
-        env:
-          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   frontend_lint:
     name: eslint & stylelint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - name: Setup Node.js 18
+        uses: actions/setup-node@v1
         with:
-          node-version: 14
-      - run: cd frontend && yarn --frozen-lockfile
+          node-version: 18
+          cache: yarn
+          cache-dependency-path: frontend/yarn.lock
+      - name: Install frontend dependencies
+        run: cd frontend && yarn --frozen-lockfile
       - run: cd frontend && yarn lint
+
   mypy:
     name: mypy
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
+      - name: Install poetry
+        run: pipx install poetry
+      - name: Setup Python 3.9
+        uses: actions/setup-python@v1
         with:
           python-version: 3.9
-      - name: Install Poetry
-        uses: snok/install-poetry@v1
+          cache: poetry
+          cache-dependency-path: backend/poetry.lock
       - run: |-
           cd backend
           poetry install
           poetry run mypy
+
   black:
     name: black
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds caching to a bunch of dependency installs we're doing in CI to reduce the runtime. Future:

- `Install apt dependencies (initial)` could definitely be made quicker
- `Build decompme_backend image` is 6min, perhaps we could use [cached-docker-build](https://github.com/marketplace/actions/cached-docker-build)

(These are fine for now I think- I don't want to touch them much because I didn't write them & CI has always been brittle.)