### PR TITLE
Toggle problems by clicking anywhere on the bar

### DIFF
--- a/frontend/src/components/Diff/CompilationPanel.tsx
+++ b/frontend/src/components/Diff/CompilationPanel.tsx
@@ -76,12 +76,8 @@ export default function CompilationPanel({ compilation, isCompiling, isCompilati
             >
                 <div className="flex h-full w-full flex-col">
                     <h2 className="flex items-center border-b border-b-gray-5 p-1 pl-3">
-                        <span className="text-sm font-medium">
-                            {(problemState == ProblemState.NO_PROBLEMS) ? "No problems" : "Problems"}
-                        </span>
-                        <div className="grow" />
                         <GhostButton
-                            className="text-gray-11"
+                            className="flex w-max grow justify-between text-gray-11"
                             onClick={() => {
                                 const containerHeight = container.current?.clientHeight ?? 0
                                 const newProblemsHeight = isProblemsCollapsed ? problemsDefaultHeight : problemsCollapsedHeight
@@ -91,6 +87,9 @@ export default function CompilationPanel({ compilation, isCompiling, isCompilati
                                 ])
                             }}
                         >
+                            <span className="text-sm font-medium">
+                                {(problemState == ProblemState.NO_PROBLEMS) ? "No problems" : "Problems"}
+                            </span>
                             {isProblemsCollapsed ? <ChevronUpIcon /> : <ChevronDownIcon />}
                         </GhostButton>
                     </h2>


### PR DESCRIPTION
## Description

Previously the "Problems" bar could only be toggled by clicking the small icon on the very far right. It would be a more pleasant of a user experience to be able to simply click the bar anywhere to toggle it, as it is much quicker and requires less precision.

This stretches the button to fit the full bar while keeping the spacing of the text an arrow icon as before.

## Demonstration
![Peek_2024-03-19_18-37](https://github.com/decompme/decomp.me/assets/4957200/7339f52e-a8c9-43df-8e1f-55a060ea37a5)
