### PR TITLE
Ensure compiler.path exists before mounting it

### DIFF
--- a/backend/coreapp/compiler_wrapper.py
+++ b/backend/coreapp/compiler_wrapper.py
@@ -175,6 +175,10 @@ class CompilerWrapper:
             if compiler.is_ido and "-KPIC" in compiler_flags:
                 cc_cmd = cc_cmd.replace("-non_shared", "")
 
+            if compiler.platform != platforms.DUMMY and not compiler.path.exists():
+                logging.warning("%s does not exist, creating it!", compiler.path)
+                compiler.path.mkdir(parents=True)
+
             # Run compiler
             try:
                 st = round(time.time() * 1000)


### PR DESCRIPTION
With this change:

**server logs:**
```
decompme-backend-1   | 21:23:40 WARNING /backend/compilers/n64/ido5.3 does not exist, creating it!
```
**user message:**
```
/bin/bash: line 1: /backend/compilers/n64/ido5.3/cc: No such file or directory
```

And `download.py` will run successfully because there isn't a file called `/backend/compilers/n64/ido5.3`.

Closes #862.