### PR TITLE
feat(presets): include profile in preset owner field

### DIFF
--- a/backend/coreapp/serializers.py
+++ b/backend/coreapp/serializers.py
@@ -66,7 +66,8 @@ class LibrarySerializer(serializers.Serializer[Library]):
 class PresetSerializer(serializers.ModelSerializer[Preset]):
     libraries = serializers.ListField(child=LibrarySerializer(), default=list)
     num_scratches = serializers.SerializerMethodField()
-
+    owner = ProfileField(read_only=True)
+    
     class Meta:
         model = Preset
         fields = [
@@ -80,11 +81,12 @@ class PresetSerializer(serializers.ModelSerializer[Preset]):
             "decompiler_flags",
             "libraries",
             "num_scratches",
-            "owner",
+            "owner"
         ]
         read_only_fields = [
             "creation_time",
             "last_updated",
+            "owner",
         ]
 
     def get_num_scratches(self, preset: Preset) -> int:

--- a/backend/coreapp/serializers.py
+++ b/backend/coreapp/serializers.py
@@ -67,7 +67,7 @@ class PresetSerializer(serializers.ModelSerializer[Preset]):
     libraries = serializers.ListField(child=LibrarySerializer(), default=list)
     num_scratches = serializers.SerializerMethodField()
     owner = ProfileField(read_only=True)
-    
+
     class Meta:
         model = Preset
         fields = [

--- a/backend/coreapp/serializers.py
+++ b/backend/coreapp/serializers.py
@@ -81,7 +81,7 @@ class PresetSerializer(serializers.ModelSerializer[Preset]):
             "decompiler_flags",
             "libraries",
             "num_scratches",
-            "owner"
+            "owner",
         ]
         read_only_fields = [
             "creation_time",

--- a/backend/coreapp/tests/test_preset.py
+++ b/backend/coreapp/tests/test_preset.py
@@ -120,7 +120,7 @@ class PresetTests(BaseTestCase):
         # Ensure the user is the owner of the preset
         owner = results[0].get("owner")
         assert owner is not None
-        assert owner.get('id') == self.user.pk
+        assert owner.get("id") == self.user.pk
 
     @requiresCompiler(GCC281PM)
     def test_create_preset_with_invalid_compiler(self) -> None:

--- a/backend/coreapp/tests/test_preset.py
+++ b/backend/coreapp/tests/test_preset.py
@@ -118,7 +118,9 @@ class PresetTests(BaseTestCase):
         assert len(results) == 1
         assert results[0].get("name") == DUMMY_PRESET_DICT.get("name")
         # Ensure the user is the owner of the preset
-        assert results[0].get("owner") == self.user.pk
+        owner = results[0].get("owner")
+        assert owner is not None
+        assert owner.get('id') == self.user.pk
 
     @requiresCompiler(GCC281PM)
     def test_create_preset_with_invalid_compiler(self) -> None:

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -132,6 +132,7 @@ export type Preset = {
     decompiler_flags: string
     libraries: Library[]
     num_scratches: number
+    owner: User | null // null = default
 }
 
 export type Compiler = {


### PR DESCRIPTION
In scratch api, we get the full profile with username and user's id in owner field. However in preset we were only getting the id.

<table>
<tr>
<td> Before </td> <td> After </td>
</tr>
<tr>
<td> 

```json
{
    "id": 2,
    "name": "random",
    "platform": "dummy",
    "compiler": "dummy",
    "assembler_flags": "-dummy-asm",
    "compiler_flags": "-dummy-compiler",
    "diff_flags": {},
    "decompiler_flags": "-decompiler",
    "libraries": [],
    "num_scratches": 0,
    "owner": 2
}
```

</td>
<td> 

```json
{
    "id": 2,
    "name": "random",
    "platform": "dummy",
    "compiler": "dummy",
    "assembler_flags": "-dummy-asm",
    "compiler_flags": "-dummy-compiler",
    "diff_flags": {},
    "decompiler_flags": "-decompiler",
    "libraries": [],
    "num_scratches": 0,
    "owner": {
        "is_anonymous": false,
        "id": 2,
        "is_online": true,
        "is_admin": false,
        "username": "axel7083",
        "github_id": 42176370
    }
}
```

</td>
</tr>

This will allow us to improve the Preset card, introduced by https://github.com/decompme/decomp.me/pull/1232 with the user icon.