### PR TITLE
Avoid changing state in useEffect for progress bar

### DIFF
--- a/frontend/src/components/Scratch/Scratch.tsx
+++ b/frontend/src/components/Scratch/Scratch.tsx
@@ -154,14 +154,12 @@ export default function Scratch({
 
     const [saveSource, saveContext] = useLanguageServer(languageServerEnabledSetting, scratch, sourceEditor, contextEditor)
 
-    const [lastGoodScore, setLastGoodScore] = useState<number>(scratch.score)
-    const [lastGoodMaxScore, setLastGoodMaxScore] = useState<number>(scratch.max_score)
-    useEffect(() => {
-        if (compilation?.success) {
-            setLastGoodScore(compilation.diff_output.current_score)
-            setLastGoodMaxScore(compilation.diff_output.max_score)
-        }
-    }, [compilation.diff_output.current_score, compilation.diff_output.max_score, compilation?.success])
+    const lastGoodScore = useRef<number>(scratch.score)
+    const lastGoodMaxScore = useRef<number>(scratch.max_score)
+    if (compilation?.success) {
+        lastGoodScore.current = compilation?.diff_output?.current_score
+        lastGoodMaxScore.current = compilation?.diff_output?.max_score
+    }
 
     // TODO: CustomLayout should handle adding/removing tabs
     const [decompilationTabEnabled, setDecompilationTabEnabled] = useState(false)
@@ -316,7 +314,7 @@ export default function Scratch({
             : <></>
     )
 
-    const matchPercent = calculateScorePercent(lastGoodScore, lastGoodMaxScore)
+    const matchPercent = calculateScorePercent(lastGoodScore.current, lastGoodMaxScore.current)
 
     return <div ref={container.ref} className={styles.container}>
         <ErrorBoundary>


### PR DESCRIPTION
It is a pattern best avoided, since it causes a re-render after rendering one frame. In this case, refs work just as well.

In addition, this fixes a potential crash from accessing diff_output.current_score, where diff_output may be null. (Reported in Discord chat.)