### PR TITLE
Bump m2c to `581031e`

### DIFF
--- a/backend/coreapp/tests/test_decompilation.py
+++ b/backend/coreapp/tests/test_decompilation.py
@@ -19,7 +19,9 @@ class DecompilationTests(BaseTestCase):
             "target_asm": "glabel return_2\njr $ra\nli $v0,2",
         }
         scratch = self.create_scratch(scratch_dict)
-        self.assertEqual(scratch.source_code, "? return_2(void) {\n    return 2;\n}\n")
+        self.assertEqual(
+            scratch.source_code, "s32 return_2(void) {\n    return 2;\n}\n"
+        )
 
     @requiresCompiler(GCC281PM)
     def test_decompile_endpoint(self) -> None:
@@ -38,7 +40,7 @@ class DecompilationTests(BaseTestCase):
             reverse("scratch-decompile", kwargs={"pk": scratch.slug})
         )
         self.assertEqual(
-            response.json()["decompilation"], "? return_2(void) {\n    return 2;\n}\n"
+            response.json()["decompilation"], "s32 return_2(void) {\n    return 2;\n}\n"
         )
 
         # Provide context and see that the decompilation changes

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -817,7 +817,7 @@ pycparser = "^2.21"
 type = "git"
 url = "https://github.com/matt-kempster/m2c.git"
 reference = "HEAD"
-resolved_reference = "a39b70e85329b0bcaeb4350510ddb23dc9840dce"
+resolved_reference = "581031e603caa5abf75d26ebfb30bc11a9190a22"
 
 [[package]]
 name = "moreorless"


### PR DESCRIPTION
Target commit is https://github.com/matt-kempster/m2c/commit/581031e603caa5abf75d26ebfb30bc11a9190a22.

Addresses `.L` style labels being used as callbacks. See https://github.com/matt-kempster/m2c/commit/0514701ef53ce46e91e4e675455c44647714d014 and matt-kempster/m2c#269.