### PR TITLE
Add family page back in tab form

### DIFF
--- a/frontend/src/components/GhostButton.tsx
+++ b/frontend/src/components/GhostButton.tsx
@@ -14,7 +14,7 @@ export type Props = {
 export default function GhostButton({ children, href, onClick, className }: Props) {
     const isClickable = !!(href || onClick)
     const cn = classNames(className, {
-        "rounded bg-transparent px-2 py-1 text-sm whitespace-nowrap": true,
+        "rounded bg-transparent px-2 py-1 text-sm whitespace-nowrap inline-block": true,
         "transition-colors hover:bg-gray-3 cursor-pointer active:translate-y-px hover:text-gray-12": isClickable,
     })
 
@@ -24,7 +24,13 @@ export default function GhostButton({ children, href, onClick, className }: Prop
         </Link>
     }
 
-    return <button className={cn} onClick={onClick}>
+    if (onClick) {
+        return <button className={cn} onClick={onClick}>
+            {children}
+        </button>
+    }
+
+    return <div className={cn}>
         {children}
-    </button>
+    </div>
 }

--- a/frontend/src/components/ScoreBadge.tsx
+++ b/frontend/src/components/ScoreBadge.tsx
@@ -27,7 +27,7 @@ export function getScoreText(score: number, maxScore: number): string {
     if (score === -1) {
         return "No score available"
     } else if (score === 0) {
-        return "0 (100%) 🎊"
+        return "MATCH"
     } else {
         const percent = calculateScorePercent(score, maxScore)
 

--- a/frontend/src/components/ScoreBadge.tsx
+++ b/frontend/src/components/ScoreBadge.tsx
@@ -29,9 +29,15 @@ export function getScoreText(score: number, maxScore: number): string {
     } else if (score === 0) {
         return "MATCH"
     } else {
-        const percent = calculateScorePercent(score, maxScore)
+        return percentToString(calculateScorePercent(score, maxScore))
+    }
+}
 
-        return `${score} (${percentToString(percent)})`
+export function getScoreAsFraction(score: number, maxScore: number): string {
+    if (score === -1) {
+        return `???/${maxScore}`
+    } else {
+        return `${maxScore - score}/${maxScore}`
     }
 }
 
@@ -42,17 +48,19 @@ export type Props = {
 }
 
 export default function ScoreBadge({ score, maxScore, compiledSuccessfully }: Props) {
-    if (!compiledSuccessfully) {
-        return <div className={classNames(styles.badge, { [styles.error]: true })}>
+    if (!compiledSuccessfully || score === -1) {
+        return <div className={classNames(styles.badge, { [styles.error]: true })} title="Does not compile">
             <AlertIcon className={styles.icon} />
         </div>
     } else if (score === 0) {
-        return <div className={classNames(styles.badge, { [styles.match]: true })}>
+        return <div className={classNames(styles.badge, { [styles.match]: true })} title="Match">
             <CheckIcon className={styles.icon} />
         </div>
     } else {
         const text = getScoreText(score, maxScore)
-        return <div className={styles.badge} aria-label="Score">
+        const title = getScoreAsFraction(score, maxScore)
+
+        return <div className={styles.badge} aria-label="Score" title={title}>
             {text}
         </div>
     }

--- a/frontend/src/components/Scratch/AboutScratch.tsx
+++ b/frontend/src/components/Scratch/AboutScratch.tsx
@@ -41,22 +41,6 @@ function ScratchLink({ url }: { url: string }) {
     )
 }
 
-function FamilyField({ scratch }: { scratch: api.Scratch }) {
-    const { data } = useSWR<api.TerseScratch[]>(`/scratch/${scratch.slug}/family`, api.get)
-
-    return (
-        <div className={styles.horizontalField}>
-            <p className={styles.label}>Family</p>
-            {(data?.length ?? 1) == 1
-                ? "No family"
-                : <Link href={`/scratch/${scratch.slug}/family`}>
-                    {`${data.length} scratches`}
-                </Link>
-            }
-        </div>
-    )
-}
-
 export type Props = {
     scratch: api.Scratch
     setScratch?: (scratch: Partial<api.Scratch>) => void
@@ -81,7 +65,6 @@ export default function AboutScratch({ scratch, setScratch }: Props) {
                     <p className={styles.label}>Fork of</p>
                     <ScratchLink url={scratch.parent} />
                 </div>}
-                <FamilyField scratch={scratch} />
                 <div className={styles.horizontalField}>
                     <p className={styles.label}>Platform</p>
                     <PlatformIcon platform={scratch.platform} className={styles.platformIcon} />

--- a/frontend/src/components/Scratch/FamilyPanel.tsx
+++ b/frontend/src/components/Scratch/FamilyPanel.tsx
@@ -1,0 +1,20 @@
+import dynamic from "next/dynamic"
+
+import Loading from "@/components/loading.svg"
+import { TerseScratch } from "@/lib/api/types"
+
+const SortableFamilyList = dynamic(() => import("./SortableFamilyList"), {
+    loading: () => <div className="flex h-full w-full items-center justify-center">
+        <Loading />
+    </div>,
+})
+
+type Props = {
+    scratch: TerseScratch
+}
+
+export default function FamilyPanel({ scratch }: Props) {
+    return <div className="h-full p-4">
+        <SortableFamilyList scratch={scratch} />
+    </div>
+}

--- a/frontend/src/components/Scratch/FamilyPanel.tsx
+++ b/frontend/src/components/Scratch/FamilyPanel.tsx
@@ -5,7 +5,7 @@ import { TerseScratch } from "@/lib/api/types"
 
 const SortableFamilyList = dynamic(() => import("./SortableFamilyList"), {
     loading: () => <div className="flex h-full w-full items-center justify-center">
-        <Loading />
+        <Loading className="h-8 w-8 animate-pulse" />
     </div>,
 })
 

--- a/frontend/src/components/Scratch/Scratch.tsx
+++ b/frontend/src/components/Scratch/Scratch.tsx
@@ -19,6 +19,7 @@ import { Tab, TabCloseButton } from "../Tabs"
 
 import AboutScratch from "./AboutScratch"
 import DecompilationPanel from "./DecompilePanel"
+import FamilyPanel from "./FamilyPanel"
 import styles from "./Scratch.module.scss"
 import ScratchMatchBanner from "./ScratchMatchBanner"
 import ScratchToolbar from "./ScratchToolbar"
@@ -30,6 +31,7 @@ enum TabId {
     OPTIONS = "scratch_options",
     DIFF = "scratch_diff",
     DECOMPILATION = "scratch_decompilation",
+    FAMILY = "scratch_family",
 }
 
 const DEFAULT_LAYOUTS: Record<"desktop_2col" | "mobile_2row", Layout> = {
@@ -45,6 +47,7 @@ const DEFAULT_LAYOUTS: Record<"desktop_2col" | "mobile_2row", Layout> = {
                 activeTab: TabId.SOURCE_CODE,
                 tabs: [
                     TabId.ABOUT,
+                    TabId.FAMILY,
                     TabId.SOURCE_CODE,
                     TabId.CONTEXT,
                     TabId.OPTIONS,
@@ -74,6 +77,7 @@ const DEFAULT_LAYOUTS: Record<"desktop_2col" | "mobile_2row", Layout> = {
                 activeTab: TabId.DIFF,
                 tabs: [
                     TabId.ABOUT,
+                    TabId.FAMILY,
                     TabId.DIFF,
                     TabId.DECOMPILATION,
                 ],
@@ -249,6 +253,10 @@ export default function Scratch({
                 </>}
             >
                 {() => <DecompilationPanel scratch={scratch} />}
+            </Tab>
+        case TabId.FAMILY:
+            return <Tab key={id} tabKey={id} label="Family">
+                {() => <FamilyPanel scratch={scratch} />}
             </Tab>
         default:
             return <Tab key={id} tabKey={id} label={id} disabled />

--- a/frontend/src/components/Scratch/SortableFamilyList.tsx
+++ b/frontend/src/components/Scratch/SortableFamilyList.tsx
@@ -28,8 +28,9 @@ function produceSortFunction(sortMode: SortMode): (a: TerseScratch, b: TerseScra
         return (a, b) => new Date(a.last_updated).getTime() - new Date(b.last_updated).getTime()
     case SortMode.SCORE:
         return (a, b) => {
-            const aScore = a.score == 0 ? Infinity : a.score
-            const bScore = b.score == 0 ? Infinity : b.score
+            // If not compiling, give it a score of Infinity so it's sorted to the end
+            const aScore = a.score < 0 ? Infinity : a.score
+            const bScore = b.score < 0 ? Infinity : b.score
 
             return aScore - bScore
         }

--- a/frontend/src/components/Scratch/SortableFamilyList.tsx
+++ b/frontend/src/components/Scratch/SortableFamilyList.tsx
@@ -9,7 +9,7 @@ import Select from "@/components/Select2"
 import { get } from "@/lib/api/request"
 import { TerseScratch } from "@/lib/api/types"
 
-import { getScoreText } from "../ScoreBadge"
+import { getScoreAsFraction, getScoreText } from "../ScoreBadge"
 import UserLink from "../user/UserLink"
 
 enum SortMode {
@@ -69,7 +69,10 @@ function FamilyMember({
             {scratch.name}
         </Link>}
         <div className="grow" />
-        <div className={classNames({ "text-gray-11": !isBetter })}>
+        <div
+            title={getScoreAsFraction(scratch.score, scratch.max_score)}
+            className={classNames({ "text-gray-11": !isBetter })}
+        >
             {getScoreText(scratch.score, scratch.max_score)}
         </div>
     </div>
@@ -115,7 +118,7 @@ export default function SortableFamilyList({ scratch }: { scratch: TerseScratch 
             </div>
         </div>
         <ol>
-            {family.sorted.map(member => <li key={member.url} className="mb-1">
+            {family.sorted.map(member => <li key={member.url} className="mb-2">
                 <FamilyMember
                     scratch={member}
                     isCurrent={member.url === scratch.url}

--- a/frontend/src/components/Scratch/SortableFamilyList.tsx
+++ b/frontend/src/components/Scratch/SortableFamilyList.tsx
@@ -1,0 +1,111 @@
+import { useMemo, useState } from "react"
+
+import Link from "next/link"
+
+import useSWR from "swr"
+
+import Select from "@/components/Select2"
+import { get } from "@/lib/api/request"
+import { TerseScratch } from "@/lib/api/types"
+
+import { getScoreText } from "../ScoreBadge"
+import UserLink from "../user/UserLink"
+
+enum SortMode {
+    NEWEST_FIRST = "newest_first",
+    OLDEST_FIRST = "oldest_first",
+    LAST_UPDATED = "last_updated",
+    SCORE = "score",
+}
+
+function produceSortFunction(sortMode: SortMode): (a: TerseScratch, b: TerseScratch) => number {
+    switch (sortMode) {
+    case SortMode.NEWEST_FIRST:
+        return (a, b) => new Date(b.creation_time).getTime() - new Date(a.creation_time).getTime()
+    case SortMode.OLDEST_FIRST:
+        return (a, b) => new Date(a.creation_time).getTime() - new Date(b.creation_time).getTime()
+    case SortMode.LAST_UPDATED:
+        return (a, b) => new Date(a.last_updated).getTime() - new Date(b.last_updated).getTime()
+    case SortMode.SCORE:
+        return (a, b) => {
+            const aScore = a.score == 0 ? Infinity : a.score
+            const bScore = b.score == 0 ? Infinity : b.score
+
+            return aScore - bScore
+        }
+    }
+}
+
+function useFamily(scratch: TerseScratch) {
+    const { data: family } = useSWR<TerseScratch[]>(scratch.url + "/family", get, {
+        suspense: true,
+    })
+
+    const [sortMode, setSortMode] = useState(SortMode.SCORE)
+    const sorted = useMemo(() => [...family].sort(produceSortFunction(sortMode)), [family, sortMode])
+
+    return { sorted, sortMode, setSortMode }
+}
+
+function FamilyMember({ scratch, isCurrent }: { scratch: TerseScratch, isCurrent: boolean }) {
+    return <div className="flex">
+        <UserLink user={scratch.owner} />
+        <span className="mx-2 text-gray-8">/</span>
+        {isCurrent ? <span className="font-medium text-gray-11">
+            This scratch
+        </span> : <Link href={scratch.html_url} className="font-medium">
+            {scratch.name}
+        </Link>}
+        <div className="grow" />
+        <div>
+            {getScoreText(scratch.score, scratch.max_score)}
+        </div>
+    </div>
+}
+
+export default function SortableFamilyList({ scratch }: { scratch: TerseScratch }) {
+    const family = useFamily(scratch)
+
+    if (family.sorted.length <= 1) {
+        return <div className="flex h-full items-center justify-center">
+            <div className="max-w-prose text-center">
+                <div className="mb-2 text-xl">
+                    No parents or forks
+                </div>
+                <p className="text-gray-11">
+                    This scratch has no family members.
+                    It's the only attempt at this function.
+                </p>
+            </div>
+        </div>
+    }
+
+    return <div>
+        <div className="mb-4 flex items-center">
+            <div>
+                {family.sorted.length} family members
+            </div>
+            <div className="grow" />
+            <div>
+                <span className="mr-2 text-sm text-gray-11">
+                    Sort by
+                </span>
+                <Select
+                    value={family.sortMode}
+                    onChange={m => family.setSortMode(m as SortMode)}
+                    options={{
+                        [SortMode.SCORE]: "Match completion",
+                        [SortMode.NEWEST_FIRST]: "Newest first",
+                        [SortMode.OLDEST_FIRST]: "Oldest first",
+                        [SortMode.LAST_UPDATED]: "Last modified",
+                    }}
+                />
+            </div>
+        </div>
+        <ol>
+            {family.sorted.map(member => <li key={member.url} className="mb-1">
+                <FamilyMember scratch={member} isCurrent={member.url === scratch.url} />
+            </li>)}
+        </ol>
+    </div>
+}

--- a/frontend/src/components/user/UserLink.tsx
+++ b/frontend/src/components/user/UserLink.tsx
@@ -1,6 +1,6 @@
-import { isAnonUser, User, AnonymousUser } from "@/lib/api/types"
+import Link from "next/link"
 
-import GhostButton from "../GhostButton"
+import { isAnonUser, User, AnonymousUser } from "@/lib/api/types"
 
 import UserAvatar from "./UserAvatar"
 
@@ -10,12 +10,24 @@ export type Props = {
 }
 
 export default function UserLink({ user, showUsername }: Props) {
+    if (!user) {
+        return null
+    }
+
     const url: string | null = isAnonUser(user) ? null : `/u/${user.username}`
 
-    return <GhostButton href={url} className="rounded-full">
+    const inner = <>
         <UserAvatar user={user} className="mr-1 h-4 w-4 align-middle" />
         {showUsername != false && <span>
             {user.username}
         </span>}
-    </GhostButton>
+    </>
+
+    if (!url) {
+        return <span>{inner}</span>
+    }
+
+    return <Link href={url} className="hover:underline active:translate-y-px">
+        {inner}
+    </Link>
 }

--- a/frontend/src/components/user/UserLink.tsx
+++ b/frontend/src/components/user/UserLink.tsx
@@ -11,7 +11,7 @@ export type Props = {
 
 export default function UserLink({ user, showUsername }: Props) {
     if (!user) {
-        return null
+        return <span>?</span>
     }
 
     const url: string | null = isAnonUser(user) ? null : `/u/${user.username}`


### PR DESCRIPTION
See it in action: click the Family tab of https://decomp.me/scratch/2LQOY on the deployment (press 'View deployment'):

<img width="876" alt="image" src="https://user-images.githubusercontent.com/9429556/210916980-175997c9-285d-4e33-8c48-069bd8bfb78e.png">

Todo:
- [x] Fix issue where matched functions are sorted to the bottom of the list instead of the top
- [x] Fix loading spinner being comically large / use a skeleton