### PR TITLE
Update LoK: SR compiler version and flags

### DIFF
--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -898,8 +898,8 @@ _all_presets = [
     ),
     Preset(
         "Legacy of Kain: Soul Reaver",
-        PSYQ45,
-        "-g -Wall -O2 -G256",
+        PSYQ43,
+        "-O2 -G65536",
     ),
     Preset(
         "Metal Gear Solid",


### PR DESCRIPTION
The correct compiler version for KAIN2.EXE is "mostly" PsyQ 4.3.

The AADLIB is what uses 4.5 I think so it's probably best to use 4.3 since 80% of the code is using that.