### PR TITLE
Add mwcceppc 1.3.2r & update AC preset

### DIFF
--- a/backend/compilers/download.py
+++ b/backend/compilers/download.py
@@ -804,7 +804,10 @@ def download_wii_gc():
     }
 
     single_compilers = {
-        "1.3.2r": ["mwcc_242_81r", "https://cdn.discordapp.com/attachments/598600200084258822/1136883349642825728/MWCCEPPC_1.3.2r.zip"]
+        "1.3.2r": [
+            "mwcc_242_81r",
+            "https://cdn.discordapp.com/attachments/598600200084258822/1136883349642825728/MWCCEPPC_1.3.2r.zip"
+        ]
     }
 
     download_zip(
@@ -858,10 +861,6 @@ def download_wii_gc():
         set_x(compiler_dir / "mwcceppc.exe")
 
         (compiler_dir / "license.dat").touch()
-
-        # remove old dir
-        shutil.rmtree(COMPILERS_DIR / ver)
-
 
     # copy in clean 1.2.5 for frank
     shutil.copy(

--- a/backend/compilers/download.py
+++ b/backend/compilers/download.py
@@ -806,7 +806,7 @@ def download_wii_gc():
     single_compilers = {
         "1.3.2r": [
             "mwcc_242_81r",
-            "https://cdn.discordapp.com/attachments/598600200084258822/1136883349642825728/MWCCEPPC_1.3.2r.zip"
+            "https://cdn.discordapp.com/attachments/598600200084258822/1136883349642825728/MWCCEPPC_1.3.2r.zip",
         ]
     }
 

--- a/backend/compilers/download.py
+++ b/backend/compilers/download.py
@@ -803,6 +803,10 @@ def download_wii_gc():
         },
     }
 
+    single_compilers = {
+        "1.3.2r": ["mwcc_242_81r", "https://cdn.discordapp.com/attachments/598600200084258822/1136883349642825728/MWCCEPPC_1.3.2r.zip"]
+    }
+
     download_zip(
         url="https://cdn.discordapp.com/attachments/727918646525165659/1129759991696457728/GC_WII_COMPILERS.zip"
     )
@@ -827,6 +831,37 @@ def download_wii_gc():
             (compiler_dir / "license.dat").touch()
 
         shutil.rmtree(COMPILERS_DIR / group_id)
+
+    # copy single compilers over
+    for ver, info in single_compilers.items():
+        compiler_id = info[0]
+        url = info[1]
+
+        # download zip to COMPILERS_DIR
+        download_zip(url=url)
+
+        compiler_dir = COMPILERS_DIR / compiler_id
+
+        # move version dir to compiler dir
+        if not compiler_dir.exists():
+            shutil.move(COMPILERS_DIR / ver, compiler_dir)
+
+        # Rename dll to uppercase - WSL is case sensitive without wine
+        lowercase_lmgr = compiler_dir / "lmgr326b.dll"
+        if lowercase_lmgr.exists():
+            shutil.move(lowercase_lmgr, compiler_dir / "LMGR326B.dll")
+
+        lowercase_lmgr = compiler_dir / "lmgr8c.dll"
+        if lowercase_lmgr.exists():
+            shutil.move(lowercase_lmgr, compiler_dir / "LMGR8C.dll")
+
+        set_x(compiler_dir / "mwcceppc.exe")
+
+        (compiler_dir / "license.dat").touch()
+
+        # remove old dir
+        shutil.rmtree(COMPILERS_DIR / ver)
+
 
     # copy in clean 1.2.5 for frank
     shutil.copy(

--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -752,6 +752,12 @@ MWCC_242_81 = MWCCCompiler(
     cc=MWCCEPPC_CC,
 )
 
+MWCC_242_81R = MWCCCompiler(
+    id="mwcc_242_81r",
+    platform=GC_WII,
+    cc=MWCCEPPC_CC,
+)
+
 MWCC_247_92 = MWCCCompiler(
     id="mwcc_247_92",
     platform=GC_WII,
@@ -1613,13 +1619,13 @@ _all_presets = [
     ),
     Preset(
         "Animal Crossing (REL)",
-        MWCC_242_81,
-        "-O4 -fp hard -sdata 0 -sdata2 0 -Cpp_exceptions off -pool off, -enum int",
+        MWCC_242_81R,
+        "-O4 -fp hard -sdata 0 -sdata2 0 -Cpp_exceptions off -enum int -sym on",
     ),
     Preset(
         "Animal Crossing (DOL)",
         MWCC_242_81,
-        "-O4 -fp hard -sdata 8 -sdata2 8 -Cpp_exceptions off, -char unsigned, -enum int",
+        "-O4 -fp hard -sdata 8 -sdata2 8 -Cpp_exceptions off -char unsigned -enum int",
     ),
     # NDS
     Preset(

--- a/frontend/src/lib/i18n/locales/en/compilers.json
+++ b/frontend/src/lib/i18n/locales/en/compilers.json
@@ -64,6 +64,7 @@
     "mwcc_233_163e": "2.3.3 build 163 (GC MW 1.2.5e)",
     "mwcc_233_163n": "2.3.3 build 163 (GC MW 1.2.5n)",
     "mwcc_242_81": "2.4.2 build 81 (GC MW 1.3.2)",
+    "mwcc_242_81r": "2.4.2 build 81 (GC MW 1.3.2r)",
     "mwcc_247_105": "2.4.7 build 105 (GC MW 2.5)",
     "mwcc_247_107": "2.4.7 build 107 (GC MW 2.6)",
     "mwcc_247_108": "2.4.7 build 108 (GC MW 2.7)",


### PR DESCRIPTION
Due to a quirk with the GameCube Animal Crossing line (DnM+, AC, DnMe+), .rodata is not pooled while .data and .bss are. There is likely a set of flags which reproduces this behavior, but we could not determine them.

Instead, we have modified mwcceppc 1.3.2 to force disable data pooling for the .rodata section with the 1.3.2r compiler variant.