### PR TITLE
remove api.getCached

### DIFF
--- a/frontend/src/app/(navfooter)/new/page.tsx
+++ b/frontend/src/app/(navfooter)/new/page.tsx
@@ -1,10 +1,10 @@
-import { getCached } from "@/lib/api/request"
+import { get } from "@/lib/api/request"
 
 import DESCRIPTION from "./description"
 import NewScratchForm from "./NewScratchForm"
 
 export default async function NewScratchPage() {
-    const compilers = await getCached("/compilers")
+    const compilers = await get("/compilers")
 
     return <main>
         <h1 className="text-2xl font-semibold tracking-tight text-gray-12 md:text-3xl">Start a new scratch</h1>

--- a/frontend/src/components/PlatformSelect/PlatformName.tsx
+++ b/frontend/src/components/PlatformSelect/PlatformName.tsx
@@ -14,7 +14,7 @@ export default function PlatformName({ platform }: Props) {
                 description: string
             }
         }
-    }>("/compilers", api.getCached)
+    }>("/compilers", api.get)
 
     return <>
         {data?.platforms[platform]?.name ?? platform}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation"
 import useSWR, { Revalidator, RevalidatorOptions, mutate } from "swr"
 import { useDebouncedCallback } from "use-debounce"
 
-import { ResponseError, get, getCached, post, patch, delete_ } from "./api/request"
+import { ResponseError, get, post, patch, delete_ } from "./api/request"
 import { AnonymousUser, User, Scratch, TerseScratch, Compilation, Page, Compiler, Platform, Project, ProjectMember } from "./api/types"
 import { ignoreNextWarnBeforeUnload } from "./hooks"
 
@@ -229,7 +229,7 @@ export function useCompilation(scratch: Scratch | null, autoRecompile = true, au
 }
 
 export function usePlatforms(): Record<string, Platform> {
-    const { data } = useSWR<{ "platforms": Record<string, Platform> }>("/compilers", getCached, {
+    const { data } = useSWR<{ "platforms": Record<string, Platform> }>("/compilers", get, {
         refreshInterval: 0,
         revalidateOnFocus: false,
         suspense: true, // TODO: remove

--- a/frontend/src/lib/api/request.ts
+++ b/frontend/src/lib/api/request.ts
@@ -35,12 +35,12 @@ export function normalizeUrl(url: string) {
     return url
 }
 
-export async function get(url: string, useCacheIfFresh = false) {
+export async function get(url: string) {
     url = normalizeUrl(url)
 
     const response = await fetch(url, {
         ...commonOpts,
-        cache: useCacheIfFresh ? "default" : "no-cache",
+        cache: "no-cache",
         next: { revalidate: 10 },
     })
 
@@ -61,8 +61,6 @@ export async function get(url: string, useCacheIfFresh = false) {
         throw error
     }
 }
-
-export const getCached = (url: string) => get(url, true)
 
 export async function post(url: string, data: Json | FormData, method = "POST") {
     url = normalizeUrl(url)


### PR DESCRIPTION
This should fix #597. It's hard to say, since I can't reproduce it.

I *think* the problem lay in the API not providing an age for `/compilers` using the `Cache-Control` or `Expires` headers. Combined with frontend's `api.getCached`, which does a fetch but - crucially - with `cache: "default"` instead of `cache: "no-cache"` ([docs](https://developer.mozilla.org/en-US/docs/Web/API/Request/cache#value)). In "default", because there's no age given on the resource, [the browser will use implementation-defined heuristics](https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching#heuristic_caching) to decide whether to use the cached version - which is what I think is happening here.

Problem is, we don't know in advance when the compilers will change. This could have gone two ways:
1. Send a max-age for `/compilers`, e.g. a week.
2. Stop using `cache: "default"` 👈 I've done this

(2) shouldn't be a big deal: "no-cache" will send a little HEAD request to see if the Last-Modified has changed since the cached version, in case it doesn't need a full GET request. This is what we do with every other API call anyway.
