### PR TITLE
Add ee-gcc2.9-991111-01 compiler

### DIFF
--- a/backend/compilers/download.py
+++ b/backend/compilers/download.py
@@ -636,6 +636,7 @@ def download_ps2():
 
     ps2_compilers = {
         "ee-gcc2.9-990721": "https://cdn.discordapp.com/attachments/1067192766918037536/1067306679806464060/ee-gcc2.9-990721.tar.xz",
+        "ee-gcc2.9-991111-01": "https://cdn.discordapp.com/attachments/1067192766918037536/1119832299400331314/ee-gcc2.9-991111-01.tar.xz",
         "ee-gcc2.96": "https://cdn.discordapp.com/attachments/1067192766918037536/1067306680179752990/ee-gcc2.96.tar.xz",
         "ee-gcc3.2-040921": "https://cdn.discordapp.com/attachments/1067192766918037536/1067306680548855908/ee-gcc3.2-040921.tar.xz",
     }

--- a/backend/compilers/download.py
+++ b/backend/compilers/download.py
@@ -636,6 +636,8 @@ def download_ps2():
 
     ps2_compilers = {
         "ee-gcc2.9-990721": "https://cdn.discordapp.com/attachments/1067192766918037536/1067306679806464060/ee-gcc2.9-990721.tar.xz",
+        "ee-gcc2.9-991111": "https://cdn.discordapp.com/attachments/1067192766918037536/1120445542279954482/ee-gcc2.9-991111.tar.xz",
+        "ee-gcc2.9-991111a": "https://cdn.discordapp.com/attachments/1067192766918037536/1120445479797395506/ee-gcc2.9-991111a.tar.xz",
         "ee-gcc2.9-991111-01": "https://cdn.discordapp.com/attachments/1067192766918037536/1119832299400331314/ee-gcc2.9-991111-01.tar.xz",
         "ee-gcc2.96": "https://cdn.discordapp.com/attachments/1067192766918037536/1067306680179752990/ee-gcc2.96.tar.xz",
         "ee-gcc3.2-040921": "https://cdn.discordapp.com/attachments/1067192766918037536/1067306680548855908/ee-gcc3.2-040921.tar.xz",
@@ -652,7 +654,7 @@ def download_ps2():
 
     # Extra compiler collection
     download_tar(
-        url="https://cdn.discordapp.com/attachments/1067904954779586650/1083990728365068328/ps2_compilers.tar.xz",
+        url="https://cdn.discordapp.com/attachments/1067192766918037536/1120445708516995118/ps2_compilers.tar.xz",
         mode="r:xz",
         dl_name="ps2_compilers.tar.xz",
         create_subdir=False,

--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -359,7 +359,13 @@ EE_GCC29_990721 = GCCCompiler(
 EE_GCC29_991111 = GCCCompiler(
     id="ee-gcc2.9-991111",
     platform=PS2,
-    cc='${WINE} "${COMPILER_DIR}/bin/ee-gcc.exe" -c -B "${COMPILER_DIR}"/lib/gcc-lib/ee/2.9-ee-991111/ $COMPILER_FLAGS "$INPUT" -o "$OUTPUT"',
+    cc='${COMPILER_DIR}/bin/ee-gcc -c $COMPILER_FLAGS "$INPUT" -o "$OUTPUT"',
+)
+
+EE_GCC29_991111A = GCCCompiler(
+    id="ee-gcc2.9-991111a",
+    platform=PS2,
+    cc='${COMPILER_DIR}/bin/ee-gcc -c $COMPILER_FLAGS "$INPUT" -o "$OUTPUT"',
 )
 
 EE_GCC29_991111_01 = GCCCompiler(
@@ -924,6 +930,7 @@ _all_compilers: List[Compiler] = [
     # PS2
     EE_GCC29_990721,
     EE_GCC29_991111,
+    EE_GCC29_991111A,
     EE_GCC29_991111_01,
     EE_GCC2952_273A,
     EE_GCC2952_274,

--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -362,6 +362,12 @@ EE_GCC29_991111 = GCCCompiler(
     cc='${WINE} "${COMPILER_DIR}/bin/ee-gcc.exe" -c -B "${COMPILER_DIR}"/lib/gcc-lib/ee/2.9-ee-991111/ $COMPILER_FLAGS "$INPUT" -o "$OUTPUT"',
 )
 
+EE_GCC29_991111_01 = GCCCompiler(
+    id="ee-gcc2.9-991111-01",
+    platform=PS2,
+    cc='${COMPILER_DIR}/bin/ee-gcc -c $COMPILER_FLAGS "$INPUT" -o "$OUTPUT"',
+)
+
 EE_GCC2952_273A = GCCCompiler(
     id="ee-gcc2.95.2-273a",
     platform=PS2,
@@ -918,6 +924,7 @@ _all_compilers: List[Compiler] = [
     # PS2
     EE_GCC29_990721,
     EE_GCC29_991111,
+    EE_GCC29_991111_01,
     EE_GCC2952_273A,
     EE_GCC2952_274,
     EE_GCC2953_107,

--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -1492,12 +1492,12 @@ _all_presets = [
     # PS2
     Preset(
         "Ty the Tasmanian Tiger (July 1st)",
-        EE_GCC29_991111,
+        EE_GCC29_991111A,
         "-x c++ -O2 -fno-exceptions -gstabs -ffast-math -finline-functions",
     ),
     Preset(
         "Sunny Garcia Surfing",
-        EE_GCC29_991111,
+        EE_GCC29_991111A,
         "-x c++ -O2 -fno-exceptions -gstabs -ffast-math",
     ),
 ]

--- a/backend/coreapp/migrations/0032_replace_ps2_991111_with_991111a.py
+++ b/backend/coreapp/migrations/0032_replace_ps2_991111_with_991111a.py
@@ -1,0 +1,35 @@
+import django.db.migrations.operations.special
+from django.apps.registry import Apps
+from django.db import migrations
+from django.db.backends.base.schema import BaseDatabaseSchemaEditor
+
+
+def rename_compilers(apps: Apps, schema_editor: BaseDatabaseSchemaEditor) -> None:
+    """
+    Migrate the compiler ID 'ee-gcc2.9-991111' into 'ee-gcc2.9-991111a'
+    """
+
+    compiler_map = {
+        "ee-gcc2.9-991111": "ee-gcc2.9-991111a",
+    }
+
+    Scratch = apps.get_model("coreapp", "Scratch")
+    for row in Scratch.objects.only("compiler").filter(
+        compiler__endswith="ee-gcc2.9-991111"
+    ):
+        if row.compiler in compiler_map:
+            row.compiler = compiler_map[row.compiler]
+            row.save(update_fields=["compiler"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("coreapp", "0031_raise_scratch_and_diff_label_length_limit_to_1024"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            code=rename_compilers,
+            reverse_code=django.db.migrations.operations.special.RunPython.noop,
+        )
+    ]

--- a/frontend/src/lib/i18n/locales/en/compilers.json
+++ b/frontend/src/lib/i18n/locales/en/compilers.json
@@ -19,6 +19,7 @@
     "dummy_longrunning": "Dummy (long-running)",
     "ee-gcc2.9-990721": "EE GCC 2.9 build 990721",
     "ee-gcc2.9-991111": "EE GCC 2.9 build 991111",
+    "ee-gcc2.9-991111-01": "EE GCC 2.9 build 991111-01",
     "ee-gcc2.95.2-273a": "EE GCC 2.95.2 (SN BUILD v2.73a)",
     "ee-gcc2.95.2-274": "EE GCC 2.95.2 (SN BUILD v2.74)",
     "ee-gcc2.95.3-107": "EE GCC 2.95.3 (SN BUILD v1.07)",

--- a/frontend/src/lib/i18n/locales/en/compilers.json
+++ b/frontend/src/lib/i18n/locales/en/compilers.json
@@ -19,6 +19,7 @@
     "dummy_longrunning": "Dummy (long-running)",
     "ee-gcc2.9-990721": "EE GCC 2.9 build 990721",
     "ee-gcc2.9-991111": "EE GCC 2.9 build 991111",
+    "ee-gcc2.9-991111a": "EE GCC 2.9 build 991111a",
     "ee-gcc2.9-991111-01": "EE GCC 2.9 build 991111-01",
     "ee-gcc2.95.2-273a": "EE GCC 2.95.2 (SN BUILD v2.73a)",
     "ee-gcc2.95.2-274": "EE GCC 2.95.2 (SN BUILD v2.74)",


### PR DESCRIPTION
This compiler is required to get this scratch this to match: https://decomp.me/scratch/oPCWT

I also added a few notes at the top of that scratch detailing the differences between 991111, 991111-01, and the 991111 Windows build that the site currently uses (I'll call this 991111-win). 991111 can be compiled from source so Wine wouldn't have to be used, though it produces different code than 991111-win, so I'm not sure how to proceed with adding that compiler version.

(technically 991111 should be `ee-gcc2.9-991111` and 991111-win should be moved to a separate compiler ID like `ee-gcc2.9-991111-win` to avoid confusion since 991111-win seems to be a compiler version in between 991111 and 991111-01, though that means certain scratches that need 991111-win would have to change the compiler used, i.e. https://decomp.me/scratch/QIQfY)