### PR TITLE
x86: Update asm-differ and fix some incorrect objdump output by using mingw instead of msdosdjgpp.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
             binutils-mips-linux-gnu \
             binutils-powerpc-linux-gnu \
             binutils-sh-elf \
+            binutils-mingw-w64-i686 \
             dos2unix \
             libprotobuf-dev \
             libnl-route-3-dev \

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -40,7 +40,7 @@ RUN apt-get -y update && apt-get install -y \
     binutils-mips-linux-gnu \
     binutils-powerpc-linux-gnu \
     binutils-sh-elf \
-    bintuils-mingw-w64-i686 \
+    binutils-mingw-w64-i686 \
     ca-certificates \
     curl \
     dos2unix \

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -40,6 +40,7 @@ RUN apt-get -y update && apt-get install -y \
     binutils-mips-linux-gnu \
     binutils-powerpc-linux-gnu \
     binutils-sh-elf \
+    bintuils-mingw-w64-i686 \
     ca-certificates \
     curl \
     dos2unix \

--- a/backend/coreapp/diff_wrapper.py
+++ b/backend/coreapp/diff_wrapper.py
@@ -263,7 +263,7 @@ class DiffWrapper:
             objdump_flags,
         )
         # hack to ignore functions other than the one we want to diff, in case debug flags cause inlined/template functions to be included in the diff (it happens)
-        if platform.id in ["win9x"] and diff_label is not None and diff_label:
+        if platform.id in ["win32"] and diff_label is not None and diff_label:
             objdump_flags += [f"--disassemble={diff_label}"]
         try:
             mydump = DiffWrapper.get_dump(

--- a/backend/coreapp/diff_wrapper.py
+++ b/backend/coreapp/diff_wrapper.py
@@ -262,6 +262,9 @@ class DiffWrapper:
             config,
             objdump_flags,
         )
+        # hack to ignore functions other than the one we want to diff, in case debug flags cause inlined/template functions to be included in the diff (it happens)
+        if platform.id in ["win9x"] and diff_label is not None and diff_label:
+            objdump_flags += [f"--disassemble={diff_label}"]
         try:
             mydump = DiffWrapper.get_dump(
                 compiled_elf, platform, diff_label, config, objdump_flags

--- a/backend/coreapp/platforms.py
+++ b/backend/coreapp/platforms.py
@@ -83,9 +83,9 @@ WIN32 = Platform(
     name="Windows (9x/NT)",
     description="x86 (32bit)",
     arch="i686",
-    assemble_cmd='i386-pc-msdosdjgpp-as --32 -mmnemonic=intel -msyntax=intel -mnaked-reg -o "$OUTPUT" "$INPUT"',
-    objdump_cmd="i386-pc-msdosdjgpp-objdump",
-    nm_cmd="i386-pc-msdosdjgpp-nm",
+    assemble_cmd='i686-w64-mingw32-as --32 -mmnemonic=intel -msyntax=intel -mnaked-reg -o "$OUTPUT" "$INPUT"',
+    objdump_cmd="i686-w64-mingw32-objdump",
+    nm_cmd="i686-w64-mingw32-nm",
     asm_prelude="",
 )
 

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -51,7 +51,7 @@ watchdog = "^2.2.0"
 type = "git"
 url = "https://github.com/simonlindholm/asm-differ.git"
 reference = "HEAD"
-resolved_reference = "6a710eb110f44339d35efece4f993d2ce00cef67"
+resolved_reference = "2ad88533f676a2e5c1dc038caf60897b150718fd"
 
 [[package]]
 name = "attrs"


### PR DESCRIPTION
Note that this also gets around an issue involving diffing msvc compiler output for debug/no-inline code. See the changes to diff_wrapper.py.