### PR TITLE
Add ProDG compilers (GameCube)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
           poetry run python3 libraries/download.py
       - name: Install wibo
         run: |-
-          wget https://github.com/decompals/WiBo/releases/download/0.6.4/wibo && chmod +x wibo && sudo cp wibo /usr/bin/
+          wget https://github.com/decompals/wibo/releases/download/0.6.7/wibo && chmod +x wibo && sudo cp wibo /usr/bin/
 
       - name: Run backend tests
         run: |-

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -63,7 +63,7 @@ RUN curl -sSL https://install.python-poetry.org/ | \
 
 COPY --from=nsjail /nsjail/nsjail /bin/nsjail
 
-COPY --from=ghcr.io/decompals/wibo:0.6.4 /usr/local/sbin/wibo /usr/bin/
+COPY --from=ghcr.io/decompals/wibo:0.6.7 /usr/local/sbin/wibo /usr/bin/
 
 # windows compilers need i386 wine
 

--- a/backend/compilers/compilers.linux.yaml
+++ b/backend/compilers/compilers.linux.yaml
@@ -21,6 +21,9 @@ gc_wii:
   - mwcc_242_81r
   - mwcc_233_163e
   - mwcc_42_127
+  - prodg_35
+  - prodg_37
+  - prodg_393
 
 n64:
   - gcc2.7.2kmc

--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -891,8 +891,8 @@ MWCC_43_213 = MWCCCompiler(
 
 PRODG_CC = (
     'cpp -E "${INPUT}" -o "${INPUT}".i && '
-    '${WIBO} ${COMPILER_DIR}/cc1.exe -quiet ${COMPILER_FLAGS} -o ${OUTPUT}.s ${INPUT}.i && '
-    '${WIBO} ${COMPILER_DIR}/NgcAs.exe ${OUTPUT}.s -o ${OUTPUT}'
+    "${WIBO} ${COMPILER_DIR}/cc1.exe -quiet ${COMPILER_FLAGS} -o ${OUTPUT}.s ${INPUT}.i && "
+    "${WIBO} ${COMPILER_DIR}/NgcAs.exe ${OUTPUT}.s -o ${OUTPUT}"
 )
 
 PRODG_35 = GCCCompiler(

--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -889,6 +889,30 @@ MWCC_43_213 = MWCCCompiler(
     cc=MWCCEPPC_CC,
 )
 
+PRODG_CC = (
+    'cpp -E "${INPUT}" -o "${INPUT}".i && '
+    '${WIBO} ${COMPILER_DIR}/cc1.exe -quiet ${COMPILER_FLAGS} -o ${OUTPUT}.s ${INPUT}.i && '
+    '${WIBO} ${COMPILER_DIR}/NgcAs.exe ${OUTPUT}.s -o ${OUTPUT}'
+)
+
+PRODG_35 = GCCCompiler(
+    id="prodg_35",
+    platform=GC_WII,
+    cc=PRODG_CC,
+)
+
+PRODG_37 = GCCCompiler(
+    id="prodg_37",
+    platform=GC_WII,
+    cc=PRODG_CC,
+)
+
+PRODG_393 = GCCCompiler(
+    id="prodg_393",
+    platform=GC_WII,
+    cc=PRODG_CC,
+)
+
 # NDS_ARM9
 MWCCARM_CC = '${WINE} "${COMPILER_DIR}/mwccarm.exe" -pragma "msg_show_realref off" -c -proc arm946e -nostdinc -stderr ${COMPILER_FLAGS} -o "${OUTPUT}" "${INPUT}"'
 
@@ -1263,6 +1287,9 @@ _all_compilers: List[Compiler] = [
     MWCC_43_151,
     MWCC_43_172,
     MWCC_43_213,
+    PRODG_35,
+    PRODG_37,
+    PRODG_393,
     # NDS
     MWCC_20_72,
     MWCC_20_79,

--- a/frontend/src/lib/i18n/locales/en/compilers.json
+++ b/frontend/src/lib/i18n/locales/en/compilers.json
@@ -109,6 +109,10 @@
     "mwcc_43_213": "4.3 build 213 (Wii MW 1.7)",
     "mwcppc_23": "MWCPPC 2.3 (CodeWarrior Pro 5)",
     "mwcppc_24": "MWCPPC 2.4 (CodeWarrior Pro 6)",
+    "prodg_35": "ProDG 3.5 (gcc 2.95.2)",
+    "prodg_37": "ProDG 3.7 (gcc 2.95.2)",
+    "prodg_393": "ProDG 3.9.3 (gcc 2.95.3)",
+
     "old_agbcc": "old_agbcc",
     "gcc-5370": "GCC 4.0.1 (Xcode 2.5) (C)",
     "gcc-5370-cpp": "GCC 4.0.1 (Xcode 2.5) (C++)",


### PR DESCRIPTION
- [ ] ~~ngccc.exe working in decomp.me (3.9.3 crashes under wine, all fail under wibo)~~
- [ ] ~~ngccc.exe 3.9.3 working under wibo (see https://github.com/decompals/wibo/issues/58)~~

Using ngccc.exe is too much trouble (especially given there are no known active projects using the ProDG compilers). We can try to use ngccc.exe another time if the current approach becomes an issue for anyone.

Closes #895.