### PR TITLE
Add "Metal Gear Solid (overlays)" preset

### DIFF
--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -1384,6 +1384,11 @@ _all_presets = [
         "-O2 -G8",
     ),
     Preset(
+        "Metal Gear Solid (overlays)",
+        PSYQ44,
+        "-O2 -G0 -Wall",
+    ),
+    Preset(
         "vib-ribbon",
         GCC29166_MIPSEL,
         "-Os -G4 -mel -g0 -mno-abicalls -fno-builtin -fsigned-char -fpeephole -ffunction-cse -fkeep-static-consts -fpcc-struct-return -fcommon -fgnu-linker -fargument-alias -msplit-addresses -mgas -mgpOPT -mgpopt -msoft-float -gcoff",


### PR DESCRIPTION
Add a new "Metal Gear Solid (overlays)" preset that uses `-G0` flag instead of `-G8` flag, as was the case in the "Metal Gear Solid" preset  (preset for the main executable). 

Additionally add `-Wall` flag, because we use it very often in our scratches.