### PR TITLE
add GCC 2.8.0-mipsel for PSX

### DIFF
--- a/backend/compilers/download.py
+++ b/backend/compilers/download.py
@@ -593,7 +593,7 @@ def download_ps1():
 
     # vanilla gcc + maspsx patch
 
-    old_gcc_base_url = "https://github.com/decompals/old-gcc/releases/download/0.2"
+    old_gcc_base_url = "https://github.com/decompals/old-gcc/releases/download/0.3"
     old_gcc_urls = {
         "gcc2.6.3-psx": f"{old_gcc_base_url}/gcc-2.6.3-psx.tar.gz",
         "gcc2.6.3": f"{old_gcc_base_url}/gcc-2.6.3.tar.gz",
@@ -601,6 +601,7 @@ def download_ps1():
         "gcc2.7.2": f"{old_gcc_base_url}/gcc-2.7.2.tar.gz",
         "gcc2.7.2.1": f"{old_gcc_base_url}/gcc-2.7.2.1.tar.gz",
         "gcc2.7.2.3": f"{old_gcc_base_url}/gcc-2.7.2.3.tar.gz",
+        "gcc2.8.0": f"{old_gcc_base_url}/gcc-2.8.0.tar.gz",
         "gcc2.8.1": f"{old_gcc_base_url}/gcc-2.8.1.tar.gz",
         "gcc2.91.66": f"{old_gcc_base_url}/gcc-2.91.66.tar.gz",
         "gcc2.95.2": f"{old_gcc_base_url}/gcc-2.95.2.tar.gz",
@@ -612,6 +613,7 @@ def download_ps1():
         "gcc2.7.2": "gcc2.7.2-mipsel",
         "gcc2.7.2.1": "gcc2.7.2.1-mipsel",
         "gcc2.7.2.3": "gcc2.7.2.3-mipsel",
+        "gcc2.8.0": "gcc2.8.0-mipsel",
         "gcc2.8.1": "gcc2.8.1-mipsel",
         "gcc2.91.66": "gcc2.91.66-mipsel",
         "gcc2.95.2": "gcc2.95.2-mipsel",

--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -387,6 +387,12 @@ GCC2723_MIPSEL = GCCPS1Compiler(
     cc=PS1_GCC,
 )
 
+GCC280_MIPSEL = GCCPS1Compiler(
+    id="gcc2.8.0-mipsel",
+    platform=PS1,
+    cc=PS1_GCC,
+)
+
 GCC281_MIPSEL = GCCPS1Compiler(
     id="gcc2.8.1-mipsel",
     platform=PS1,
@@ -1141,6 +1147,7 @@ _all_compilers: List[Compiler] = [
     GCC2672MIPSEL,
     GCC2721_MIPSEL,
     GCC2723_MIPSEL,
+    GCC280_MIPSEL,
     GCC281_MIPSEL,
     GCC29166_MIPSEL,
     GCC2952_MIPSEL,

--- a/frontend/src/lib/i18n/locales/en/compilers.json
+++ b/frontend/src/lib/i18n/locales/en/compilers.json
@@ -38,6 +38,7 @@
     "gcc2.7.2sn": "GCC 2.7.2 (SN)",
     "gcc2.7.2snew": "GCC 2.7.2 (SN, experimental)",
     "gcc2.8.1sn-cxx": "GCC 2.8.1 (SN) (C++)",
+    "gcc2.8.0": "GCC 2.8.0",
     "gcc2.8.1": "GCC 2.8.1",
     "gcc4.4.0-mips64-elf": "GCC 4.4.0 (mips64-elf)",
     "ido5.3_irix": "IDO 5.3",


### PR DESCRIPTION
One more compiler to the collection =)

Co-authored-by: @mkst 