### PR TITLE
Singularise 'libraries' and 'compilers' api endpoints

### DIFF
--- a/backend/coreapp/urls.py
+++ b/backend/coreapp/urls.py
@@ -1,8 +1,8 @@
 from django.urls import path
 
 from coreapp.views import (
-    compilers,
-    libraries,
+    compiler,
+    library,
     platform,
     preset,
     stats,
@@ -12,8 +12,8 @@ from coreapp.views import (
 )
 
 urlpatterns = [
-    path("compilers", compilers.CompilersDetail.as_view(), name="compilers"),
-    path("libraries", libraries.LibrariesDetail.as_view(), name="libraries"),
+    path("compiler", compiler.CompilerDetail.as_view(), name="compiler"),
+    path("library", library.LibraryDetail.as_view(), name="library"),
     path("platform", platform.PlatformDetail.as_view(), name="platform"),
     path(
         "platform/<slug:id>",
@@ -36,4 +36,7 @@ urlpatterns = [
         user.UserScratchList.as_view(),
         name="user-scratches",
     ),
+    # TODO: remove
+    path("compilers", compiler.CompilerDetail.as_view(), name="compilers"),
+    path("libraries", library.LibraryDetail.as_view(), name="libraries"),
 ]

--- a/backend/coreapp/views/compiler.py
+++ b/backend/coreapp/views/compiler.py
@@ -13,7 +13,7 @@ from ..decorators.django import condition
 boot_time = now()
 
 
-class CompilersDetail(APIView):
+class CompilerDetail(APIView):
     @staticmethod
     def compilers_json() -> Dict[str, Dict[str, object]]:
         return {
@@ -45,7 +45,7 @@ class CompilersDetail(APIView):
     def get(self, request: Request) -> Response:
         return Response(
             {
-                "compilers": CompilersDetail.compilers_json(),
-                "platforms": CompilersDetail.platforms_json(),
+                "compilers": CompilerDetail.compilers_json(),
+                "platforms": CompilerDetail.platforms_json(),
             }
         )

--- a/backend/coreapp/views/library.py
+++ b/backend/coreapp/views/library.py
@@ -12,7 +12,7 @@ from ..decorators.django import condition
 boot_time = now()
 
 
-class LibrariesDetail(APIView):
+class LibraryDetail(APIView):
     @staticmethod
     def libraries_json() -> list[dict[str, object]]:
         return [
@@ -28,6 +28,6 @@ class LibrariesDetail(APIView):
     def get(self, request: Request) -> Response:
         return Response(
             {
-                "libraries": LibrariesDetail.libraries_json(),
+                "libraries": LibraryDetail.libraries_json(),
             }
         )

--- a/backend/coreapp/views/platform.py
+++ b/backend/coreapp/views/platform.py
@@ -1,6 +1,6 @@
 from coreapp import compilers
 from coreapp.models.preset import Preset
-from coreapp.views.compilers import CompilersDetail
+from coreapp.views.compiler import CompilerDetail
 from django.utils.timezone import now
 from rest_framework.decorators import api_view
 from rest_framework.request import Request
@@ -21,7 +21,7 @@ class PlatformDetail(APIView):
     def get(self, request: Request) -> Response:
         return Response(
             {
-                "platforms": CompilersDetail.platforms_json(
+                "platforms": CompilerDetail.platforms_json(
                     include_presets=False, include_num_scratches=True
                 ),
             }

--- a/frontend/src/app/(navfooter)/new/page.tsx
+++ b/frontend/src/app/(navfooter)/new/page.tsx
@@ -8,7 +8,7 @@ export const metadata = {
 }
 
 export default async function NewScratchPage() {
-    const compilers = await get("/compilers")
+    const compilers = await get("/compiler")
 
     return <main>
         <h1 className="text-2xl font-semibold tracking-tight text-gray-12 md:text-3xl">Start a new scratch</h1>

--- a/frontend/src/components/PlatformSelect/PlatformName.tsx
+++ b/frontend/src/components/PlatformSelect/PlatformName.tsx
@@ -16,7 +16,7 @@ export default function PlatformName({ platform }: Props) {
                 description: string
             }
         }
-    }>("/compilers", api.get)
+    }>("/compiler", api.get)
 
     return <>
         <Link href={"/platform/" + platform}>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -243,7 +243,7 @@ export function useCompilation(scratch: Scratch | null, autoRecompile = true, au
 }
 
 export function usePlatforms(): Record<string, Platform> {
-    const { data } = useSWR<{ "platforms": Record<string, Platform> }>("/compilers", get, {
+    const { data } = useSWR<{ "platforms": Record<string, Platform> }>("/compiler", get, {
         refreshInterval: 0,
         revalidateOnFocus: false,
         suspense: true, // TODO: remove
@@ -254,7 +254,7 @@ export function usePlatforms(): Record<string, Platform> {
 }
 
 export function useCompilers(): Record<string, Compiler> {
-    const { data } = useSWR("/compilers", get, {
+    const { data } = useSWR("/compiler", get, {
         refreshInterval: 0,
         suspense: true, // TODO: remove
         onErrorRetry,
@@ -264,7 +264,7 @@ export function useCompilers(): Record<string, Compiler> {
 }
 
 export function useLibraries(): LibraryVersions[] {
-    const { data } = useSWR("/libraries", get, {
+    const { data } = useSWR("/library", get, {
         refreshInterval: 0,
         onErrorRetry,
     })


### PR DESCRIPTION
The `/api/compilers` endpoint will still work (i.e. for decomp-permuter looking up decomp.me compilers when import.py is run with --decomp.me).