### PR TITLE
Fix vib-ribbon preset

### DIFF
--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -1274,7 +1274,7 @@ _all_presets = [
     Preset(
         "vib-ribbon",
         PSYQ45,
-        "-O2 -G4 -mel -mno-abicalls -fno-builtin",
+        "-Os -G4 -mel -mno-abicalls -fno-builtin",
     ),
     # Saturn
     Preset(


### PR DESCRIPTION
Use `-Os` instead of `-O2`.