### PR TITLE
Use custom powerpc-eabi binutils for GC/Wii

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,8 +78,8 @@ jobs:
       - name: Install GC/Wii binutils
         run: |-
           curl -sSL https://github.com/encounter/gc-wii-binutils/releases/download/2.42-1/linux-`uname -m`.zip | \
-            bsdtar -xvf- -C /usr/bin
-          chmod +x /usr/bin/powerpc-eabi-*
+            sudo bsdtar -xvf- -C /usr/bin
+          sudo chmod +x /usr/bin/powerpc-eabi-*
       - name: Cache compilers
         uses: actions/cache@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
             binutils-sh-elf \
             binutils-mingw-w64-i686 \
             dos2unix \
+            libarchive-tools \
             libprotobuf-dev \
             libnl-route-3-dev \
             libncurses5 \
@@ -74,6 +75,11 @@ jobs:
           git clone --recursive --branch=3.1 https://github.com/google/nsjail
           make -C nsjail
           sudo cp nsjail/nsjail /usr/bin/
+      - name: Install GC/Wii binutils
+        run: |-
+          curl -sSL https://github.com/encounter/gc-wii-binutils/releases/download/2.42-1/linux-`uname -m`.zip | \
+            bsdtar -xvf- -C /usr/bin
+          chmod +x /usr/bin/powerpc-eabi-*
       - name: Cache compilers
         uses: actions/cache@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,7 @@ jobs:
           docker build backend \
             -t decompme_backend \
             --build-arg ENABLE_MSDOS_SUPPORT=YES \
+            --build-arg ENABLE_GC_WII_SUPPORT=YES \
             --build-arg ENABLE_PS2_SUPPORT=YES \
             --build-arg ENABLE_SATURN_SUPPORT=YES \
             --build-arg ENABLE_WIN32_SUPPORT=YES

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -47,6 +47,7 @@ RUN apt-get -y update && apt-get install -y \
     gcc-mips-linux-gnu \
     git \
     iptables \
+    libarchive-tools \
     libc6-dev-i386 \
     libdevmapper1.02.1 \
     libgpgme11 \
@@ -91,6 +92,14 @@ RUN if [ "${ENABLE_MSDOS_SUPPORT}" = "YES" ]; then \
     rm omftools.tar.gz; \
     fi
 
+# Patched PowerPC binutils
+ARG ENABLE_GC_WII_SUPPORT
+RUN if [ "${ENABLE_GC_WII_SUPPORT}" = "YES" ]; then \
+    curl -sSL https://github.com/encounter/gc-wii-binutils/releases/download/2.42-1/linux-`uname -m`.zip | \
+    bsdtar -xvf- -C /usr/bin && \
+    chmod +x /usr/bin/powerpc-eabi-*; \
+  fi
+
 RUN mkdir -p /etc/fonts
 
 WORKDIR /backend
@@ -119,7 +128,6 @@ ENV PATH="$PATH:/etc/poetry/bin"
 
 # no special dependencies required for these platforms
 ARG ENABLE_GBA_SUPPORT
-ARG ENABLE_GC_WII_SUPPORT
 ARG ENABLE_MACOSX_SUPPORT
 ARG ENABLE_N3DS_SUPPORT
 ARG ENABLE_N64_SUPPORT

--- a/backend/coreapp/platforms.py
+++ b/backend/coreapp/platforms.py
@@ -501,9 +501,9 @@ GC_WII = Platform(
     name="GameCube / Wii",
     description="PowerPC",
     arch="ppc",
-    assemble_cmd='powerpc-linux-gnu-as -mgekko -o "$OUTPUT" "$INPUT"',
-    objdump_cmd="powerpc-linux-gnu-objdump -M broadway",
-    nm_cmd="powerpc-linux-gnu-nm",
+    assemble_cmd='powerpc-eabi-as -mgekko -o "$OUTPUT" "$INPUT"',
+    objdump_cmd="powerpc-eabi-objdump -M broadway",
+    nm_cmd="powerpc-eabi-nm",
     asm_prelude="""
 .macro glabel label
     .global \label


### PR DESCRIPTION
Source: https://github.com/encounter/gc-wii-binutils

Right now there's only one patch to fix mftb instructions, but it's an issue that pops up pretty frequently.