### PR TITLE
Make libraries platform-specific redux

### DIFF
--- a/backend/coreapp/compiler_wrapper.py
+++ b/backend/coreapp/compiler_wrapper.py
@@ -182,7 +182,8 @@ class CompilerWrapper:
                 st = round(time.time() * 1000)
                 libraries_compiler_flags = " ".join(
                     (
-                        compiler.library_include_flag + str(lib.include_path)
+                        compiler.library_include_flag
+                        + str(lib.get_include_path(compiler.platform.id))
                         for lib in libraries
                     )
                 )

--- a/backend/coreapp/libraries.py
+++ b/backend/coreapp/libraries.py
@@ -16,7 +16,7 @@ class Library:
     name: str
     version: str
 
-    def get_include_path(self, platform: str):
+    def get_include_path(self, platform: str) -> Path:
         return LIBRARY_BASE_PATH / platform / self.name / self.version
 
     def available(self, platform: str) -> bool:

--- a/backend/coreapp/libraries.py
+++ b/backend/coreapp/libraries.py
@@ -16,58 +16,53 @@ class Library:
     name: str
     version: str
 
-    @property
-    def path(self) -> Path:
-        return LIBRARY_BASE_PATH / self.name / self.version
+    def get_include_path(self, platform: str):
+        return LIBRARY_BASE_PATH / platform / self.name / self.version
 
-    @property
-    def include_path(self) -> Path:
-        return self.path / "include"
-
-    def available(self) -> bool:
-        if not self.include_path.exists():
-            print(
-                f"Library {self.name} {self.version} not found at {self.include_path}"
-            )
-        return self.include_path.exists()
+    def available(self, platform: str) -> bool:
+        include_path = self.get_include_path(platform)
+        if not include_path.exists():
+            print(f"Library {self.name} {self.version} not found at {include_path}")
+        return include_path.exists()
 
 
 @dataclass(frozen=True)
 class LibraryVersions:
     name: str
     supported_versions: list[str]
+    platform: str
 
     @property
     def path(self) -> Path:
-        return LIBRARY_BASE_PATH / self.name
+        return LIBRARY_BASE_PATH / self.platform / self.name
 
 
 @cache
 def available_libraries() -> list[LibraryVersions]:
     results = []
 
-    for lib_dir in LIBRARY_BASE_PATH.iterdir():
-        versions = []
-        if not lib_dir.is_dir():
+    for platform_dir in LIBRARY_BASE_PATH.iterdir():
+        if not platform_dir.is_dir():
             continue
-        for version_dir in lib_dir.iterdir():
-            if not version_dir.is_dir():
+        for lib_dir in platform_dir.iterdir():
+            versions = []
+            if not lib_dir.is_dir():
                 continue
-            if not (version_dir / "include").exists():
-                continue
+            for version_dir in lib_dir.iterdir():
+                if not version_dir.is_dir():
+                    continue
+                if not (version_dir / "include").exists():
+                    continue
 
-            versions.append(version_dir.name)
+                versions.append(version_dir.name)
 
