### PR TITLE
Add current.o to export zip

### DIFF
--- a/backend/coreapp/compiler_wrapper.py
+++ b/backend/coreapp/compiler_wrapper.py
@@ -237,7 +237,7 @@ class CompilerWrapper:
 
             compile_errors = CompilerWrapper.filter_compile_errors(compile_proc.stdout)
 
-            return CompilationResult(object_path.read_bytes(), compile_errors)
+            return CompilationResult(object_bytes, compile_errors)
 
     @staticmethod
     def assemble_asm(platform: Platform, asm: Asm) -> Assembly:

--- a/backend/coreapp/views/scratch.py
+++ b/backend/coreapp/views/scratch.py
@@ -500,6 +500,10 @@ class ScratchViewSet(
             if scratch.context:
                 zip_f.writestr(f"ctx.{src_ext}", scratch.context)
 
+            compilation = compile_scratch(scratch)
+            if compilation.elf_object:
+                zip_f.writestr("current.o", compilation.elf_object)
+
         # Prevent possible header injection attacks
         safe_name = re.sub(r"[^a-zA-Z0-9_:]", "_", scratch.name)[:64]
 


### PR DESCRIPTION
Does this seem reasonable? It makes exports slightly slower, but I imagine the feature isn't used much (?). I've needed this a couple of times for debugging.