### PR TITLE
Checkbox for disabling pseudo instructions for MIPS

### DIFF
--- a/backend/coreapp/diff_wrapper.py
+++ b/backend/coreapp/diff_wrapper.py
@@ -122,10 +122,12 @@ class DiffWrapper:
 
     @staticmethod
     def parse_objdump_flags(diff_flags: List[str]) -> List[str]:
+        known_objdump_flags = ["-Mreg-names=32", "-Mno-aliases"]
         ret = []
 
-        if "-Mreg-names=32" in diff_flags:
-            ret.append("-Mreg-names=32")
+        for flag in known_objdump_flags:
+            if flag in diff_flags:
+                ret.append(flag)
 
         return ret
 

--- a/backend/coreapp/flags.py
+++ b/backend/coreapp/flags.py
@@ -94,6 +94,7 @@ COMMON_DIFF_FLAGS: Flags = [
 
 COMMON_MIPS_DIFF_FLAGS: Flags = [
     Checkbox("mreg_names=32", "-Mreg-names=32"),
+    Checkbox("mno_aliases", "-Mno-aliases"),
     Checkbox("no_show_rodata_refs", ASMDIFF_FLAG_PREFIX + "no_show_rodata_refs"),
 ]
 

--- a/backend/coreapp/platforms.py
+++ b/backend/coreapp/platforms.py
@@ -201,6 +201,7 @@ PS1 = Platform(
     assemble_cmd='mips-linux-gnu-as -march=r3000 -mabi=32 -o "$OUTPUT" "$INPUT"',
     objdump_cmd="mips-linux-gnu-objdump",
     nm_cmd="mips-linux-gnu-nm",
+    diff_flags=COMMON_DIFF_FLAGS + COMMON_MIPS_DIFF_FLAGS,
     asm_prelude="""
 .macro .late_rodata
     .section .rodata
@@ -226,6 +227,7 @@ PS2 = Platform(
     assemble_cmd='mips-linux-gnu-as -march=r5900 -mabi=eabi -o "$OUTPUT" "$INPUT"',
     objdump_cmd="mips-linux-gnu-objdump",
     nm_cmd="mips-linux-gnu-nm",
+    diff_flags=COMMON_DIFF_FLAGS + COMMON_MIPS_DIFF_FLAGS,
     asm_prelude="""
 .macro .late_rodata
     .section .rodata

--- a/frontend/locales/en/compilers.json
+++ b/frontend/locales/en/compilers.json
@@ -232,7 +232,7 @@
     "sdata_limit.-G4": "4 bytes",
     "sdata_limit.-G8": "8 bytes",
     "mreg_names=32": "ABI FPR names",
-    "mno_aliases": "Disable use pseudo instructions",
+    "mno_aliases": "Disable pseudo instructions",
     "no_show_rodata_refs": "Hide rodata refs in diff, e.g. jtbl labels",
 
     "diff_algorithm": "Diff algorithm",

--- a/frontend/locales/en/compilers.json
+++ b/frontend/locales/en/compilers.json
@@ -232,6 +232,7 @@
     "sdata_limit.-G4": "4 bytes",
     "sdata_limit.-G8": "8 bytes",
     "mreg_names=32": "ABI FPR names",
+    "mno_aliases": "Disable use pseudo instructions",
     "no_show_rodata_refs": "Hide rodata refs in diff, e.g. jtbl labels",
 
     "diff_algorithm": "Diff algorithm",


### PR DESCRIPTION
Adds a new checkbox for disabling pseudo instructions on MIPS scratches by passing the `-Mno-aliases` flag to `objdump`. This is disabled by default.
![image](https://user-images.githubusercontent.com/7416381/209376892-47209728-6791-49ad-89c8-19abe7903ecf.png)

### Why is this useful?

Because GAS likes using the same pseudo instruction for multiple instructions, which sometimes leads to confusion of "why this doesn't match if it is the same instruction". Complains about this usually happen with the `li` pseudo instruction.

Example ("both are `li`s, why it doesn't match?!?!?"):
![image](https://user-images.githubusercontent.com/7416381/209378149-b89c339b-2d29-4fb4-a0ff-0f17a2957ff2.png)
Disabling pseudos ("oh, they actually are different instructions"):
![image](https://user-images.githubusercontent.com/7416381/209378326-2bdb6544-a78c-418e-b69d-e7c727ca0b1f.png)

### Disadvantages

Some pseudos are clearer as pseudos than their actual raw instruction; like for example the `nop`, which gets disassembled as `sll, zero, zero, 0x0`. `move` is also an example of this (even if the underlying instruction changes depending on the assembler).
There doesn't seem to be any option in `objdump` to only allow some pseudos.

`asm-differ` seems to have custom logic for handling `nop`s which gets lost when disabling them, this can be seen in this screenshot:
![image](https://user-images.githubusercontent.com/7416381/209380469-cd14e671-4fd6-4a2b-aefe-a2dbd21646c6.png)
A workaround for this could be made in the `asm-differ` repo.


### Other

I also allowed passing the other objdump flags to PS1 and PS2.