### PR TITLE
make presets great again

### DIFF
--- a/frontend/src/app/(navfooter)/new/NewScratchForm.tsx
+++ b/frontend/src/app/(navfooter)/new/NewScratchForm.tsx
@@ -158,7 +158,7 @@ export default function NewScratchForm({ serverCompilers }: {
         } else {
             localStorage["new_scratch_presetId"] = presetId
         }
-    }, [ready.current, label, asm, context, platform, compilerId, compilerFlags, diffFlags, libraries, presetId])
+    }, [ready, label, asm, context, platform, compilerId, compilerFlags, diffFlags, libraries, presetId])
 
     // Use first available platform if no platform was selected or is unavailable
     if (!platform || Object.keys(serverCompilers.platforms).indexOf(platform) === -1) {
@@ -188,7 +188,7 @@ export default function NewScratchForm({ serverCompilers }: {
                 }
             }
         }
-    }, [ready.current, presetId, compilerId, platformCompilers, serverCompilers, platform])
+    }, [ready, presetId, compilerId, platformCompilers, serverCompilers, platform])
 
     const compilersTranslation = useTranslation("compilers")
     const compilerChoiceOptions = useMemo(() => {

--- a/frontend/src/components/Scratch/Scratch.tsx
+++ b/frontend/src/components/Scratch/Scratch.tsx
@@ -241,7 +241,7 @@ export default function Scratch({
             </Tab>
         case TabId.OPTIONS:
             return <Tab key={id} tabKey={id} label="Options" className={styles.compilerOptsTab}>
-                {() => <div className={styles.compilerOptsContainer}>
+                <div className={styles.compilerOptsContainer}>
                     <CompilerOpts
                         platform={scratch.platform}
                         value={scratch}
@@ -253,7 +253,7 @@ export default function Scratch({
                         matchOverride={scratch.match_override}
                         onMatchOverrideChange={m => setScratch({ match_override: m })}
                     />
-                </div>}
+                </div>
             </Tab>
         case TabId.DIFF:
             return <Tab

--- a/frontend/src/components/compiler/PresetSelect.tsx
+++ b/frontend/src/components/compiler/PresetSelect.tsx
@@ -24,7 +24,7 @@ export default function PresetSelect({ className, platform, presetId, setPreset,
     if (typeof serverPresets === "undefined")
         serverPresets = api.usePresets(platform)
 
-    const sortedPresets = typeof serverPresets === "undefined" ? null : serverPresets.toSorted((a, b) => a.name[0].localeCompare(b.name[0]))
+    const sortedPresets = typeof serverPresets === "undefined" ? null : serverPresets.toSorted((a, b) => a.name.localeCompare(b.name))
 
     if (sortedPresets === null) {
         return <Select

--- a/frontend/src/components/compiler/PresetSelect.tsx
+++ b/frontend/src/components/compiler/PresetSelect.tsx
@@ -21,23 +21,31 @@ export default function PresetSelect({ className, platform, presetId, setPreset,
     setPreset: (preset: api.Preset) => void
     serverPresets?: api.Preset[]
 }) {
-    if (!serverPresets)
+    if (typeof serverPresets === "undefined")
         serverPresets = api.usePresets(platform)
 
-    const selectedPreset = serverPresets.find(p => p.id === presetId)
+    const sortedPresets = typeof serverPresets === "undefined" ? null : serverPresets.toSorted((a, b) => a.name[0].localeCompare(b.name[0]))
 
-    if (serverPresets.length > 0 && typeof presetId === "number" && !selectedPreset)
+    if (sortedPresets === null) {
+        return <Select
+            className={className}
+            options={{ "Loading": "Loading..." }}
+            value={"Loading"}
+            onChange={null}
+        />
+    }
+
+    const selectedPreset = sortedPresets.find((p: api.Preset) => p.id === presetId)
+
+    if (sortedPresets.length > 0 && typeof presetId === "number" && !selectedPreset)
         console.warn(`Scratch.preset == '${presetId}' but no preset with that id was found.`)
 
     return <Select
         className={className}
-        options={presetsToOptions(serverPresets)}
+        options={presetsToOptions(sortedPresets)}
         value={selectedPreset?.name || "Custom"}
         onChange={name => {
-            const p = serverPresets.find(p => p.name === name)
-            if (p) {
-                setPreset(p)
-            }
+            setPreset(name === "Custom" ? null : sortedPresets.find((p: api.Preset) => p.name === name))
         }}
     />
 }

--- a/frontend/src/components/compiler/PresetSelect.tsx
+++ b/frontend/src/components/compiler/PresetSelect.tsx
@@ -24,7 +24,7 @@ export default function PresetSelect({ className, platform, presetId, setPreset,
     if (typeof serverPresets === "undefined")
         serverPresets = api.usePresets(platform)
 
-    const sortedPresets = typeof serverPresets === "undefined" ? null : serverPresets.toSorted((a, b) => a.name.localeCompare(b.name))
+    const sortedPresets = typeof serverPresets === "undefined" ? null : serverPresets.slice().sort((a, b) => a.name.localeCompare(b.name))
 
     if (sortedPresets === null) {
         return <Select

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -288,11 +288,7 @@ export function usePresets(platform: string): Preset[] {
         onErrorRetry,
     })
 
-    if (!data) {
-        return []
-    }
-
-    return data.results
+    return data?.results
 }
 
 export function usePreset(id: number | undefined): Preset | undefined {


### PR DESCRIPTION
- (per ConorB) don't wrap the Options tab in a function to fix the "Problems" issue
- Differentiate between no presets (i.e. either Options tab, or API hasn't returned yet) and empty presets (i.e. PSP platform)
  - show "Loading..." whilst waiting for API to return
- Allow user to select "Custom" preset
- Sort presets alphabetically by name

Closes #1157.