### PR TITLE
Scroll to line when clicking line number

### DIFF
--- a/frontend/src/components/Diff/Diff.tsx
+++ b/frontend/src/components/Diff/Diff.tsx
@@ -94,7 +94,7 @@ function scrollToSourceFromLineNumber(cell: api.DiffCell | undefined) {
         const lineNumbersEle = document.getElementsByClassName("cm-gutter cm-lineNumbers").item(0)
         const scrollerEle = document.getElementsByClassName("cm-scroller").item(0)
         if (lineNumbersEle) {
-            const lineNumberEle = lineNumbersEle.children[cell.src_line]
+            const lineNumberEle = lineNumbersEle.children[cell.src_line] as HTMLElement
             if (lineNumberEle) {
                 scrollerEle.scroll({
                     left: lineNumberEle.offsetLeft,

--- a/frontend/src/components/Diff/Diff.tsx
+++ b/frontend/src/components/Diff/Diff.tsx
@@ -99,7 +99,7 @@ function scrollToSourceFromLineNumber(cell: api.DiffCell | undefined) {
                 scrollerEle.scroll({
                     left: lineNumberEle.offsetLeft,
                     top: lineNumberEle.offsetTop,
-                    behavior: "smooth" // smoothly scroll to the line
+                    behavior: "smooth", // smoothly scroll to the line
                 })
             }
         }

--- a/frontend/src/components/Diff/Diff.tsx
+++ b/frontend/src/components/Diff/Diff.tsx
@@ -87,6 +87,25 @@ function FormatDiffText({ texts, highlighter }: {
     }</>
 }
 
+function scrollToSourceFromLineNumber(cell: api.DiffCell | undefined) {
+    if (cell) {
+        // item(0) is the source tab
+        // item(1) is the context tab
+        const lineNumbersEle = document.getElementsByClassName("cm-gutter cm-lineNumbers").item(0)
+        const scrollerEle = document.getElementsByClassName("cm-scroller").item(0)
+        if (lineNumbersEle) {
+            const lineNumberEle = lineNumbersEle.children[cell.src_line]
+            if (lineNumberEle) {
+                scrollerEle.scroll({
+                    left: lineNumberEle.offsetLeft,
+                    top: lineNumberEle.offsetTop,
+                    behavior: "smooth" // smoothly scroll to the line
+                })
+            }
+        }
+    }
+}
+
 function DiffCell({ cell, className, highlighter }: {
     cell: api.DiffCell | undefined
     className?: string
@@ -103,7 +122,7 @@ function DiffCell({ cell, className, highlighter }: {
             [styles.highlight]: hasLineNo && cell.src_line == selectedSourceLine,
         })}
     >
-        {hasLineNo && <span className={styles.lineNumber}>{cell.src_line}</span>}
+        {hasLineNo && <span className={styles.lineNumber}><button onClick={() => scrollToSourceFromLineNumber(cell)}>{cell.src_line}</button></span>}
         <FormatDiffText texts={cell.text} highlighter={highlighter} />
     </div>
 }


### PR DESCRIPTION
Scroll to line in source tab when line numbers in diff are clicked.

This does not highlight the newly selected line.

Related to https://github.com/decompme/decomp.me/issues/115.
"Click a line number to jump to it in the source"

This should be reviewed.