### PR TITLE
Add more verbosity to debug CCPSX compiler failure

### DIFF
--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -379,8 +379,8 @@ PSYQ46 = GCCPS1Compiler(
 )
 
 PSYQ_CCPSX = (
-    'echo ${OUTPUT} && '
-    'echo pwd is $(pwd) && '
+    "echo ${OUTPUT} && "
+    "echo pwd is $(pwd) && "
     'echo "[ccpsx]" >> SN.INI && '
     'echo "compiler_path=${COMPILER_DIR//\\//\\\\}" >> SN.INI && '
     'echo "assembler_path=${COMPILER_DIR//\\//\\\\}" >> SN.INI && '

--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -379,10 +379,13 @@ PSYQ46 = GCCPS1Compiler(
 )
 
 PSYQ_CCPSX = (
+    'echo ${OUTPUT} && '
+    'echo pwd is $(pwd) && '
     'echo "[ccpsx]" >> SN.INI && '
     'echo "compiler_path=${COMPILER_DIR//\\//\\\\}" >> SN.INI && '
     'echo "assembler_path=${COMPILER_DIR//\\//\\\\}" >> SN.INI && '
-    'TMPDIR=. SN_PATH=. ${WINE} ${COMPILER_DIR}/CCPSX.EXE -v -c ${COMPILER_FLAGS} "${INPUT}" -o "${OUTPUT}bj" && '
+    'echo "tmpdir=/tmp" >> SN.INI && '
+    'SN_PATH=. ${WINE} ${COMPILER_DIR}/CCPSX.EXE -v -c ${COMPILER_FLAGS} "${INPUT}" -o "${OUTPUT}bj" && '
     '${COMPILER_DIR}/psyq-obj-parser "${OUTPUT}"bj -o "${OUTPUT}"'
 )
 


### PR DESCRIPTION
It seemed like the `TMPDIR` environment variable was being ignored, so I've stuck it in the SN.INI file instead, also echo out more stuff to ensure we are in the directory I expect us to be in!