### PR TITLE
Add gcc 2.5.7 for ps1

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -65,6 +65,10 @@ COPY --from=nsjail /nsjail/nsjail /bin/nsjail
 
 COPY --from=ghcr.io/decompals/wibo:0.6.8 /usr/local/sbin/wibo /usr/bin/
 
+RUN add-apt-repository -y ppa:dosemu2/ppa && \
+    apt-get update && \
+    apt-get install -y dosemu2
+
 # windows compilers need i386 wine
 
 ARG ENABLE_MSDOS_SUPPORT
@@ -76,14 +80,6 @@ RUN if [ "${ENABLE_MSDOS_SUPPORT}" = "YES" ] || \
     dpkg --add-architecture i386 && apt-get update && \
     apt-get install -y -o APT::Immediate-Configure=false \
         wine; \
-    fi
-
-ARG ENABLE_SATURN_SUPPORT
-# install dosemu2 for saturn
-RUN if [ "${ENABLE_SATURN_SUPPORT}" = "YES" ]; then \
-    add-apt-repository -y ppa:dosemu2/ppa && \
-    apt-get update && \
-    apt-get install -y dosemu2; \
     fi
 
 # msdos specific
@@ -127,6 +123,7 @@ ARG ENABLE_N3DS_SUPPORT
 ARG ENABLE_N64_SUPPORT
 ARG ENABLE_NDS_ARM9_SUPPORT
 ARG ENABLE_PS1_SUPPORT
+ARG ENABLE_SATURN_SUPPORT
 ARG ENABLE_SWITCH_SUPPORT
 
 ENV ENABLE_GBA_SUPPORT=${ENABLE_GBA_SUPPORT}

--- a/backend/compilers/compilers.linux.yaml
+++ b/backend/compilers/compilers.linux.yaml
@@ -92,6 +92,7 @@ ps1:
   - psyq4.4
   - psyq4.5
   - psyq4.6
+  - gcc2.5.7-psx
   - gcc2.6.3-psx
   - gcc2.6.0-mipsel
   - gcc2.6.3-mipsel

--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -349,7 +349,13 @@ PSYQ46 = GCCPS1Compiler(
 
 PS1_GCC = (
     'cpp -E -lang-c -nostdinc "${INPUT}" -o "${INPUT}".i && '
-    '${COMPILER_DIR}/gcc -c -pipe -B${COMPILER_DIR}/ ${COMPILER_FLAGS} -o "${OUTPUT}" "${INPUT}.i"'
+    '${COMPILER_DIR}/gcc -c -B${COMPILER_DIR}/ ${COMPILER_FLAGS} -o "${OUTPUT}" "${INPUT}.i"'
+)
+
+GCC257_PSX = GCCPS1Compiler(
+    id="gcc2.5.7-psx",
+    platform=PS1,
+    cc=PS1_GCC,
 )
 
 GCC263_PSX = GCCPS1Compiler(
@@ -1180,6 +1186,7 @@ _all_compilers: List[Compiler] = [
     PSYQ44,
     PSYQ45,
     PSYQ46,
+    GCC257_PSX,
     GCC263_PSX,
     GCC260_MIPSEL,
     GCC263_MIPSEL,

--- a/frontend/src/lib/i18n/locales/en/compilers.json
+++ b/frontend/src/lib/i18n/locales/en/compilers.json
@@ -122,6 +122,7 @@
     "gcc-5026-cpp": "GCC 4.0.0 (Xcode 2.1) (C++)",
     "gcc3-1041": "GCC 3.1 (Mac OS 10.1.4) (C)",
 
+    "gcc2.5.7-psx": "gcc 2.5.7-psx + maspsx",
     "gcc2.6.3-psx": "gcc 2.6.3-psx + maspsx",
     "gcc2.6.0-mipsel": "gcc 2.6.0 + maspsx",
     "gcc2.6.3-mipsel": "gcc 2.6.3 + maspsx",


### PR DESCRIPTION
Also updating the Dockerfile so we always install dosemu.

Note gcc 2.5.7 doesnt support the `-pipe` argument (`-pipe` uses pipes between processes rather than using temporary files) hence it's been removed.