### PR TITLE
Add PS1 compiler using CCPSX.EXE (PSYQ4.4)

### DIFF
--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -347,6 +347,21 @@ PSYQ46 = GCCPS1Compiler(
     cc=PSYQ_CC,
 )
 
+PSYQ_CCPSX = (
+    'echo "[ccpsx]" >> SN.INI && '
+    'echo "compiler_path=${COMPILER_DIR//\\//\\\\}" >> SN.INI && '
+    'echo "assembler_path=${COMPILER_DIR//\\//\\\\}" >> SN.INI && '
+    'SN_PATH=. ${WINE} ${COMPILER_DIR}/CCPSX.EXE -v -c ${COMPILER_FLAGS} "${INPUT}" -o "${OUTPUT}bj" && '
+    '${COMPILER_DIR}/psyq-obj-parser "${OUTPUT}"bj -o "${OUTPUT}"'
+)
+
+PSYQ44_CCPSX = GCCPS1Compiler(
+    id="psyq4.4-ccpsx",
+    base_compiler=PSYQ44,
+    platform=PS1,
+    cc=PSYQ_CCPSX,
+)
+
 PS1_GCC = (
     'cpp -E -lang-c -nostdinc "${INPUT}" -o "${INPUT}".i && '
     '${COMPILER_DIR}/gcc -c -pipe -B${COMPILER_DIR}/ ${COMPILER_FLAGS} -o "${OUTPUT}" "${INPUT}.i"'
@@ -1186,6 +1201,7 @@ _all_compilers: List[Compiler] = [
     PSYQ44,
     PSYQ45,
     PSYQ46,
+    PSYQ44_CCPSX,
     GCC257_PSX,
     GCC263_PSX,
     GCC260_MIPSEL,

--- a/frontend/src/lib/i18n/locales/en/compilers.json
+++ b/frontend/src/lib/i18n/locales/en/compilers.json
@@ -147,6 +147,8 @@
     "psyq4.5": "PSYQ4.5 (gcc 2.91.66 + aspsx 2.81)",
     "psyq4.6": "PSYQ4.6 (gcc 2.95.2 + aspsx 2.86)",
 
+    "psyq4.4-ccpsx": "CCPSX (PSYQ4.4: gcc 2.8.1 + aspsx 2.79)",
+
     "wcc10.5": "Watcom Optimizing C i386 Compiler 10.5",
     "wpp10.5": "Watcom Optimizing C++ i386 Compiler 10.5",
     "wcc10.5a": "Watcom Optimizing C i386 Compiler 10.5a",


### PR DESCRIPTION
Picked this one cos I believe it's the one that Soul Reaver uses (and so we can demonstrate the `-Wa,0` flag.