### PR TITLE
Use modified PS2 binutils for PSP

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -85,8 +85,10 @@ RUN if [ "${ENABLE_MSDOS_SUPPORT}" = "YES" ] || \
     wine; \
     fi
 
+ARG ENABLE_PSP_SUPPORT
+
 # Patched mips binutils
-RUN if [ "${ENABLE_PS2_SUPPORT}" = "YES" ]; then \
+RUN if [ "${ENABLE_PS2_SUPPORT}" = "YES" ] || [ "${ENABLE_PSP_SUPPORT}" = "YES" ]; then \
     wget "https://github.com/decompals/binutils-mips-ps2-decompals/releases/download/v0.4/binutils-mips-ps2-decompals-linux-x86-64.tar.gz" && \
     tar xvzf binutils-mips-ps2-decompals-linux-x86-64.tar.gz -C /usr/bin mips-ps2-decompals-as mips-ps2-decompals-nm mips-ps2-decompals-objdump && \
     rm binutils-mips-ps2-decompals-linux-x86-64.tar.gz && \
@@ -141,7 +143,6 @@ ARG ENABLE_N3DS_SUPPORT
 ARG ENABLE_N64_SUPPORT
 ARG ENABLE_NDS_ARM9_SUPPORT
 ARG ENABLE_PS1_SUPPORT
-ARG ENABLE_PSP_SUPPORT
 ARG ENABLE_SATURN_SUPPORT
 ARG ENABLE_SWITCH_SUPPORT
 

--- a/backend/coreapp/platforms.py
+++ b/backend/coreapp/platforms.py
@@ -146,9 +146,9 @@ PSP = Platform(
     name="PlayStation Portable",
     description="MIPS (little-endian)",
     arch="mipsel:4000",
-    assemble_cmd='mips-linux-gnu-as -EL -march=gs464 -mabi=32 -o "$OUTPUT" "$PRELUDE" "$INPUT"',
-    objdump_cmd="mips-linux-gnu-objdump",
-    nm_cmd="mips-linux-gnu-nm",
+    assemble_cmd='mips-ps2-decompals-as -EL -march=gs464 -mabi=32 -o "$OUTPUT" "$PRELUDE" "$INPUT"',
+    objdump_cmd="mips-ps2-decompals-objdump",
+    nm_cmd="mips-ps2-decompals-nm",
     diff_flags=COMMON_DIFF_FLAGS + COMMON_MIPS_DIFF_FLAGS,
     has_decompiler=True,
 )


### PR DESCRIPTION
SOTN uses a Metrowerks compiler that seems to emit the same sort of debug info as the PS2 compilers. This commit changes the binutils to use the modified PS2 binutils. From what I see locally it seems to work fine.

![image](https://github.com/decompme/decomp.me/assets/122322823/670b6b6b-1e33-43e4-a591-902e68aa7dd0)