### PR TITLE
Bump m2c to latest

### DIFF
--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -817,7 +817,7 @@ pycparser = "^2.21"
 type = "git"
 url = "https://github.com/matt-kempster/m2c.git"
 reference = "HEAD"
-resolved_reference = "dbdb35c3507b54de05c7a47bb06fbb21b9374360"
+resolved_reference = "a39b70e85329b0bcaeb4350510ddb23dc9840dce"
 
 [[package]]
 name = "moreorless"


### PR DESCRIPTION
This PR incorporates [this](https://github.com/matt-kempster/m2c/issues/268) fix which allows %gp_rel to be parsed correctly :+1: