### PR TITLE
Allow saving of custom preset

### DIFF
--- a/frontend/src/components/compiler/PresetSelect.tsx
+++ b/frontend/src/components/compiler/PresetSelect.tsx
@@ -28,7 +28,7 @@ export default function PresetSelect({ className, platform, presetId, setPreset,
 
     const selectedPreset = serverPresets.find(p => p.id === presetId)
 
-    if (!selectedPreset && presetId !== undefined)
+    if (!selectedPreset && presetId !== undefined && presetId !== null)
         console.warn(`Scratch.preset == '${presetId}' but no preset with that id was found.`)
 
     return <Select

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -20,7 +20,7 @@ function onErrorRetry<C>(error: ResponseError, key: string, config: C, revalidat
 
 function undefinedIfUnchanged<O, K extends keyof O>(saved: O, local: O, key: K): O[K] | undefined {
     if (saved[key] !== local[key]) {
-        return local[key]
+        return local[key] !== undefined ? local[key] : null
     }
 }
 


### PR DESCRIPTION
The PATCH to scratch with `preset: undefined` does not set `preset` to `null` - therefore whilst the compiler value will be updated, the preset will still have the original value.

This PR explicitly sets `preset: null` in the PATCH request (along with any other fields that have a local value of `undefined`).

Fixes #939.