### PR TITLE
Fix saturn path issue and use objcopy to convert to elf

### DIFF
--- a/backend/compilers/download.py
+++ b/backend/compilers/download.py
@@ -613,7 +613,10 @@ def download_saturn():
         url="https://github.com/sozud/saturn-compilers/archive/refs/heads/main.zip",
     )
 
-    shutil.move(f"{COMPILERS_DIR}/saturn-compilers-main/cygnus-2.7-96Q3", COMPILERS_DIR)
+    shutil.move(
+        f"{COMPILERS_DIR}/saturn-compilers-main/cygnus-2.7-96Q3-bin",
+        f"{COMPILERS_DIR}/cygnus-2.7-96Q3",
+    )
     shutil.rmtree(f"{COMPILERS_DIR}/saturn-compilers-main")
 
 

--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -343,11 +343,13 @@ PSYQ46 = GCCPS1Compiler(
 
 # Saturn
 SATURN_CC = (
-    'cat "$INPUT" | unix2dos > dos_src.c && cp -r ${COMPILER_DIR}/* . && '
-    + '(HOME="." dosemu -quiet -dumb -f ${COMPILER_DIR}/dosemurc -K . -E "G:\RUN_CPP.BAT dos_src.c -o src_proc.c") && '
-    + '(HOME="." dosemu -quiet -dumb -f ${COMPILER_DIR}/dosemurc -K . -E "G:\RUN_CC1.BAT -quiet ${COMPILER_FLAGS} src_proc.c -o cc1.o") && '
-    + '(HOME="." dosemu -quiet -dumb -f ${COMPILER_DIR}/dosemurc -K . -E "G:\RUN_AS.BAT cc1.o -o as.o") && '
-    + 'cp as.o "$OUTPUT"'
+    'cat "$INPUT" | unix2dos > dos_src.c && '
+    + "cp -r ${COMPILER_DIR}/* . && "
+    + '(HOME="." dosemu -quiet -dumb -f ${COMPILER_DIR}/dosemurc -K . -E "CPP.EXE dos_src.c -o src_proc.c") && '
+    + '(HOME="." dosemu -quiet -dumb -f ${COMPILER_DIR}/dosemurc -K . -E "CC1.EXE -quiet ${COMPILER_FLAGS} src_proc.c -o cc1_out.asm") && '
+    + '(HOME="." dosemu -quiet -dumb -f ${COMPILER_DIR}/dosemurc -K . -E "AS.EXE cc1_out.asm -o as_out.o") && '
+    + "sh-elf-objcopy -Icoff-sh -Oelf32-sh as_out.o &&"
+    + 'cp as_out.o "$OUTPUT"'
 )
 
 CYGNUS_2_7_96Q3 = GCCSaturnCompiler(


### PR DESCRIPTION
This changes the directory layout of the compiler so that the batch files and absolute paths aren't needed. This also includes the change by @Ced2911 to use objcopy to convert the coff to elf. I don't understand why this is necessary for some inputs on certain systems but it seems to work fine locally.