### PR TITLE
Make it a little easier to move target/current diff divider on mobile

### DIFF
--- a/frontend/src/components/Diff/DragBar.module.scss
+++ b/frontend/src/components/Diff/DragBar.module.scss
@@ -1,5 +1,5 @@
 .vertical {
-    width: 4px;
+    width: 8px;
     height: 100%;
 
     position: absolute;


### PR DESCRIPTION
8px matches the size of the vertical dividers.