-        if len(versions) > 0:
-            results.append(
-                LibraryVersions(
-                    name=lib_dir.name,
-                    supported_versions=versions,
+            if len(versions) > 0:
+                results.append(
+                    LibraryVersions(
+                        name=lib_dir.name,
+                        supported_versions=versions,
+                        platform=platform_dir.name,
+                    )
                 )
-            )
 
     return results
-
-
-DIRECTX5 = Library("directx", "5.0")
-DIRECTX8 = Library("directx", "8.0")

--- a/backend/coreapp/views/library.py
+++ b/backend/coreapp/views/library.py
@@ -14,10 +14,15 @@ boot_time = now()
 
 class LibraryDetail(APIView):
     @staticmethod
-    def libraries_json() -> list[dict[str, object]]:
+    def libraries_json(platform: str = "") -> list[dict[str, object]]:
         return [
-            {"name": l.name, "supported_versions": l.supported_versions}
+            {
+                "name": l.name,
+                "supported_versions": l.supported_versions,
+                "platform": l.platform,
+            }
             for l in libraries.available_libraries()
+            if platform == "" or l.platform == platform
         ]
 
     @condition(last_modified_func=lambda request: boot_time)
@@ -26,8 +31,9 @@ class LibraryDetail(APIView):
 
     @condition(last_modified_func=lambda request: boot_time)
     def get(self, request: Request) -> Response:
+        platform = request.query_params.get("platform", "")
         return Response(
             {
-                "libraries": LibraryDetail.libraries_json(),
+                "libraries": LibraryDetail.libraries_json(platform=platform),
             }
         )

--- a/backend/coreapp/views/scratch.py
+++ b/backend/coreapp/views/scratch.py
@@ -253,9 +253,7 @@ def create_scratch(data: Dict[str, Any], allow_project: bool = False) -> Scratch
 
     name = data.get("name", diff_label) or "Untitled"
 
-    libraries = [
-        Library(name=lib["name"], version=lib["version"]) for lib in data["libraries"]
-    ]
+    libraries = [Library(**lib) for lib in data["libraries"]]
 
     ser = ScratchSerializer(
         data={
@@ -376,10 +374,7 @@ class ScratchViewSet(
             if "context" in request.data:
                 scratch.context = request.data["context"]
             if "libraries" in request.data:
-                libs = [
-                    Library(name=data["name"], version=data["version"])
-                    for data in request.data["libraries"]
-                ]
+                libs = [Library(**lib) for lib in request.data["libraries"]]
                 scratch.libraries = libs
 
         compilation = compile_scratch(scratch)

--- a/backend/libraries/libraries.yaml
+++ b/backend/libraries/libraries.yaml
@@ -1,9 +1,10 @@
-directx:
-  '5.0':
-    git:
-      url: https://github.com/roblabla/directx-headers
-      branch: '5.0'
-  '8.0':
-    git:
-      url: https://github.com/roblabla/directx-headers
-      branch: main
+win32:
+  directx:
+    '5.0':
+      git:
+        url: https://github.com/roblabla/directx-headers
+        branch: '5.0'
+    '8.0':
+      git:
+        url: https://github.com/roblabla/directx-headers
+        branch: main

--- a/frontend/src/components/compiler/CompilerOpts.tsx
+++ b/frontend/src/components/compiler/CompilerOpts.tsx
@@ -281,7 +281,7 @@ export default function CompilerOpts({ platform, value, onChange, diffLabel, onD
         </OptsContext.Provider>
 
         <section className={styles.section}>
-            <LibrariesEditor libraries={value.libraries} setLibraries={setLibraries} />
+            <LibrariesEditor libraries={value.libraries} setLibraries={setLibraries} platform={platform} />
         </section>
 
         <OptsContext.Provider value={diffOptsEditorProvider}>
@@ -379,11 +379,12 @@ export function DiffOptsEditor({ platform, compiler: compilerId, diffLabel, onDi
     </div>
 }
 
-export function LibrariesEditor({ libraries, setLibraries }: {
+export function LibrariesEditor({ libraries, setLibraries, platform }: {
     libraries: Library[]
     setLibraries: (libraries: Library[]) => void
+    platform: string
 }) {
-    const supportedLibraries = api.useLibraries()
+    const supportedLibraries = api.useLibraries(platform)
     const librariesTranslations = useTranslation("libraries")
 
     const libraryVersions = (scratchlib: api.Library) => {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -264,17 +264,18 @@ export function useCompilers(): Record<string, Compiler> {
     return data.compilers
 }
 
-export function useLibraries(): LibraryVersions[] {
-    const { data } = useSWR("/library", get, {
+export function useLibraries(platform: string): LibraryVersions[] {
+    const getByPlatform = ([url, platform]: [string | null, string]) => {
+        return get(url && platform && `${url}?platform=${platform}`)
+    }
+
+    const url = typeof platform === "string" ? "/library" : null
+    const { data } = useSWR([url, platform], getByPlatform, {
         refreshInterval: 0,
         onErrorRetry,
     })
 
-    if (!data) {
-        return []
-    }
-
-    return data.libraries
+    return data?.libraries || []
 }
 
 export function usePresets(platform: string): Preset[] {

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -118,6 +118,7 @@ export type Library = {
 export type LibraryVersions = {
     name: string
     supported_versions: string[]
+    platform: string
 }
 
 export type Preset = {


### PR DESCRIPTION
We know the platform when we come to use the library, so passing it in here is less intrusive than trying to give all Libraries a platform.

I've also updated the useLibraries / `api/library` view to support `platform=xyz` being passed, the alternative could be to return all libraries and then doing some filtering on the client side. This could be changed if we find ourselves with libraries supporting multiple platforms... or it could be changed now :)