### PR TITLE
Use wine for ProDG compilers

### DIFF
--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -864,7 +864,7 @@ MWCC_43_213 = MWCCCompiler(
 
 PRODG_CC = (
     'cpp -E "${INPUT}" -o "${INPUT}".i && '
-    "${WIBO} ${COMPILER_DIR}/cc1.exe -quiet ${COMPILER_FLAGS} -o ${OUTPUT}.s ${INPUT}.i && "
+    "${WINE} ${COMPILER_DIR}/cc1.exe -quiet ${COMPILER_FLAGS} -o ${OUTPUT}.s ${INPUT}.i && "
     "${WIBO} ${COMPILER_DIR}/NgcAs.exe ${OUTPUT}.s -o ${OUTPUT}"
 )
 


### PR DESCRIPTION
Until https://github.com/decompals/wibo/issues/64 is fixed, let's switch back to wine so these compilers can be used.