### PR TITLE
Consume stderr when checking git hash

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -19,7 +19,7 @@ const getEnvBool = (key, fallback=false) => {
 
 let git_hash
 try {
-    git_hash = execSync("git rev-parse HEAD").toString().trim()
+    git_hash = execSync("git rev-parse HEAD", {stdio: "pipe"}).toString().trim()
 } catch (error) {
     console.log("Unable to get git hash, assume running inside Docker")
     git_hash = "abc123"


### PR DESCRIPTION
The [documentation](https://nodejs.org/api/child_process.html#child_processexeccommand-options-callback) says that "pipe" is the default option, but it's [clearly not](https://stackoverflow.com/a/45578119/7290888). This change consumes any stderr from the `git rev-parse HEAD` command rather than spitting it out in the log.
**Before:**
```
decompme-frontend-1  | fatal: not a git repository (or any parent up to mount point /)
decompme-frontend-1  | Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
decompme-frontend-1  | Unable to get git hash, assume running inside Docker
```
**After:**
```
decompme-frontend-1  | Unable to get git hash, assume running inside Docker
```