### PR TITLE
fix: profile field serialization in compiler view

### DIFF
--- a/backend/coreapp/serializers.py
+++ b/backend/coreapp/serializers.py
@@ -22,7 +22,7 @@ from .models.project import Project, ProjectMember
 from .models.scratch import Scratch
 
 
-def serialize_profile(request: Request, profile: Profile) -> Dict[str, Any]:
+def serialize_profile(profile: Profile) -> Dict[str, Any]:
     if profile.user is None:
         return {
             "is_anonymous": True,
@@ -55,7 +55,7 @@ else:
 
 class ProfileField(ProfileFieldBaseClass):
     def to_representation(self, profile: Profile) -> Dict[str, Any]:
-        return serialize_profile(self.context["request"], profile)
+        return serialize_profile(profile)
 
 
 class LibrarySerializer(serializers.Serializer[Library]):

--- a/backend/coreapp/tests/test_preset.py
+++ b/backend/coreapp/tests/test_preset.py
@@ -77,6 +77,19 @@ class PresetTests(BaseTestCase):
         preset = self.create_preset(DUMMY_PRESET_DICT)
         assert preset.owner is not None
         assert preset.owner.pk == self.user.pk
+        
+    def test_list_compiler_with_presets(self) -> None:
+        user = self.create_user()
+        self.create_preset(DUMMY_PRESET_DICT)
+        response = self.client.get(reverse("compiler"))
+        body = response.json()
+
+        assert 'platforms' in body
+        assert 'dummy' in body['platforms']
+        assert 'presets' in body['platforms']['dummy']
+        assert len(body['platforms']['dummy']['presets']) == 1
+        assert body['platforms']['dummy']['presets'][0]['name'] == DUMMY_PRESET_DICT['name']
+        assert body['platforms']['dummy']['presets'][0]['owner']['id'] == user.pk
 
     def test_owner_can_delete_preset(self) -> None:
         self.create_user()

--- a/backend/coreapp/tests/test_preset.py
+++ b/backend/coreapp/tests/test_preset.py
@@ -77,19 +77,22 @@ class PresetTests(BaseTestCase):
         preset = self.create_preset(DUMMY_PRESET_DICT)
         assert preset.owner is not None
         assert preset.owner.pk == self.user.pk
-        
+
     def test_list_compiler_with_presets(self) -> None:
         user = self.create_user()
         self.create_preset(DUMMY_PRESET_DICT)
         response = self.client.get(reverse("compiler"))
         body = response.json()
 
-        assert 'platforms' in body
-        assert 'dummy' in body['platforms']
-        assert 'presets' in body['platforms']['dummy']
-        assert len(body['platforms']['dummy']['presets']) == 1
-        assert body['platforms']['dummy']['presets'][0]['name'] == DUMMY_PRESET_DICT['name']
-        assert body['platforms']['dummy']['presets'][0]['owner']['id'] == user.pk
+        assert "platforms" in body
+        assert "dummy" in body["platforms"]
+        assert "presets" in body["platforms"]["dummy"]
+        assert len(body["platforms"]["dummy"]["presets"]) == 1
+        assert (
+            body["platforms"]["dummy"]["presets"][0]["name"]
+            == DUMMY_PRESET_DICT["name"]
+        )
+        assert body["platforms"]["dummy"]["presets"][0]["owner"]["id"] == user.pk
 
     def test_owner_can_delete_preset(self) -> None:
         self.create_user()

--- a/backend/coreapp/tests/test_preset.py
+++ b/backend/coreapp/tests/test_preset.py
@@ -78,7 +78,7 @@ class PresetTests(BaseTestCase):
         assert preset.owner is not None
         assert preset.owner.pk == self.user.pk
 
-    def test_list_compiler_with_presets(self) -> None:
+    def test_list_compiler_with_custom_presets(self) -> None:
         user = self.create_user()
         self.create_preset(DUMMY_PRESET_DICT)
         response = self.client.get(reverse("compiler"))

--- a/backend/coreapp/views/user.py
+++ b/backend/coreapp/views/user.py
@@ -20,7 +20,7 @@ class CurrentUser(APIView):
     """
 
     def get(self, request: Request) -> Response:
-        user = serialize_profile(request, request.profile)
+        user = serialize_profile(request.profile)
         return Response(user)
 
     def post(self, request: Request) -> Response:
@@ -72,11 +72,11 @@ class UserScratchList(generics.ListAPIView):  # type: ignore
 
 
 @api_view(["GET"])  # type: ignore
-def user(request: Request, username: str) -> Response:
+def user(username: str) -> Response:
     """
     Gets a user's basic data
     """
 
     return Response(
-        serialize_profile(request, get_object_or_404(Profile, user__username=username))
+        serialize_profile(get_object_or_404(Profile, user__username=username))
     )


### PR DESCRIPTION
## Description

When creating custom presets, the `/api/compiler` is including the presets for each platforms, however when serialiazing the owner field a KeyError is raised.

As visible in the code bellow, we are tyring to get the `request` from the context.

https://github.com/decompme/decomp.me/blob/294a2dc1b9fe1d6a033e07d88c92bf4a885d4769/backend/coreapp/serializers.py#L56-L58

However, in this specific context (serialiazing the owner field of a custom preset we include for a platform), it is not available. 
![image](https://github.com/decompme/decomp.me/assets/42176370/15fedae6-4510-4b66-bf23-71e56f7ad68a)

We can clearly notice however that the `serialize_profile` function is not using the request argument we are sending, it uses the `profile` only. Therefore an easy fix is to remove the request.

## Tests

- [x] regression unit tests has been added
