### PR TITLE
Include M2CError response when decompilation fails due to bad context

### DIFF
--- a/backend/coreapp/decompiler_wrapper.py
+++ b/backend/coreapp/decompiler_wrapper.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 MAX_M2C_ASM_LINES = 15000
 
-DECOMP_WITH_CONTEXT_FAILED_PREAMBLE = "/* Decompilation with context failed; here's the decompilation without context: */\n\n"
+DECOMP_WITH_CONTEXT_FAILED_PREAMBLE = "/* Decompilation with context failed; here's the decompilation without context: */\n"
 
 
 class DecompilerWrapper:
@@ -35,7 +35,7 @@ class DecompilerWrapper:
                 # Attempt to decompile the source without context as a last-ditch effort
                 try:
                     ret = M2CWrapper.decompile(asm, "", compiler, platform.arch)
-                    ret = DECOMP_WITH_CONTEXT_FAILED_PREAMBLE + ret
+                    ret = f"{e}\n{DECOMP_WITH_CONTEXT_FAILED_PREAMBLE}\n{ret}"
                 except M2CError as e:
                     ret = f"{e}\n{default_source_code}"
             except Exception:

--- a/backend/coreapp/tests/test_decompilation.py
+++ b/backend/coreapp/tests/test_decompilation.py
@@ -71,8 +71,9 @@ class DecompilationTests(BaseTestCase):
         )
         self.assertEqual(
             response.json()["decompilation"],
-            DECOMP_WITH_CONTEXT_FAILED_PREAMBLE
-            + "s32 return_2(void) {\n    return 2;\n}\n",
+            "/*\nDecompilation failure:\n\nSyntax error when parsing C context.\nbefore: jeff at line 1, column 10\n\ntypedeff jeff;\n*/\n\n"
+            + DECOMP_WITH_CONTEXT_FAILED_PREAMBLE
+            + "\ns32 return_2(void) {\n    return 2;\n}\n",
         )
 
 


### PR DESCRIPTION
e.g.

```
/*
Decompilation failure:

Syntax error when parsing C context.
before: context at line 1, column 5

bad context
*/

/* Decompilation with context failed; here's the decompilation without context: */

void myfunc(void) {

}
```

Closes #1166.