### PR TITLE
Use same blue for diff vertical splitter as horizontal splits

### DIFF
--- a/frontend/src/components/Diff/DragBar.module.scss
+++ b/frontend/src/components/Diff/DragBar.module.scss
@@ -22,3 +22,10 @@
         transform: translateX(-50%);
     }
 }
+
+.active {
+    &::after {
+        width: 4px;
+        background: #007fd4;
+    }
+}

--- a/frontend/src/components/Diff/DragBar.tsx
+++ b/frontend/src/components/Diff/DragBar.tsx
@@ -35,7 +35,7 @@ export default function DragBar({ pos, onChange }: Props) {
 
     return <div
         ref={ref}
-        className={styles.vertical}
+        className={`${styles.vertical} ${isActive ? styles.active : ""}`}
         style={{ left: `${pos}px` }}
         onMouseDown={() => setIsActive(true)}
     />

--- a/frontend/src/components/Diff/DragBar.tsx
+++ b/frontend/src/components/Diff/DragBar.tsx
@@ -35,7 +35,7 @@ export default function DragBar({ pos, onChange }: Props) {
 
     return <div
         ref={ref}
-        className={`${styles.vertical} ${isActive ? styles.active : ""}`}
+        className={`${styles.vertical} ${isActive && styles.active}`}
         style={{ left: `${pos}px` }}
         onMouseDown={() => setIsActive(true)}
     />


### PR DESCRIPTION
After looking at #1217 I thought it would be good to use the same blue highlighting when dragging the bar to resize target/current asm:

![image](https://github.com/decompme/decomp.me/assets/22226349/9671f27b-8573-42d1-a45a-1bbbfb599c29)
