### PR TITLE
Remove 'language' from TerseScratch serializer

### DIFF
--- a/backend/coreapp/serializers.py
+++ b/backend/coreapp/serializers.py
@@ -267,7 +267,6 @@ class TerseScratchSerializer(ScratchSerializer):
             "platform",
             "compiler",
             "preset",
-            "language",
             "name",
             "score",
             "max_score",


### PR DESCRIPTION
Closes #1201.

I'm pretty sure we don't need `language` as part of a terse scratch - it's the only thing making the site explode when a compiler isn't available.