### PR TITLE
Fixup owner alignment in ScratchList

### DIFF
--- a/frontend/src/components/ScratchList.tsx
+++ b/frontend/src/components/ScratchList.tsx
@@ -173,11 +173,11 @@ export function ScratchItemPlatformList({ scratch }: { scratch: api.TerseScratch
                         {scratch.name}
                     </Link>
                     <div className={styles.owner}>
-                    {scratch.owner ?
-                        <UserLink user={scratch.owner} />
-                        :
-                        <div>No Owner</div>
-                    }
+                        {scratch.owner ?
+                            <UserLink user={scratch.owner} />
+                            :
+                            <div>No Owner</div>
+                        }
                     </div>
 
                 </div>
@@ -207,11 +207,11 @@ export function ScratchItemPresetList({ scratch }: { scratch: api.TerseScratch }
                         </span>
                     </div>
                     <div className={styles.owner}>
-                    {scratch.owner ?
-                        <UserLink user={scratch.owner} />
-                        :
-                        <div>No Owner</div>
-                    }
+                        {scratch.owner ?
+                            <UserLink user={scratch.owner} />
+                            :
+                            <div>No Owner</div>
+                        }
                     </div>
                 </div>
 

--- a/frontend/src/components/ScratchList.tsx
+++ b/frontend/src/components/ScratchList.tsx
@@ -138,6 +138,9 @@ export function ScratchItemNoOwner({ scratch }: { scratch: api.TerseScratch }) {
                     <Link href={scratchUrl(scratch)} className={classNames(styles.link, styles.name)}>
                         {scratch.name}
                     </Link>
+                    <div>
+                        {/* empty div for alignment */}
+                    </div>
                 </div>
                 <div className={styles.metadata}>
                     <span>
@@ -169,9 +172,14 @@ export function ScratchItemPlatformList({ scratch }: { scratch: api.TerseScratch
                     <Link href={scratchUrl(scratch)} className={classNames(styles.link, styles.name)}>
                         {scratch.name}
                     </Link>
-                    {scratch.owner && <div className={styles.owner}>
+                    <div className={styles.owner}>
+                    {scratch.owner ?
                         <UserLink user={scratch.owner} />
-                    </div>}
+                        :
+                        <div>No Owner</div>
+                    }
+                    </div>
+
                 </div>
                 <div className={styles.metadata}>
                     <span>
@@ -198,9 +206,13 @@ export function ScratchItemPresetList({ scratch }: { scratch: api.TerseScratch }
                             {matchPercentString} matched • <TimeAgo date={scratch.last_updated} />
                         </span>
                     </div>
-                    {scratch.owner && <div className={styles.owner}>
+                    <div className={styles.owner}>
+                    {scratch.owner ?
                         <UserLink user={scratch.owner} />
-                    </div>}
+                        :
+                        <div>No Owner</div>
+                    }
+                    </div>
                 </div>
 
             </div>

--- a/frontend/src/components/ScratchList.tsx
+++ b/frontend/src/components/ScratchList.tsx
@@ -100,9 +100,13 @@ export function ScratchItem({ scratch, children } : { scratch: api.TerseScratch,
                     <Link href={scratchUrl(scratch)} className={classNames(styles.link, styles.name)}>
                         {scratch.name}
                     </Link>
-                    {scratch.owner && <div className={styles.owner}>
-                        <UserLink user={scratch.owner} />
-                    </div>}
+                    <div className={styles.owner}>
+                        {scratch.owner ?
+                            <UserLink user={scratch.owner} />
+                            :
+                            <div>No Owner</div>
+                        }
+                    </div>
                 </div>
                 <div className={styles.metadata}>
                     <span>


### PR DESCRIPTION
Should fix #1112. Opening PR for testing,

This is somewhat of a temporary fix - we should try and consolidate all of the various ScratchList code to simplify things.

**Homepage**

![image](https://github.com/decompme/decomp.me/assets/22226349/70af5d10-6041-4db0-8e9c-4df95eb178aa)

**User**

![image](https://github.com/decompme/decomp.me/assets/22226349/948ba239-8b7e-47ee-a70e-f01c86f8aa0f)