### PR TITLE
Add setting for vim bindings to be used

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
         "@radix-ui/colors": "^0.1.8",
         "@react-hook/resize-observer": "^1.2.6",
         "@replit/codemirror-indentation-markers": "^6.4.2",
+        "@replit/codemirror-vim": "^6.2.0",
         "allotment": "^1.19.0",
         "ansi-to-react": "^6.1.6",
         "classnames": "^2.3.2",

--- a/frontend/src/app/(navfooter)/settings/editor/EditorSettings.tsx
+++ b/frontend/src/app/(navfooter)/settings/editor/EditorSettings.tsx
@@ -12,6 +12,7 @@ export default function EditorSettings() {
     const [autoRecompile, setAutoRecompile] = settings.useAutoRecompileSetting()
     const [autoRecompileDelay, setAutoRecompileDelay] = settings.useAutoRecompileDelaySetting()
     const [languageServerEnabled, setLanguageServerEnabled] = settings.useLanguageServerEnabled()
+    const [vimModeEnabled, setVimModeEnabled] = settings.useVimModeEnabled()
 
     const [downloadingLanguageServer, setDownloadingLanguageServer] = useState(false)
 
@@ -67,6 +68,14 @@ export default function EditorSettings() {
                 description="Enable editor features such as code completion, error checking, and formatting via clangd and WebAssembly magic. WARNING: enabling will incur a one time ~13MB download, and bump up resource usage during editing.">
 
                 {downloadingLanguageServer && <div className="flex gap-2 p-4"><LoadingSpinner width="24px" /> Downloading...</div>}
+            </Checkbox>
+        </Section>
+        <Section title="Vim Mode">
+            <Checkbox
+                checked={vimModeEnabled}
+                onChange={setVimModeEnabled}
+                label="Enable Vim bindings"
+                description="Enables Vim bindings to be used inside of the scratch editor">
             </Checkbox>
         </Section>
     </>

--- a/frontend/src/components/Scratch/Scratch.tsx
+++ b/frontend/src/components/Scratch/Scratch.tsx
@@ -2,12 +2,13 @@ import { useEffect, useReducer, useRef, useState } from "react"
 
 import { cpp } from "@codemirror/lang-cpp"
 import { EditorView } from "@codemirror/view"
+import { vim } from "@replit/codemirror-vim"
 
 import * as api from "@/lib/api"
 import basicSetup from "@/lib/codemirror/basic-setup"
 import useCompareExtension from "@/lib/codemirror/useCompareExtension"
 import { useSize } from "@/lib/hooks"
-import { useAutoRecompileSetting, useAutoRecompileDelaySetting, useLanguageServerEnabled } from "@/lib/settings"
+import { useAutoRecompileSetting, useAutoRecompileDelaySetting, useLanguageServerEnabled, useVimModeEnabled } from "@/lib/settings"
 
 import CompilerOpts from "../compiler/CompilerOpts"
 import CustomLayout, { activateTabInLayout, Layout } from "../CustomLayout"
@@ -102,7 +103,6 @@ const CODEMIRROR_EXTENSIONS = [
     basicSetup,
     cpp(),
 ]
-
 function getDefaultLayout(width: number, _height: number): keyof typeof DEFAULT_LAYOUTS {
     if (width > 700) {
         return "desktop_2col"
@@ -151,7 +151,7 @@ export default function Scratch({
     const contextCompareExtension = useCompareExtension(contextEditor, shouldCompare ? parentScratch?.context : undefined)
 
     const [saveSource, saveContext] = useLanguageServer(languageServerEnabledSetting, scratch, sourceEditor, contextEditor)
-
+    const [useVim] = useVimModeEnabled()
     // TODO: CustomLayout should handle adding/removing tabs
     const [decompilationTabEnabled, setDecompilationTabEnabled] = useState(false)
     useEffect(() => {
@@ -168,6 +168,15 @@ export default function Scratch({
     useEffect(() => {
         incrementValueVersion()
     }, [scratch.slug, scratch.last_updated])
+
+    const cmExtensions = [...CODEMIRROR_EXTENSIONS, sourceCompareExtension]
+    const cmExtensionsRef = useRef(cmExtensions)
+    useEffect(() => {
+        if (useVim == true) {
+            cmExtensionsRef.current = [...cmExtensionsRef.current, vim()]
+        }
+    })
+    const refCmExtensions = cmExtensionsRef.current
 
     const renderTab = (id: string) => {
         switch (id as TabId) {
@@ -197,7 +206,7 @@ export default function Scratch({
                         setScratch({ source_code: value })
                     }}
                     onSelectedLineChange={setSelectedSourceLine}
-                    extensions={[...CODEMIRROR_EXTENSIONS, sourceCompareExtension]}
+                    extensions={refCmExtensions}
                 />
             </Tab>
         case TabId.CONTEXT:

--- a/frontend/src/lib/settings.ts
+++ b/frontend/src/lib/settings.ts
@@ -8,6 +8,7 @@ const monospaceFont = createPersistedState("monospaceFont")
 const codeLineHeight = createPersistedState("codeLineHeight")
 const codeColorScheme = createPersistedState("codeColorScheme")
 const languageServerEnabled = createPersistedState("languageServerEnabled")
+const vimModeEnabled = createPersistedState("vimModeEnabled")
 
 export const useTheme = () => theme("auto")
 export const useAutoRecompileSetting = () => autoRecompile(true)
@@ -17,6 +18,7 @@ export const useMonospaceFont = () => monospaceFont(undefined)
 export const useCodeLineHeight = () => codeLineHeight(1.5)
 export const useCodeColorScheme = () => codeColorScheme("Frog Dark")
 export const useLanguageServerEnabled = () => languageServerEnabled(false)
+export const useVimModeEnabled = () => vimModeEnabled(false)
 
 export function useIsSiteThemeDark() {
     const [theme] = useTheme()

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1422,6 +1422,11 @@
   resolved "https://registry.yarnpkg.com/@replit/codemirror-indentation-markers/-/codemirror-indentation-markers-6.5.0.tgz#e853e406cf05fea13449578c6c9c1383c6feb219"
   integrity sha512-5RgeuQ6erfROi1EVI2X7G4UR+KByjb07jhYMynvpvlrV22JlnARifmKMGEUKy0pKcxBNfwbFqoUlTYHPgyZNlg==
 
+"@replit/codemirror-vim@^6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@replit/codemirror-vim/-/codemirror-vim-6.2.0.tgz#aa86be5d8e3dcf6be2ea4acc50aec4ffb7246bba"
+  integrity sha512-05E27W7m9HLwnhIHaXAdBTca1uN6n3j57wAsGI8rb+0LDIWgaLgS65xJ4TRJnwJOX4N0iWLGq38McDheSO5eOQ==
+
 "@rollup/plugin-babel@^5.2.0":
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz#04bc0608f4aa4b2e4b1aebf284344d0f68fda283"


### PR DESCRIPTION
Resolves #1130 by adding vim bindings as an option inside of `/settings/editor`, apologies in advance if I didn't make the most optimal react code, I have worked with it very little. Doesn't seem to cause any lag for me, but I believe that it might be rerendering too much