### PR TITLE
Allow users to select 'Custom' preset again

### DIFF
--- a/frontend/src/components/compiler/CompilerOpts.tsx
+++ b/frontend/src/components/compiler/CompilerOpts.tsx
@@ -203,13 +203,20 @@ export default function CompilerOpts({ platform, value, onChange, diffLabel, onD
     }
 
     const setPreset = (preset: api.Preset) => {
-        onChange({
-            compiler: preset.compiler,
-            compiler_flags: preset.compiler_flags,
-            diff_flags: preset.diff_flags,
-            libraries: preset.libraries,
-            preset: preset.id,
-        })
+        if (preset) {
+            onChange({
+                compiler: preset.compiler,
+                compiler_flags: preset.compiler_flags,
+                diff_flags: preset.diff_flags,
+                libraries: preset.libraries,
+                preset: preset.id,
+            })
+        } else {
+            // "Custom" preset selected
+            onChange({
+                preset: null,
+            })
+        }
     }
 
     const setLibraries = (libraries: Library[]) => {

--- a/frontend/src/components/compiler/PresetSelect.tsx
+++ b/frontend/src/components/compiler/PresetSelect.tsx
@@ -2,12 +2,10 @@ import * as api from "@/lib/api"
 
 import Select from "../Select2"
 
-function presetsToOptions(presets: api.Preset[], addCustom: boolean): { [key: string]: string } {
+function presetsToOptions(presets: api.Preset[]): { [key: string]: string } {
     const options = {}
 
-    if (addCustom) {
-        options["Custom"] = "Custom"
-    }
+    options["Custom"] = "Custom"
 
     for (const preset of presets) {
         options[preset.name] = preset.name
@@ -33,12 +31,10 @@ export default function PresetSelect({ className, platform, presetId, setPreset,
 
     return <Select
         className={className}
-        options={presetsToOptions(serverPresets, !selectedPreset)}
+        options={presetsToOptions(serverPresets)}
         value={selectedPreset?.name || "Custom"}
         onChange={name => {
-            const preset = serverPresets.find(p => p.name === name)
-            if (preset)
-                setPreset(preset)
+            setPreset(serverPresets.find(p => p.name === name))
         }}
     />
 }


### PR DESCRIPTION
Is there a nicer way to write this? We want to set the preset.id to null to clear it in the database, but do not want to change any other scratch configuration.