### PR TITLE
Diff text color overhaul

### DIFF
--- a/frontend/src/components/Diff/Diff.module.scss
+++ b/frontend/src/components/Diff/Diff.module.scss
@@ -123,32 +123,7 @@
 
 .source_other { font-style: italic; }
 .source_line_num { font-style: italic; }
- color:#cd5252
-}
-.Diff_rotation1__cQ_cP {
- color:#cda452
-}
-.Diff_rotation2__KBLKI {
- color:#a4cd52
-}
-.Diff_rotation3__35Yxv {
- color:#52cd52
-}
-.Diff_rotation4__G2xR5 {
- color:#52cda4
-}
-.Diff_rotation5__kkcNj {
- color:#52a4cd
-}
-.Diff_rotation6__5x_yp {
- color:#5252cd
-}
-.Diff_rotation7__x8lnZ {
- color:#a452cd
-}
-.Diff_rotation8__TYVPj {
- color:#cd52a4
-}
+
 .rotation0 { color: rgb(205,82,82); }
 .rotation1 { color: rgb(205,164,82); }
 .rotation2 { color: rgb(164,205,82); }

--- a/frontend/src/components/Diff/Diff.module.scss
+++ b/frontend/src/components/Diff/Diff.module.scss
@@ -124,15 +124,15 @@
 .source_other { font-style: italic; }
 .source_line_num { font-style: italic; }
 
-.rotation0 { color: rgb(205,82,82); }
-.rotation1 { color: rgb(205,164,82); }
-.rotation2 { color: rgb(164,205,82); }
-.rotation3 { color: rgb(82,205,82); }
-.rotation4 { color: rgb(82,205,164); }
-.rotation5 { color: rgb(82,164,205); }
-.rotation6 { color: rgb(82,82,205); }
-.rotation7 { color: rgb(164,82,205); }
-.rotation8 { color: rgb(205,82,164); }
+.rotation0 { color: rgb(205, 82, 82); }
+.rotation1 { color: rgb(205, 164, 82); }
+.rotation2 { color: rgb(164, 205, 82); }
+.rotation3 { color: rgb(82, 205, 82); }
+.rotation4 { color: rgb(82, 205, 164); }
+.rotation5 { color: rgb(82, 164, 205); }
+.rotation6 { color: rgb(82, 82, 205); }
+.rotation7 { color: rgb(164, 82, 205); }
+.rotation8 { color: rgb(205, 82, 164); }
 
 .highlighted {
     color: white;

--- a/frontend/src/components/Diff/Diff.module.scss
+++ b/frontend/src/components/Diff/Diff.module.scss
@@ -123,15 +123,41 @@
 
 .source_other { font-style: italic; }
 .source_line_num { font-style: italic; }
-.rotation0 { color: magenta; }
-.rotation1 { color: cyan; }
-.rotation2 { color: rgb(0, 212, 0); }
-.rotation3 { color: red; }
-.rotation4 { color: rgb(103, 106, 255); }
-.rotation5 { color: lightpink; }
-.rotation6 { color: blue; }
-.rotation7 { color: lightgreen; }
-.rotation8 { color: grey; }
+ color:#cd5252
+}
+.Diff_rotation1__cQ_cP {
+ color:#cda452
+}
+.Diff_rotation2__KBLKI {
+ color:#a4cd52
+}
+.Diff_rotation3__35Yxv {
+ color:#52cd52
+}
+.Diff_rotation4__G2xR5 {
+ color:#52cda4
+}
+.Diff_rotation5__kkcNj {
+ color:#52a4cd
+}
+.Diff_rotation6__5x_yp {
+ color:#5252cd
+}
+.Diff_rotation7__x8lnZ {
+ color:#a452cd
+}
+.Diff_rotation8__TYVPj {
+ color:#cd52a4
+}
+.rotation0 { color: rgb(205,82,82); }
+.rotation1 { color: rgb(205,164,82); }
+.rotation2 { color: rgb(164,205,82); }
+.rotation3 { color: rgb(82,205,82); }
+.rotation4 { color: rgb(82,205,164); }
+.rotation5 { color: rgb(82,164,205); }
+.rotation6 { color: rgb(82,82,205); }
+.rotation7 { color: rgb(164,82,205); }
+.rotation8 { color: rgb(205,82,164); }
 
 .highlighted {
     color: white;

--- a/frontend/src/components/Diff/Diff.module.scss
+++ b/frontend/src/components/Diff/Diff.module.scss
@@ -129,7 +129,7 @@
 .rotation3 { color: red; }
 .rotation4 { color: rgb(103, 106, 255); }
 .rotation5 { color: lightpink; }
-.rotation6 { color: lightcyan; }
+.rotation6 { color: blue; }
 .rotation7 { color: lightgreen; }
 .rotation8 { color: grey; }
 


### PR DESCRIPTION
Diff colors can be hard to read on some backgrounds, especially the existing light cyan. This changes colors from an arbitrary-seeming set to a programmatic set, generated through equally spaced HSV values. This should approximate a strong set of distinguishable colors. These colors are easy to read on both light and dark modes, as shown in this test screenshot:

https://cdn.discordapp.com/attachments/897075447534354462/1112075654947672134/image.png