### PR TITLE
Fix gc/wii error messages

### DIFF
--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -721,7 +721,7 @@ PBX_GCC3 = GCCCompiler(
 # GC_WII
 # Thanks to Gordon Davisson for the xargs trick:
 # https://superuser.com/questions/1529226/get-bash-to-respect-quotes-when-word-splitting-subshell-output/1529316#1529316
-MWCCEPPC_CC = 'printf "%s" "${COMPILER_FLAGS}" | xargs -x -- ${WINE} "${COMPILER_DIR}/mwcceppc.exe" -c -proc gekko -nostdinc -stderr -o "${OUTPUT}" "${INPUT}"'
+MWCCEPPC_CC = 'printf "%s" "${COMPILER_FLAGS}" | xargs -x -- ${WINE} "${COMPILER_DIR}/mwcceppc.exe" -pragma "msg_show_realref off" -c -proc gekko -nostdinc -stderr -o "${OUTPUT}" "${INPUT}"'
 
 MWCC_233_144 = MWCCCompiler(
     id="mwcc_233_144",


### PR DESCRIPTION
#488 fixed the DWARF line numbers for newer GC/Wii compilers (which just required the files containing code to exist), but made error messages messy in the process.

The error messages show both the version of the line from the preprocessed file, and the version from the original based on the info given from `#line`.
- The preprocessed code is stored in `code.c`, which also has a `#line` statement half way through claiming to be the start of `code.c`. This meant that the line of code shown in the second half of the error message that looks up the `#line` would just be a random unrelated line from the file.
- Any context errors would just show a blank line in the second half of the error messaage
- The first half of the message would show the correct line contents, but the line number would be useless since it was for the preprocessed version

This PR makes a few changes:
- Use the same pragma as #505 to only show one version of the line. This gets rid of the mess, but unfortunately picks the version of the line that was currently broken
- Changes the filename in the `#file` statement for the main code back to `src.c` so that it won't read incorrect lines from the preprocessed version
- For MWCC only, creates actual copies of the files `ctx.c` and `src.c` for the error messages to read

Errors now go from looking like
```
Compiler error: ### mwcceppc.exe Compiler:
#    File: code.c
# ---------------
#       4:     int a error; 
#   Error:           ^^^^^
#   (10123) ';' expected
### mwcceppc.exe Compiler:
#      In: ctx.c
# --------------
#       3: 
#    Note: ^
#   (10435)     (corresponding #line reference)
### mwcceppc.exe Compiler:
#    File: code.c
# ---------------
#      12:     wp = 0 error; 
#   Error:            ^^^^^
#   (10123) ';' expected
### mwcceppc.exe Compiler:
#       5: }; 
#    Note: ^
#   (10435)     (corresponding #line reference)
```
to
```
Compiler error: ### mwcceppc.exe Compiler:
#      In: ctx.c
#    From: code.c
# ---------------
#       3:     int a error; 
#   Error: ^
#   (10123) ';' expected
### mwcceppc.exe Compiler:
#      In: src.c
# --------------
#       5:     wp = 0 error; 
#   Error: ^
#   (10123) ';' expected
```
