### PR TITLE
Switch agbcc to follow pret's fork

### DIFF
--- a/backend/compilers/download.py
+++ b/backend/compilers/download.py
@@ -264,7 +264,7 @@ def download_gba():
         download_tar(url=url, dest_name=dest)
 
     download_agbcc(
-        "https://github.com/ethteck/agbcc/releases/download/master/agbcc.tar.gz",
+        "https://github.com/pret/agbcc/releases/download/release/agbcc.tar.gz",
         "agbcc",
     )
     download_agbcc(


### PR DESCRIPTION
Fixes #820
Adds `-fprologue-bugfix` and whatever else is new in agbcc since January 2022