### PR TITLE
make score 'tick' white rather than theme-dependent

### DIFF
--- a/frontend/src/components/ScoreBadge.module.scss
+++ b/frontend/src/components/ScoreBadge.module.scss
@@ -33,4 +33,5 @@
 
 .icon {
     width: 1.2em;
+    color: white;
 }


### PR DESCRIPTION
closes #750.

![image](https://github.com/decompme/decomp.me/assets/22226349/161edc7a-db95-45dc-864e-22f45de6b5c0)

