### PR TITLE
Use 'base_compiler' functionality to dedupe macosx compilers

### DIFF
--- a/backend/compilers/download.py
+++ b/backend/compilers/download.py
@@ -189,34 +189,16 @@ def download_macosx():
         dest_name="gcc-5370",
     )
     download_tar(
-        url="https://github.com/ChrisNonyminus/powerpc-darwin-cross/releases/download/initial/gcc-5370.tar.gz",
-        platform_id="macosx",
-        dl_name="gcc-5370-cpp.tar.gz",
-        dest_name="gcc-5370-cpp",
-    )
-    download_tar(
         url="https://github.com/ChrisNonyminus/powerpc-darwin-cross/releases/download/initial/gcc-5026.tar.gz",
         platform_id="macosx",
         dl_name="gcc-5026.tar.gz",
         dest_name="gcc-5026",
     )
     download_tar(
-        url="https://github.com/ChrisNonyminus/powerpc-darwin-cross/releases/download/initial/gcc-5026.tar.gz",
-        platform_id="macosx",
-        dl_name="gcc-5026-cpp.tar.gz",
-        dest_name="gcc-5026-cpp",
-    )
-    download_tar(
         url="https://github.com/ChrisNonyminus/powerpc-darwin-cross/releases/download/initial/gcc-5363.tar.gz",
         platform_id="macosx",
         dl_name="gcc-5363.tar.gz",
         dest_name="gcc-5363",
-    )
-    download_tar(
-        url="https://github.com/ChrisNonyminus/powerpc-darwin-cross/releases/download/initial/gcc-5363.tar.gz",
-        platform_id="macosx",
-        dl_name="gcc-5363-cpp.tar.gz",
-        dest_name="gcc-5363-cpp",
     )
     download_tar(
         url="https://github.com/ChrisNonyminus/powerpc-darwin-cross/releases/download/initial/gcc3-1041.tar.gz",
@@ -231,11 +213,8 @@ def download_macosx():
     )
     for compiler in [
         "gcc-5370",
-        "gcc-5370-cpp",
         "gcc-5026",
-        "gcc-5026-cpp",
         "gcc-5363",
-        "gcc-5363-cpp",
         "gcc3-1041",
     ]:
         shutil.copy(

--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -699,6 +699,7 @@ XCODE_GCC401_CPP = GCCCompiler(
     id="gcc-5370-cpp",
     platform=MACOSX,
     cc=GCC_CC1PLUS,
+    base_compiler=XCODE_GCC401_C,
 )
 
 XCODE_24_C = GCCCompiler(
@@ -711,6 +712,7 @@ XCODE_24_CPP = GCCCompiler(
     id="gcc-5363-cpp",
     platform=MACOSX,
     cc=GCC_CC1PLUS_ALT,
+    base_compiler=XCODE_24_C,
 )
 
 XCODE_GCC400_C = GCCCompiler(
@@ -723,6 +725,7 @@ XCODE_GCC400_CPP = GCCCompiler(
     id="gcc-5026-cpp",
     platform=MACOSX,
     cc=GCC_CC1PLUS_ALT,
+    base_compiler=XCODE_GCC400_C,
 )
 
 PBX_GCC3 = GCCCompiler(


### PR DESCRIPTION
Currently untested, but looks like it should work.