### PR TITLE
Wrap diff_wrapper.run_objdump in lru_cache

### DIFF
--- a/backend/coreapp/diff_wrapper.py
+++ b/backend/coreapp/diff_wrapper.py
@@ -150,9 +150,9 @@ class DiffWrapper:
         platform: Platform,
         arch_flags: tuple[str, ...],
         label: str,
-        flags: tuple[str, ...],
+        objdump_flags: tuple[str, ...],
     ) -> str:
-        flags = [flag for flag in flags if not flag.startswith(ASMDIFF_FLAG_PREFIX)]
+        flags = [flag for flag in objdump_flags if not flag.startswith(ASMDIFF_FLAG_PREFIX)]
         flags += [
             "--disassemble-zeroes",
             "--line-numbers",
@@ -217,7 +217,11 @@ class DiffWrapper:
             raise AssemblyError("Asm empty")
 
         basedump = DiffWrapper.run_objdump(
-            elf_object, platform, tuple(config.arch.arch_flags), diff_label, tuple(diff_flags)
+            elf_object,
+            platform,
+            tuple(config.arch.arch_flags),
+            diff_label,
+            tuple(diff_flags),
         )
         if not basedump:
             raise ObjdumpError("Error running objdump")

--- a/backend/coreapp/diff_wrapper.py
+++ b/backend/coreapp/diff_wrapper.py
@@ -152,7 +152,9 @@ class DiffWrapper:
         label: str,
         objdump_flags: tuple[str, ...],
     ) -> str:
-        flags = [flag for flag in objdump_flags if not flag.startswith(ASMDIFF_FLAG_PREFIX)]
+        flags = [
+            flag for flag in objdump_flags if not flag.startswith(ASMDIFF_FLAG_PREFIX)
+        ]
         flags += [
             "--disassemble-zeroes",
             "--line-numbers",


### PR DESCRIPTION
This works - I feel it's the right place, but open to suggestions.

Edit: If I have a scratch open on `main` and hit refresh, the backend does 12 calls to objdump (6 to run_objdump). With this branch I get 0 as the result is in the lru_cache.