### PR TITLE
Have NetworkErrorPage use `window.location.reload` instead of `reset`

### DIFF
--- a/frontend/src/app/error.tsx
+++ b/frontend/src/app/error.tsx
@@ -2,8 +2,6 @@
 
 import { useEffect } from "react"
 
-import { useRouter } from "next/navigation"
-
 import { SyncIcon } from "@primer/octicons-react"
 
 import Button from "@/components/Button"

--- a/frontend/src/app/error.tsx
+++ b/frontend/src/app/error.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect } from "react"
 
+import { useRouter } from "next/navigation"
+
 import { SyncIcon } from "@primer/octicons-react"
 
 import Button from "@/components/Button"
@@ -11,7 +13,7 @@ import { RequestFailedError } from "@/lib/api"
 
 type ErrorPageProps = {error: Error, reset: () => void };
 
-function NetworkErrorPage({ error, reset }: ErrorPageProps) {
+function NetworkErrorPage({ error, reset: _reset }: ErrorPageProps) {
     return <>
         <SetPageTitle title="Error" />
         <div className="grow" />
@@ -27,7 +29,7 @@ function NetworkErrorPage({ error, reset }: ErrorPageProps) {
             </p>
 
             <ErrorBoundary>
-                <Button onClick={reset}>
+                <Button onClick={() => window.location.reload()}>
                     <SyncIcon /> Try again
                 </Button>
             </ErrorBoundary>


### PR DESCRIPTION
Fixes #870.

I've left `UnexpectedErrorPage` as using `reset` - it feels like a pure client-side rerender might be more appropriate as a recovery option there? I'm open to arguments the other way, too.