### PR TITLE
Remove restrictions on i686 reloc use.

### DIFF
--- a/backend/coreapp/diff_wrapper.py
+++ b/backend/coreapp/diff_wrapper.py
@@ -156,8 +156,8 @@ class DiffWrapper:
             "--line-numbers",
         ]
 
-        # --reloc seems to add a bunch of noise to x86 disasm?
-        if platform.arch != "i686":
+        # --reloc can cause issues with DOS disasm?
+        if platform.id != "msdos":
             flags += ["--reloc"]
 
         with Sandbox() as sandbox:


### PR DESCRIPTION
Removes the restrictions on displaying reloc information for Windows platforms as that appears to work correctly after some local testing. Had issues with a DOS scratch so not including that platform for now.