### PR TITLE
Fix: misaligned GitHub link on profile page issue 686

### DIFF
--- a/frontend/src/app/(navfooter)/u/[username]/page.tsx
+++ b/frontend/src/app/(navfooter)/u/[username]/page.tsx
@@ -52,7 +52,7 @@ export default async function Page({ params }: { params: { username: string } })
                     {user.username}
                 </h1>
 
-                <div className="flex flex-wrap items-center gap-2 pt-1 text-sm text-gray-11">
+                <div className="flex justify-center md:justify-start flex-wrap items-center gap-2 pt-1 text-sm text-gray-11">
                     <GhostButton href={userGithubHtmlUrl(user)}>
                         <div className="flex items-center gap-1">
                             {userGithubHtmlUrl(user) && <MarkGithubIcon size={16} aria-label="GitHub username" />}


### PR DESCRIPTION
Hi @mkst @marijnvdwerf 
Fixed #686 
I have added classes "justify-center md:justify-start" to the div holding github icon and the user name in span tag
This fixed the issue