### PR TITLE
Update IDO recomp to v0.5

### DIFF
--- a/backend/compilers/download.py
+++ b/backend/compilers/download.py
@@ -370,7 +370,7 @@ def download_n64():
             print(f"ido{version} already exists, skipping")
         else:
             download_tar(
-                url=f"https://github.com/ethteck/ido-static-recomp/releases/download/v0.4/ido-{version}-recomp-{host_os.ido_pkg}.tar.gz",
+                url=f"https://github.com/ethteck/ido-static-recomp/releases/download/v0.5/ido-{version}-recomp-{host_os.ido_pkg}.tar.gz",
                 dest_name=f"ido{version}",
             )
 

--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -337,14 +337,14 @@ EE_GCC32_040921 = GCCCompiler(
 IDO53_IRIX = IDOCompiler(
     id="ido5.3_irix",
     platform=IRIX,
-    cc='IDO_CC="${COMPILER_DIR}/cc" "${COMPILER_DIR}/cc" -c -Xcpluscomm -G0 -non_shared -woff 649,838,712 -32 ${COMPILER_FLAGS} -o "${OUTPUT}" "${INPUT}"',
+    cc='USR_LIB="${COMPILER_DIR}" "${COMPILER_DIR}/cc" -c -Xcpluscomm -G0 -non_shared -woff 649,838,712 -32 ${COMPILER_FLAGS} -o "${OUTPUT}" "${INPUT}"',
     base_id="ido5.3",
 )
 
 IDO53PASCAL = IDOCompiler(
     id="ido5.3Pascal",
     platform=IRIX,
-    cc='IDO_CC="${COMPILER_DIR}/cc" "${COMPILER_DIR}/cc" -c -Xcpluscomm -G0 -non_shared ${COMPILER_FLAGS} -o "${OUTPUT}" "${INPUT}"',
+    cc='USR_LIB="${COMPILER_DIR}" "${COMPILER_DIR}/cc" -c -Xcpluscomm -G0 -non_shared ${COMPILER_FLAGS} -o "${OUTPUT}" "${INPUT}"',
     base_id="ido5.3",
     language=Language.PASCAL,
 )
@@ -352,14 +352,14 @@ IDO53PASCAL = IDOCompiler(
 IDO71_IRIX = IDOCompiler(
     id="ido7.1_irix",
     platform=IRIX,
-    cc='IDO_CC="${COMPILER_DIR}/cc" "${COMPILER_DIR}/cc" -c -Xcpluscomm -G0 -non_shared -woff 649,838,712 -32 ${COMPILER_FLAGS} -o "${OUTPUT}" "${INPUT}"',
+    cc='USR_LIB="${COMPILER_DIR}" "${COMPILER_DIR}/cc" -c -Xcpluscomm -G0 -non_shared -woff 649,838,712 -32 ${COMPILER_FLAGS} -o "${OUTPUT}" "${INPUT}"',
     base_id="ido7.1",
 )
 
 IDO71PASCAL = IDOCompiler(
     id="ido7.1Pascal",
     platform=IRIX,
-    cc='IDO_CC="${COMPILER_DIR}/cc" "${COMPILER_DIR}/cc" -c -Xcpluscomm -G0 -non_shared ${COMPILER_FLAGS} -o "${OUTPUT}" "${INPUT}"',
+    cc='USR_LIB="${COMPILER_DIR}" "${COMPILER_DIR}/cc" -c -Xcpluscomm -G0 -non_shared ${COMPILER_FLAGS} -o "${OUTPUT}" "${INPUT}"',
     base_id="ido7.1",
     language=Language.PASCAL,
 )
@@ -368,13 +368,13 @@ IDO71PASCAL = IDOCompiler(
 IDO53 = IDOCompiler(
     id="ido5.3",
     platform=N64,
-    cc='IDO_CC="${COMPILER_DIR}/cc" "${COMPILER_DIR}/cc" -c -Xcpluscomm -G0 -non_shared -Wab,-r4300_mul -woff 649,838,712 -32 ${COMPILER_FLAGS} -o "${OUTPUT}" "${INPUT}"',
+    cc='USR_LIB="${COMPILER_DIR}" "${COMPILER_DIR}/cc" -c -Xcpluscomm -G0 -non_shared -Wab,-r4300_mul -woff 649,838,712 -32 ${COMPILER_FLAGS} -o "${OUTPUT}" "${INPUT}"',
 )
 
 IDO71 = IDOCompiler(
     id="ido7.1",
     platform=N64,
-    cc='IDO_CC="${COMPILER_DIR}/cc" "${COMPILER_DIR}/cc" -c -Xcpluscomm -G0 -non_shared -Wab,-r4300_mul -woff 649,838,712 -32 ${COMPILER_FLAGS} -o "${OUTPUT}" "${INPUT}"',
+    cc='USR_LIB="${COMPILER_DIR}" "${COMPILER_DIR}/cc" -c -Xcpluscomm -G0 -non_shared -Wab,-r4300_mul -woff 649,838,712 -32 ${COMPILER_FLAGS} -o "${OUTPUT}" "${INPUT}"',
 )
 
 GCC272KMC = GCCCompiler(


### PR DESCRIPTION
Updates recomp ido to v0.5 which has slight differences in how it handles file path redirection.

Please let me know if there is something else I need to update as well.