### PR TITLE
Add jlabel macro for MIPS platforms

### DIFF
--- a/backend/coreapp/platforms.py
+++ b/backend/coreapp/platforms.py
@@ -80,6 +80,10 @@ N64 = Platform(
     \label:
 .endm
 
+.macro jlabel label
+    \label:
+.endm
+
 .set noat
 .set noreorder
 .set gp=64
@@ -151,6 +155,10 @@ IRIX = Platform(
     \label:
 .endm
 
+.macro jlabel label
+    \label:
+.endm
+
 .set noat
 .set noreorder
 .set gp=64
@@ -214,6 +222,10 @@ PS1 = Platform(
     \label:
 .endm
 
+.macro jlabel label
+    \label:
+.endm
+
 .set noat
 .set noreorder
 
@@ -237,6 +249,10 @@ PS2 = Platform(
 .macro glabel label
     .global \label
     .type \label, @function
+    \label:
+.endm
+
+.macro jlabel label
     \label:
 .endm
 


### PR DESCRIPTION
https://decomp.me/scratch/LdpMr has a bunch of annoying diffs of the form:
```diff
- 78:    beqz    at,L802CA24C_6DB8FC+0x78
+ 78:    beqz    at,2ec ~>
```
which appear because there's a glabel L802CA24C_6DB8FC in between branch and target that the branch decides to relocate against. If the label is made local this won't happen. `L802CA24C_6DB8FC:` may not work for all decomps, because of jtbl targets needing to be referenceable by separately compiled rodata, but `jlabel L802CA24C_6DB8FC` would, if made to expand to `L802CA24C_6DB8FC:` on decomp.me and `glabel L802CA24C_6DB8FC` locally.

decomp-permuter, m2c and splat already support `jlabel` since before; it was originally devised by @Mr-Wiseguy "mainly for the purpose of progress calculation".