### PR TITLE
Devkitpro be gone

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,10 +43,11 @@ jobs:
 
           sudo apt-get install \
             binutils-aarch64-linux-gnu \
+            binutils-arm-none-eabi \
+            binutils-djgpp \
             binutils-mips-linux-gnu \
             binutils-powerpc-linux-gnu \
             binutils-sh-elf \
-            binutils-djgpp \
             dos2unix \
             libprotobuf-dev \
             libnl-route-3-dev \
@@ -84,24 +85,6 @@ jobs:
         run: |-
           cd backend
           poetry run python3 libraries/download.py
-      - name: Install dkp dependencies (ppc)
-        run: |-
-          mkdir -p bin
-          docker run \
-            -v $(pwd)/bin:/tmp/bin \
-            --entrypoint /bin/sh \
-            devkitpro/devkitppc:20210726 \
-            -c "cp /opt/devkitpro/devkitPPC/bin/powerpc* /tmp/bin"
-          sudo mv bin/powerpc* /usr/bin/
-      - name: Install dkp dependencies (arm)
-        run: |-
-          mkdir -p bin
-          docker run \
-            -v $(pwd)/bin:/tmp/bin \
-            --entrypoint /bin/sh \
-            devkitpro/devkitarm:20210726 \
-            -c "cp /opt/devkitpro/devkitARM/bin/arm* /tmp/bin"
-          sudo mv bin/arm* /usr/bin/
       - name: Install wibo
         run: |-
           wget https://github.com/decompals/WiBo/releases/download/0.6.4/wibo && chmod +x wibo && sudo cp wibo /usr/bin/

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -35,6 +35,7 @@ FROM base AS build
 
 RUN apt-get -y update && apt-get install -y \
     binutils-aarch64-linux-gnu \
+    binutils-arm-none-eabi \
     binutils-djgpp \
     binutils-mips-linux-gnu \
     binutils-powerpc-linux-gnu \
@@ -89,12 +90,6 @@ RUN if [ "${ENABLE_SATURN_SUPPORT}" = "YES" ]; then \
     apt-get update && \
     apt-get install -y dosemu2; \
     fi
-
-# gc/wii specifics
-COPY --from=devkitpro/devkitppc:20210726 /opt/devkitpro/devkitPPC/bin/powerpc* /usr/bin/
-
-# nds specifics
-COPY --from=devkitpro/devkitarm:20210726 /opt/devkitpro/devkitARM/bin/arm* /usr/bin/
 
 # msdos specific
 RUN if [ "${ENABLE_MSDOS_SUPPORT}" = "YES" ]; then \

--- a/backend/coreapp/platforms.py
+++ b/backend/coreapp/platforms.py
@@ -605,8 +605,6 @@ NDS_ARM9 = Platform(
     assemble_cmd='sed "$INPUT" -e "s/;/;@/" | arm-none-eabi-as -march=armv5te -mthumb -o "$OUTPUT"',
     objdump_cmd="arm-none-eabi-objdump",
     nm_cmd="arm-none-eabi-nm",
-
-
     asm_prelude="""
 .macro glabel label
     .global \label

--- a/backend/coreapp/platforms.py
+++ b/backend/coreapp/platforms.py
@@ -447,9 +447,9 @@ GC_WII = Platform(
     name="GameCube / Wii",
     description="PowerPC",
     arch="ppc",
-    assemble_cmd='powerpc-eabi-as -mgekko -o "$OUTPUT" "$INPUT"',
-    objdump_cmd="powerpc-eabi-objdump -M broadway",
-    nm_cmd="powerpc-eabi-nm",
+    assemble_cmd='powerpc-linux-gnu-as -mgekko -o "$OUTPUT" "$INPUT"',
+    objdump_cmd="powerpc-linux-gnu-objdump -M broadway",
+    nm_cmd="powerpc-linux-gnu-nm",
     asm_prelude="""
 .macro glabel label
     .global \label
@@ -605,6 +605,8 @@ NDS_ARM9 = Platform(
     assemble_cmd='sed "$INPUT" -e "s/;/;@/" | arm-none-eabi-as -march=armv5te -mthumb -o "$OUTPUT"',
     objdump_cmd="arm-none-eabi-objdump",
     nm_cmd="arm-none-eabi-nm",
+
+
     asm_prelude="""
 .macro glabel label
     .global \label


### PR DESCRIPTION
Per the discord conversation. It doesn't look much work to remove devkitpro - we are only using as, objdump and nm, and those utilities are all available to install in ubuntu. For the `arm` platform we already install those binaries (but overwrite them with devkitpro ones - at least in docker, unsure what the production box is using).

I created a GC/Wii scratch (and a Nintendo DS one) locally to test based on a couple of scratches from the live site. Not sure how else to sanity test this change?