### PR TITLE
Update Frogger's compiler preset.

### DIFF
--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -1409,7 +1409,7 @@ _all_presets = [
     Preset(
         "Frogger",
         GCC263_MIPSEL,
-        "-O3 -G8 -gcoff -w -fpeephole -ffunction-cse -fpcc-struct-return -fcommon -fverbose-asm -funsigned-char -msoft-float -g -Wa,--expand-div",
+        "-O3 -G0 -gcoff -w -fpeephole -ffunction-cse -fpcc-struct-return -fcommon -fverbose-asm -funsigned-char -msoft-float -g -Wa,--expand-div",
     ),
     Preset(
         "Legacy of Kain: Soul Reaver",

--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -1408,8 +1408,8 @@ _all_presets = [
     ),
     Preset(
         "Frogger",
-        GCC260_MIPSEL,
-        "-O3 -G0 -gcoff",
+        GCC263_MIPSEL,
+        "-O3 -G8 -gcoff -w -fpeephole -ffunction-cse -fpcc-struct-return -fcommon -fverbose-asm -funsigned-char -msoft-float -g -Wa,--expand-div",
     ),
     Preset(
         "Legacy of Kain: Soul Reaver",


### PR DESCRIPTION
More investigation was done, and it was discovered that there was an official release of PsyQ GCC 2.6.3. However, it has not surfaced online. I have compiled a Win32 version which is compatible with the original PsyQ toolchain, but this is likely unnecessary for decomp.me