### PR TITLE
Fix nested anchor in Scratch Toolbar breadcrumb

### DIFF
--- a/frontend/src/app/(navfooter)/WelcomeInfo.tsx
+++ b/frontend/src/app/(navfooter)/WelcomeInfo.tsx
@@ -16,10 +16,7 @@ export default function WelcomeInfo() {
 
     return <div className="relative overflow-x-hidden p-2">
         {!saveDataEnabled && <div className="absolute top-14 -z-10 hidden w-full opacity-80 sm:block">
-            <div className="flex">
-                <ScrollingPlatformIcons />
-                <ScrollingPlatformIcons />
-            </div>
+            <ScrollingPlatformIcons />
             <div
                 className="absolute top-0 h-full w-full"
                 style={{

--- a/frontend/src/components/Breadcrumbs.tsx
+++ b/frontend/src/components/Breadcrumbs.tsx
@@ -28,7 +28,7 @@ export default function Breadcrumbs({ pages, className }: Props) {
 
                     return (
                         <li key={page.href || index}>
-                            {page.href ? <Link href={page.href} legacyBehavior>{a}</Link> : a}
+                            {page.href ? <Link href={page.href} legacyBehavior>{a}</Link> : page.label}
                         </li>
                     )
                 })}

--- a/frontend/src/components/Scratch/ScratchToolbar.module.scss
+++ b/frontend/src/components/Scratch/ScratchToolbar.module.scss
@@ -124,12 +124,8 @@ $padding: 4px;
 
 .iconNamePair {
     display: flex;
-    align-items: baseline;
+    align-items: center;
     gap: 4px;
-
-    > svg {
-        align-self: center;
-    }
 }
 
 .lastEditTime {


### PR DESCRIPTION
The platform icon being a link was throwing an error in the console - we want the platform icon to link to eg. /platforms/ps1, but the scratch name should be editable - the whole '<icon> scratchName' shouldnt (ever) be a link.

I've stopped the child entry being a link if `href` isn't provided. I'm unsure if there is a nicer way to do this - we only have a maximum of 2 levels of breadcrumbs, so maybe it's ok for now and we can address in the future? Do we want all items except the last one to be anchors? 

I've also also fixed the vertical alignment of the icon:

Before
![image](https://github.com/decompme/decomp.me/assets/22226349/3309d456-6205-4b23-8405-74751e03d355)

After:
![image](https://github.com/decompme/decomp.me/assets/22226349/c916b5d7-fe27-4401-a83a-471a5598adb2)


