### PR TITLE
Add debug symbols for PMD:Red

### DIFF
--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -1050,7 +1050,7 @@ _all_presets = [
     Preset(
         "Pokemon Mystery Dungeon: Red Rescue Team",
         AGBCC,
-        "-mthumb-interwork -Wimplicit -Wparentheses -Wunused -Werror -O2 -fhex-asm",
+        "-mthumb-interwork -Wimplicit -Wparentheses -Wunused -Werror -O2 -fhex-asm -g",
     ),
     # N3DS
     Preset(


### PR DESCRIPTION
Enable debug symbols so we get line highlighting for the current assembly