### PR TITLE
Swap usePlatforms for usePresets/usePreset

### DIFF
--- a/frontend/src/components/ScratchList.tsx
+++ b/frontend/src/components/ScratchList.tsx
@@ -82,9 +82,8 @@ export function getMatchPercentString(scratch: api.TerseScratch) {
 export function ScratchItem({ scratch, children } : { scratch: api.TerseScratch, children?: ReactNode }) {
     const compilersTranslation = useTranslation("compilers")
     const compilerName = compilersTranslation.t(scratch.compiler as any)
-    const serverPresets = api.usePlatforms()[scratch.platform].presets
     const matchPercentString = getMatchPercentString(scratch)
-    const preset = serverPresets.find(p => p.id === scratch.preset)
+    const preset = api.usePreset(scratch.preset)
     const presetName = preset?.name
 
     const presetOrCompiler = presetName ?
@@ -124,9 +123,8 @@ export function ScratchItem({ scratch, children } : { scratch: api.TerseScratch,
 export function ScratchItemNoOwner({ scratch }: { scratch: api.TerseScratch }) {
     const compilersTranslation = useTranslation("compilers")
     const compilerName = compilersTranslation.t(scratch.compiler)
-    const serverPresets = api.usePlatforms()[scratch.platform].presets
     const matchPercentString = getMatchPercentString(scratch)
-    const preset = serverPresets.find(p => p.id === scratch.preset)
+    const preset = api.usePreset(scratch.preset)
     const presetName = preset?.name
 
     const presetOrCompiler = presetName ?
@@ -159,9 +157,8 @@ export function ScratchItemNoOwner({ scratch }: { scratch: api.TerseScratch }) {
 export function ScratchItemPlatformList({ scratch }: { scratch: api.TerseScratch }) {
     const compilersTranslation = useTranslation("compilers")
     const compilerName = compilersTranslation.t(scratch.compiler)
-    const serverPresets = api.usePlatforms()[scratch.platform].presets
     const matchPercentString = getMatchPercentString(scratch)
-    const preset = serverPresets.find(p => p.id === scratch.preset)
+    const preset = api.usePreset(scratch.preset)
     const presetName = preset?.name
 
     const presetOrCompiler = presetName ?

--- a/frontend/src/components/compiler/PresetSelect.tsx
+++ b/frontend/src/components/compiler/PresetSelect.tsx
@@ -26,7 +26,7 @@ export default function PresetSelect({ className, platform, presetId, setPreset,
 
     const selectedPreset = serverPresets.find(p => p.id === presetId)
 
-    if (!selectedPreset && presetId !== undefined && presetId !== null)
+    if (serverPresets.length > 0 && typeof presetId === "number" && !selectedPreset)
         console.warn(`Scratch.preset == '${presetId}' but no preset with that id was found.`)
 
     return <Select

--- a/frontend/src/components/compiler/PresetSelect.tsx
+++ b/frontend/src/components/compiler/PresetSelect.tsx
@@ -22,7 +22,7 @@ export default function PresetSelect({ className, platform, presetId, setPreset,
     serverPresets?: api.Preset[]
 }) {
     if (!serverPresets)
-        serverPresets = api.usePlatforms()[platform].presets
+        serverPresets = api.usePresets(platform)
 
     const selectedPreset = serverPresets.find(p => p.id === presetId)
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -245,17 +245,6 @@ export function useCompilation(scratch: Scratch | null, autoRecompile = true, au
     }
 }
 
-export function usePlatforms(): Record<string, Platform> {
-    const { data } = useSWR<{ "platforms": Record<string, Platform> }>("/compiler", get, {
-        refreshInterval: 0,
-        revalidateOnFocus: false,
-        suspense: true, // TODO: remove
-        onErrorRetry,
-    })
-
-    return data?.platforms
-}
-
 export function usePlatform(id: string | undefined): Platform | undefined {
     const url = typeof id === "string" ? `/platform/${id}` : null
     const { data } = useSWR(url, get, {
@@ -286,6 +275,24 @@ export function useLibraries(): LibraryVersions[] {
     }
 
     return data.libraries
+}
+
+export function usePresets(platform: string | undefined): Preset[] {
+    const getByPlatform = ([url, platform]) => {
+        return get(url && platform && `${url}?platform=${platform}&page_size=100`)
+    }
+
+    const url = typeof platform === "string" ? "/preset" : null
+    const { data } = useSWR([url, platform], getByPlatform, {
+        refreshInterval: 0,
+        onErrorRetry,
+    })
+
+    if (!data) {
+        return []
+    }
+
+    return data.results
 }
 
 export function usePreset(id: number | undefined): Preset | undefined {


### PR DESCRIPTION
The *upside* to this change is that rather than getting all compilers + platforms + presets etc via the `/compiler`, we grab each preset as required.

```sh
$ curl --silent https://decomp.me/api/compiler?format=json | wc -c
173635
```

The *downside* to this change is that rather than getting all compilers + platforms + presets etc via the `/compiler`, we grab each preset as required. 

```sh
$ curl --silent "https://decomp.me/api/preset/21?format=json" | wc -c
244
```

I still think this is much better in terms of amount of data being sent & processed - but it is more requests to the backend (I know there is a maximum of 6 outstanding requests per tab, does this also apply to `fetch`)?

~~Gonna see how the vercel deployment looks...~~

**Edit:**

Performance seems good to me... When loading the front page we load ~20 scratches, worst-case scenario would be 20 *different* presets, but currently there are only 5 requests needed (due to scratches without any preset, as well as a number of scratches using the same preset). Loading the [platform](https://frontend-66fcwve8y-decompme.vercel.app/platform/n64) page for n64 only requires 3 calls to the presets endpoint, so I think it's OK.

**Bugs:**

- ```Scratch.preset == '97' but no preset with that id was found.``` :green_circle: Fixed!


