### PR TITLE
Fix server error upon processing user with revoked github token

### DIFF
--- a/backend/coreapp/models/github.py
+++ b/backend/coreapp/models/github.py
@@ -65,7 +65,7 @@ class GitHubUser(models.Model):
         if cached:
             return cached
 
-        details = Github(self.access_token).get_user_by_id(self.github_id)
+        details = Github().get_user_by_id(self.github_id)
 
         cache.set(cache_key, details, API_CACHE_TIMEOUT)
         return details


### PR DESCRIPTION
Fixes the root cause behind #782.

Right now, `GitHubUser.details` uses the user's authentication token to fetch their own details. In doing so, it doesn't check if the token's been revoked by its owner, and errors out if it has.

As all the details we're looking for are publicly available, this PR switches to fetching the user's details sans an authentication token. Insofar as I can tell, this is the only such place we're using an auth token unnecessarily.

This is a little bit of a band-aid fix because it ignores the fact there are still other ways fetching a user's information can fail (although they're rarer still). Happy for greater error checking to be included in this PR, or to leave it as a future issue.