### PR TITLE
API - Allow filtering scratches based on preset

### DIFF
--- a/backend/coreapp/serializers.py
+++ b/backend/coreapp/serializers.py
@@ -242,6 +242,7 @@ class TerseScratchSerializer(ScratchSerializer):
             "project",
             "project_function",
             "parent",
+            "preset",
         ]
 
 

--- a/backend/coreapp/views/scratch.py
+++ b/backend/coreapp/views/scratch.py
@@ -294,7 +294,7 @@ class ScratchViewSet(
 ):
     queryset = Scratch.objects.all()
     pagination_class = ScratchPagination
-    filter_fields = ["platform", "compiler"]
+    filterset_fields = ["platform", "compiler", "preset"]
     filter_backends = [
         django_filters.rest_framework.DjangoFilterBackend,
         filters.SearchFilter,


### PR DESCRIPTION
`filter`ing is broken at the moment (see https://stackoverflow.com/a/73887435/7290888).

This doesnt currently work:
```
curl "https://decomp.me/api/scratch?compiler=ido5.3" | jq
```

This PR adds the ability to filter scratches based on the preset (also adds preset to the terse serializer)
```
curl "http://localhost:8000/api/scratch?preset=AeroGauge"
# i.e.
curl "https://decomp.me/api/scratch?preset=AeroGauge" | jq
```

Closes #859.
