### PR TITLE
chore(frontend): adding dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5


### PR DESCRIPTION
Some package in the `frontend/packages.json` are a bit outdated, keeping them up to date manually can be often tedious.

Github has the `dependabot` allowing to automate this process.

See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file