### PR TITLE
Refactor libraries/download.py

### DIFF
--- a/backend/libraries/download.py
+++ b/backend/libraries/download.py
@@ -37,7 +37,7 @@ def get_library(
     if "git" in download_info:
         # Download with git. Get url and ref, and download using git clone.
         url = download_info["git"]["url"]
-        branch = download_info["git"]["branch"]
+        branch = str(download_info["git"]["branch"])
         logger.debug("Using git to download library at %s branch %s", url, branch)
 
         # Recreate repository if force is set.

--- a/backend/libraries/download.py
+++ b/backend/libraries/download.py
@@ -68,6 +68,15 @@ def get_library(
         )
         return False
 
+    include_dir = library_dir / "include"
+    if not include_dir.is_dir():
+        logger.error(
+            f"Failed to download {library_name} {library_version}: {include_dir} does not exist or isn't a directory."
+        )
+        return False
+
+    return True
+
 
 def download_libraries(args, libraries_config):
     to_download = []

--- a/backend/libraries/download.py
+++ b/backend/libraries/download.py
@@ -47,7 +47,7 @@ def get_library(
 
         # Make sure the git repo is initialized. If it already exists, this is
         # essentially a noop.
-        subprocess.run(["git", "init", str(library_dir)], check=True)
+        subprocess.run(["git", "init", "-b", branch, str(library_dir)], check=True)
 
         # Fetch the ref we want to download, and git reset --hard to it.
         subprocess.run(

--- a/backend/libraries/download.py
+++ b/backend/libraries/download.py
@@ -113,9 +113,6 @@ def main():
         help="Directory where libraries will be stored",
     )
     parser.add_argument(
-        "--libraries", type=str, nargs="+", help="Only run for these libraries"
-    )
-    parser.add_argument(
         "--threads", type=int, default=4, help="Number of download threads to use"
     )
     parser.add_argument("--verbose", action="store_true", help="Enable DEBUG log level")

--- a/backend/libraries/download.py
+++ b/backend/libraries/download.py
@@ -108,7 +108,7 @@ def main():
     )
     parser.add_argument(
         "--libraries-dir",
-        type=str,
+        type=Path,
         default=None,
         help="Directory where libraries will be stored",
     )
@@ -121,9 +121,7 @@ def main():
     if args.verbose:
         logger.setLevel("DEBUG")
 
-    if args.libraries_dir:
-        args.libraries_dir = Path(args.libraries_dir)
-    else:
+    if args.libraries_dir == None:
         args.libraries_dir = (
             Path(os.path.dirname(os.path.realpath(__file__))).parent / "libraries"
         )

--- a/backend/libraries/download.py
+++ b/backend/libraries/download.py
@@ -122,9 +122,7 @@ def main():
         logger.setLevel("DEBUG")
 
     if args.libraries_dir == None:
-        args.libraries_dir = (
-            Path(os.path.dirname(os.path.realpath(__file__))).parent / "libraries"
-        )
+        args.libraries_dir = Path(os.path.dirname(os.path.realpath(__file__)))
 
     libraries_yaml = (
         Path(os.path.dirname(os.path.realpath(__file__))) / f"libraries.yaml"

--- a/backend/libraries/libraries.yaml
+++ b/backend/libraries/libraries.yaml
@@ -2,7 +2,7 @@ directx:
   '5.0':
     git:
       url: https://github.com/roblabla/directx-headers
-      branch: 5.0
+      branch: '5.0'
   '8.0':
     git:
       url: https://github.com/roblabla/directx-headers


### PR DESCRIPTION
This PR:

- avoids the warning about git init without naming the branch when downloading libs:
```
hint: Using 'master' as the name for the initial branch. This default branch name
hint: is subject to change. To configure the initial branch name to use in all
hint: of your new repositories, which will suppress this warning, call:
hint: 
hint:     git config --global init.defaultBranch <name>
hint: 
hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
hint: 'development'. The just-created branch can be renamed via this command:
hint: 
hint:     git branch -m <name>
```

- Removes an unused `--libraries` argument
- Adds an error if the downloaded repository does not contain an `include` directory

Along with some misc cleanup of the script.