### PR TITLE
One line CSS change to fix #1127

### DIFF
--- a/frontend/src/components/Scratch/AboutScratch.module.scss
+++ b/frontend/src/components/Scratch/AboutScratch.module.scss
@@ -53,6 +53,7 @@
     color: var(--g800);
 
     max-width: 400px;
+    text-wrap: nowrap;
 }
 
 .scratchLink {


### PR DESCRIPTION
Just adds `text-wrap: nowrap` to `.scratchLinkContainer` to prevent the username and icon container from wrapping and instead just overflowing off the page like everything else :)
