### PR TITLE
Added mobile touch event listeners for dragbar and min allotment heights

### DIFF
--- a/frontend/src/components/CustomLayout.tsx
+++ b/frontend/src/components/CustomLayout.tsx
@@ -70,7 +70,7 @@ export default function CustomLayout({ renderTab, layout, onChange }: Props) {
         </Tabs>
     } else {
         const els = []
-
+        const minCollapsedHeight = 37
         for (let index = 0; index < layout.children.length; index++) {
             const child = layout.children[index]
 
@@ -82,7 +82,7 @@ export default function CustomLayout({ renderTab, layout, onChange }: Props) {
 
             els.push(<Allotment.Pane
                 key={child.key}
-                snap
+                minSize={minCollapsedHeight}
             >
                 <CustomLayout
                     renderTab={renderTab}

--- a/frontend/src/components/Diff/DragBar.tsx
+++ b/frontend/src/components/Diff/DragBar.tsx
@@ -20,16 +20,30 @@ export default function DragBar({ pos, onChange }: Props) {
             }
         }
 
+        const onTouchMove = (evt: TouchEvent) => {
+            if (isActive) {
+                const parent = ref.current.parentElement
+                if (parent) {
+                    const touch = evt.touches[0]
+                    onChange(touch.clientX - parent.getBoundingClientRect().x)
+                }
+            }
+        }
+
         const onMouseUp = () => {
             setIsActive(false)
         }
 
         document.addEventListener("mousemove", onMouseMove)
         document.addEventListener("mouseup", onMouseUp)
+        document.addEventListener("touchmove", onTouchMove)
+        document.addEventListener("touchend", onMouseUp)
 
         return () => {
             document.removeEventListener("mousemove", onMouseMove)
             document.removeEventListener("mouseup", onMouseUp)
+            document.removeEventListener("touchmove", onTouchMove)
+            document.removeEventListener("touchend", onMouseUp)
         }
     })
 
@@ -38,5 +52,6 @@ export default function DragBar({ pos, onChange }: Props) {
         className={styles.vertical}
         style={{ left: `${pos}px` }}
         onMouseDown={() => setIsActive(true)}
+        onTouchMove={() => setIsActive(true)}
     />
 }


### PR DESCRIPTION
This is for issue [#1202](https://github.com/decompme/decomp.me/issues/1202)

[Screencast from 2024-05-01 12-27-49.webm](https://github.com/decompme/decomp.me/assets/151766738/9347f817-2b1e-4c72-bb53-df3b153a1d50)
