### PR TITLE
dynamically render scratch pages

### DIFF
--- a/frontend/src/app/scratch/[slug]/page.tsx
+++ b/frontend/src/app/scratch/[slug]/page.tsx
@@ -1,6 +1,9 @@
 import getScratchDetails from "./getScratchDetails"
 import ScratchEditor from "./ScratchEditor"
 
+// Always server side render, avoiding caching scratch details
+export const dynamic = "force-dynamic"
+
 export default async function Page({ params }: { params: { slug: string }}) {
     const { scratch, parentScratch, compilation } = await getScratchDetails(params.slug)
 


### PR DESCRIPTION
Fixes #685.

The issue was that scratch pages were statically rendered and cached indefinitely upon first request. The client was requesting the most up-to-date scratch data from Django but didn't realise that it was out-of-date compared to what the Next.js server gave it. The simplest fix for this is to never cache scratch pages, rerendering them on every request with the latest data.
