### PR TITLE
Fix opengraph embed for platform, preset and user

### DIFF
--- a/frontend/src/app/(navfooter)/platform/[id]/page.tsx
+++ b/frontend/src/app/(navfooter)/platform/[id]/page.tsx
@@ -22,7 +22,7 @@ export async function generateMetadata({ params }: { params: { id: number } }):P
 
     let description = "There "
     description += platform.num_scratches == 1 ? "is " : "are "
-    description += platform.num_scratches == 0 ? "currently no " : `${platform.num_scratches} `
+    description += platform.num_scratches == 0 ? "currently no " : `${platform.num_scratches.toLocaleString("en-US")} `
     description += platform.num_scratches == 1 ? "scratch " : "scratches "
     description += "for this platform."
 

--- a/frontend/src/app/(navfooter)/platform/[id]/page.tsx
+++ b/frontend/src/app/(navfooter)/platform/[id]/page.tsx
@@ -1,3 +1,5 @@
+import { Metadata } from "next"
+
 import { notFound } from "next/navigation"
 
 import { PlatformIcon } from "@/components/PlatformSelect/PlatformIcon"
@@ -5,7 +7,7 @@ import ScratchList, { ScratchItemPlatformList } from "@/components/ScratchList"
 import { get } from "@/lib/api/request"
 import { PlatformMetadata } from "@/lib/api/types"
 
-export async function generateMetadata({ params }: { params: { id: number } }) {
+export async function generateMetadata({ params }: { params: { id: number } }):Promise<Metadata> {
     let platform: PlatformMetadata
 
     try {
@@ -18,8 +20,18 @@ export async function generateMetadata({ params }: { params: { id: number } }) {
         return notFound()
     }
 
+    let description = "There "
+    description += platform.num_scratches == 1 ? "is " : "are "
+    description += platform.num_scratches == 0 ? "currently no " : `${platform.num_scratches} `
+    description += platform.num_scratches == 1 ? "scratch " : "scratches "
+    description += "for this platform."
+
     return {
         title: platform.name,
+        openGraph: {
+            title: platform.name,
+            description: description,
+        },
     }
 }
 
@@ -47,7 +59,7 @@ export default async function Page({ params }: { params: { id: number } }) {
         <section>
             <h2 className="pb-2 text-lg font-medium tracking-tight">Scratches ({platform.num_scratches})</h2>
             <ScratchList
-                url={"/scratch?platform=" + platform.id + "&page_size=20"}
+                url={`/scratch?platform=${platform.id}&page_size=20`}
                 item={ScratchItemPlatformList}
             />
         </section>

--- a/frontend/src/app/(navfooter)/preset/[id]/page.tsx
+++ b/frontend/src/app/(navfooter)/preset/[id]/page.tsx
@@ -23,7 +23,7 @@ export async function generateMetadata({ params }: { params: { id: number } }):P
 
     let description = "There "
     description += preset.num_scratches == 1 ? "is " : "are "
-    description += preset.num_scratches == 0 ? "currently no " : `${preset.num_scratches} `
+    description += preset.num_scratches == 0 ? "currently no " : `${preset.num_scratches.toLocaleString("en-US")} `
     description += preset.num_scratches == 1 ? "scratch " : "scratches "
     description += "that use this preset."
 

--- a/frontend/src/app/(navfooter)/preset/[id]/page.tsx
+++ b/frontend/src/app/(navfooter)/preset/[id]/page.tsx
@@ -1,3 +1,5 @@
+import { Metadata } from "next"
+
 import { notFound } from "next/navigation"
 
 import { PlatformIcon } from "@/components/PlatformSelect/PlatformIcon"
@@ -6,7 +8,7 @@ import { get } from "@/lib/api/request"
 import { Preset } from "@/lib/api/types"
 import useTranslation from "@/lib/i18n/translate"
 
-export async function generateMetadata({ params }: { params: { id: number } }) {
+export async function generateMetadata({ params }: { params: { id: number } }):Promise<Metadata> {
     let preset: Preset
 
     try {
@@ -19,8 +21,18 @@ export async function generateMetadata({ params }: { params: { id: number } }) {
         return notFound()
     }
 
+    let description = "There "
+    description += preset.num_scratches == 1 ? "is " : "are "
+    description += preset.num_scratches == 0 ? "currently no " : `${preset.num_scratches} `
+    description += preset.num_scratches == 1 ? "scratch " : "scratches "
+    description += "that use this preset."
+
     return {
         title: preset.name,
+        openGraph: {
+            title: preset.name,
+            description: description,
+        },
     }
 }
 
@@ -52,7 +64,7 @@ export default async function Page({ params }: { params: { id: number } }) {
         <section>
             <h2 className="pb-2 text-lg font-medium tracking-tight">Scratches ({preset.num_scratches})</h2>
             <ScratchList
-                url={"/scratch?preset=" + preset.id + "&page_size=20"}
+                url={`/scratch?preset=${preset.id}&page_size=20`}
                 item={ScratchItemPresetList}
             />
         </section>

--- a/frontend/src/app/(navfooter)/u/[username]/page.tsx
+++ b/frontend/src/app/(navfooter)/u/[username]/page.tsx
@@ -1,3 +1,5 @@
+import { Metadata } from "next"
+
 import { notFound } from "next/navigation"
 
 import { MarkGithubIcon } from "@primer/octicons-react"
@@ -9,7 +11,7 @@ import { get } from "@/lib/api/request"
 import { User } from "@/lib/api/types"
 import { userGithubHtmlUrl, userUrl } from "@/lib/api/urls"
 
-export async function generateMetadata({ params }: { params: { username: string } }) {
+export async function generateMetadata({ params }: { params: { username: string } }):Promise<Metadata> {
     let user: User
 
     try {
@@ -24,6 +26,9 @@ export async function generateMetadata({ params }: { params: { username: string 
 
     return {
         title: user.username,
+        openGraph: {
+            title: user.username,
+        },
     }
 }
 


### PR DESCRIPTION
I think it could be nice to say that "User x owners n scratches", but that would require the backend to return num_scratches for users, and that looked like a bit tricky, so it's one for another day.

Before/after for preset:
![image](https://github.com/decompme/decomp.me/assets/22226349/87317b2d-85e0-47ac-8cb5-b8b96cad3b36)

Before/after for platform:
![image](https://github.com/decompme/decomp.me/assets/22226349/1ee072ad-2af6-4667-a318-f41fde0b8bbc)

**TODO:**
 - [x] add thousands separator?

Now with thousands separator:
![image](https://github.com/decompme/decomp.me/assets/22226349/b7c4ef7b-5647-41d8-bf26-7ebdd34ba030)
