### PR TITLE
Accept malformed UTF-8 in compiler output

### DIFF
--- a/backend/coreapp/sandbox.py
+++ b/backend/coreapp/sandbox.py
@@ -125,6 +125,7 @@ class Sandbox(contextlib.AbstractContextManager["Sandbox"]):
         return subprocess.run(
             command,
             text=True,
+            errors="backslashreplace",
             env=env,
             cwd=self.path,
             check=True,


### PR DESCRIPTION
Untested. See https://docs.python.org/3/library/io.html#io.TextIOWrapper for the allowed values of `errors`.