### PR TITLE
Fix permuter import

### DIFF
--- a/backend/coreapp/serializers.py
+++ b/backend/coreapp/serializers.py
@@ -208,7 +208,7 @@ class ScratchCreateSerializer(serializers.Serializer[None]):
         if "preset" in data:
             preset: Preset = data["preset"]
             # Preset dictates platform
-            data["platform"] = preset.platform
+            data["platform"] = platforms.from_id(preset.platform)
 
             if "compiler" not in data or not data["compiler"]:
                 data["compiler"] = preset.compiler
@@ -248,6 +248,7 @@ class ScratchCreateSerializer(serializers.Serializer[None]):
                     raise serializers.ValidationError(
                         f"Compiler {compiler.id} is not compatible with platform {platform.id}"
                     )
+                data["platform"] = platform
         return data
 
 

--- a/backend/coreapp/tests/test_scratch.py
+++ b/backend/coreapp/tests/test_scratch.py
@@ -105,7 +105,6 @@ nop
         scratch = self.create_scratch(scratch_dict)
         self.assertEqual(scratch.max_score, 200)
 
-
     @requiresCompiler(IDO71)
     def test_import_scratch(self) -> None:
         """

--- a/backend/coreapp/tests/test_scratch.py
+++ b/backend/coreapp/tests/test_scratch.py
@@ -106,6 +106,24 @@ nop
         self.assertEqual(scratch.max_score, 200)
 
 
+    @requiresCompiler(IDO71)
+    def test_import_scratch(self) -> None:
+        """
+        Ensure that creating a scratch created via permuter import.py is successful
+        """
+        scratch_dict = {
+            "name": "imported_function",
+            "target_asm": ".text\nglabel imported_function\njr $ra\nnop",
+            "context": "/* context */",
+            "source_code": "void imported_function(void) {}",
+            "compiler": IDO71.id,
+            "compiler_flags": "-O2",
+            "diff_label": "imported_function",
+        }
+        scratch = self.create_scratch(scratch_dict)
+        self.assertEqual(scratch.name, "imported_function")
+
+
 class ScratchModificationTests(BaseTestCase):
     @requiresCompiler(GCC281PM, IDO53)
     def test_update_scratch_score(self) -> None:

--- a/backend/coreapp/views/scratch.py
+++ b/backend/coreapp/views/scratch.py
@@ -185,11 +185,7 @@ def create_scratch(data: Dict[str, Any], allow_project: bool = False) -> Scratch
     create_ser.is_valid(raise_exception=True)
     data = create_ser.validated_data
 
-    platform: Optional[Platform] = None
-    given_platform = data.get("platform")
-    if given_platform:
-        platform = platforms.from_id(given_platform)
-
+    platform: Optional[Platform] = data.get("platform")
     compiler = compilers.from_id(data["compiler"])
     project = data.get("project")
     rom_address = data.get("rom_address")


### PR DESCRIPTION
Fixes #904. The issue was that the `platform` value was coming back as a `str` in some code paths and a `Platform` in others. Now it should come back as a `Platform`.

Broken test run: https://github.com/decompme/decomp.me/actions/runs/6697436478/job/18197319501