### PR TITLE
LEGO Island preset - pass /TP (C++) compiler flag

### DIFF
--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -1767,7 +1767,7 @@ _all_presets = [
         "-x c++ -O2 -gstabs -fno-exceptions -finline-functions",
     ),
     # Windows
-    Preset("LEGO Island", MSVC42, "/W3 /GX /O2"),
+    Preset("LEGO Island", MSVC42, "/W3 /GX /O2 /TP"),
     Preset("Touhou 6 (C)", MSVC70, "/MT /G5 /GS /Od /Oi /Ob1"),
     Preset("Touhou 6 (C++)", MSVC70, "/MT /G5 /GS /Od /Oi /Ob1 /TP"),
 ]


### PR DESCRIPTION
LEGO Island is C++ code.

I took what was in the original CMakeLists file (https://github.com/isledecomp/isle/blob/master/CMakeLists.txt) but I guess CMake automatically puts in this flag. Other flags like the /Gz or something allowing for __stdcalls might be necessary in the future, but for now this is important.