### PR TITLE
Tweak opengraph rendinger speed

### DIFF
--- a/frontend/src/app/(navfooter)/page.tsx
+++ b/frontend/src/app/(navfooter)/page.tsx
@@ -8,7 +8,7 @@ import WelcomeInfo from "./WelcomeInfo"
 export async function generateMetadata(): Promise<Metadata> {
     const title = "decomp.me"
 
-    const description = "A collaborative reverse-engineering platform for working on decompilation projects with others."
+    const description = "A collaborative decompilation platform."
 
     return {
         openGraph: {

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -13,6 +13,13 @@ export const metadata = {
     openGraph: {
         siteName: "decomp.me",
         type: "website",
+        images: [
+            {
+                url: "/opengraph-image",
+                width: 1200,
+                height: 400,
+            },
+        ],
     },
     // set this to avoid "metadata.metadataBase is not set..." warning
     metadataBase: new URL(process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : `http://localhost:${process.env.PORT || 3000}`),

--- a/frontend/src/app/opengraph-image.tsx
+++ b/frontend/src/app/opengraph-image.tsx
@@ -20,9 +20,11 @@ export default async function HomeOG() {
     const OpenSansBold = fetch(new URL("/public/fonts/OpenSans-Bold.ttf", import.meta.url)).then(res =>
         res.arrayBuffer()
     )
+
     const statsRes = await fetch("http://decomp.me/api/stats")
     const stats = await statsRes.json()
-    const icon_size = 150
+    const iconSize = 160
+    const iconCount = 5
     const textScale = 4.15
     const textSize = {
         title: textScale,
@@ -33,18 +35,18 @@ export default async function HomeOG() {
         (
             <div
                 tw="flex flex-col w-full h-full bg-zinc-900 text-slate-50 items-center justify-center">
-                <div tw="absolute flex flex-row items-center h-full gap-2 opacity-40">
+                <div tw="absolute flex flex-row items-center h-full opacity-25">
                     {PLATFORMS.map(platform => ({ platform, sort: Math.random() }))
                         .sort((a, b) => a.sort - b.sort)
+                        .slice(0, iconCount)
                         .map(({ platform }) => {
                             const Icon = platformIcon(platform)
-                            return (<Icon key={platform} width={icon_size} height={icon_size} tw="ml-16 shadow-2xl" style={{ filter: "blur(2px)" }} />)
+                            return (<Icon key={platform} width={iconSize} height={iconSize} tw="m-10" />)
                         })}
                 </div>
                 <div tw="w-full h-1/10" />
-                <div tw={`flex w-full justify-center text-[${textSize.title}rem] text-gray-12`} style={{ fontFamily: "OpenSans-ExtraBold" }}>decomp.me</div>
-                <a tw={`flex flex-wrap justify-center text-[${textSize.description}rem] text-gray-12 text-center`} style={{ fontFamily: "OpenSans-Bold" }}>Collaboratively decompile code in your</a>
-                <a tw={`flex flex-wrap justify-center text-[${textSize.description}rem] text-gray-12`} style={{ fontFamily: "OpenSans-Bold" }}>browser</a>
+                <div tw={`flex w-full justify-center text-[${textSize.title}rem]`} style={{ fontFamily: "OpenSans-ExtraBold" }}>decomp.me</div>
+                <span tw={`flex flex-wrap justify-center text-[${textSize.description}rem] text-center w-3/4`} style={{ fontFamily: "OpenSans-Bold" }}>Collaboratively decompile code in your browser</span>
                 <div tw="w-full h-1/8" />
                 <div tw={`flex justify-between w-full text-[${textSize.stats}rem]`} style={{ fontFamily: "OpenSans-SemiBold" }}>
                     <a tw="ml-10">{stats.scratch_count.toLocaleString()} scratches created</a>

--- a/frontend/src/app/opengraph-image.tsx
+++ b/frontend/src/app/opengraph-image.tsx
@@ -29,7 +29,7 @@ export default async function HomeOG() {
     const textSize = {
         title: textScale,
         description: 0.6 * textScale,
-        stats: 0.3 * textScale,
+        stats: 0.45 * textScale,
     }
     return new ImageResponse(
         (
@@ -49,10 +49,10 @@ export default async function HomeOG() {
                 <span tw={`flex flex-wrap justify-center text-[${textSize.description}rem] text-center w-3/4`} style={{ fontFamily: "OpenSans-Bold" }}>Collaboratively decompile code in your browser</span>
                 <div tw="w-full h-1/8" />
                 <div tw={`flex justify-between w-full text-[${textSize.stats}rem]`} style={{ fontFamily: "OpenSans-SemiBold" }}>
-                    <a tw="ml-10">{stats.scratch_count.toLocaleString()} scratches created</a>
-                    <a>{stats.profile_count.toLocaleString()} unique visitors</a>
-                    <a>{stats.github_user_count.toLocaleString()} users signed up</a>
-                    <a tw="mr-10">{stats.asm_count.toLocaleString()} asm globs submitted</a>
+                    <a tw="ml-10">{stats.scratch_count.toLocaleString()} scratches</a>
+                    <a>{stats.profile_count.toLocaleString()} visitors</a>
+                    <a>{stats.github_user_count.toLocaleString()} users</a>
+                    <a tw="mr-10">{stats.asm_count.toLocaleString()} asm globs</a>
                 </div>
             </div>
         ),


### PR DESCRIPTION
key change here is to only draw 5 platform icons (rather than 9) as only 5 fit.