### PR TITLE
Fix scratch og when scratch has no owner

### DIFF
--- a/frontend/src/app/scratch/[slug]/opengraph-image.tsx
+++ b/frontend/src/app/scratch/[slug]/opengraph-image.tsx
@@ -42,7 +42,7 @@ export default async function ScratchOG({ params }: { params: { slug: string }})
             <div tw="flex flex-col">
                 <div tw="flex flex-row justify-between ml-15 mr-15 mt-5">
                     <div tw="flex flex-col justify-center">
-                        <div tw="flex text-slate-300">{scratch.owner.username}</div>
+                        <div tw="flex text-slate-300">{scratch.owner?.username ?? "No Owner"}</div>
                         <div tw={`flex text-${scratchNameSize}`}>{scratchName}</div>
                     </div>
                     <div tw="flex bg-zinc-700 rounded-2xl">


### PR DESCRIPTION
[This](https://decomp.me/scratch/ukgQr) scratch currently generates a 500 error. The scratch has no owner:

Broken:
![broken](https://decomp.me/scratch/ukgQr/opengraph-image)

Fixed in this PR:
![fixed](https://frontend-3kd5bkz8t-decompme.vercel.app/scratch/ukgQr/opengraph-image)