### PR TITLE
Add mwcc_43_202 compiler (Wii MW 1.6)

### DIFF
--- a/backend/compilers/compilers.linux.yaml
+++ b/backend/compilers/compilers.linux.yaml
@@ -24,9 +24,10 @@ gc_wii:
   - mwcc_42_140
   - mwcc_42_142
   - mwcc_43_145
-  - mwcc_43_188
   - mwcc_43_151
   - mwcc_43_172
+  - mwcc_43_188
+  - mwcc_43_202
   - mwcc_43_213
   - prodg_35
   - prodg_37

--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -1129,6 +1129,12 @@ MWCC_43_172 = MWCCWiiGCCompiler(
     cc=MWCCEPPC_CC,
 )
 
+MWCC_43_202 = MWCCWiiGCCompiler(
+    id="mwcc_43_202",
+    platform=GC_WII,
+    cc=MWCCEPPC_CC,
+)
+
 MWCC_43_213 = MWCCWiiGCCompiler(
     id="mwcc_43_213",
     platform=GC_WII,
@@ -1573,6 +1579,7 @@ _all_compilers: List[Compiler] = [
     MWCC_43_151,
     MWCC_43_172,
     MWCC_43_188,
+    MWCC_43_202,
     MWCC_43_213,
     PRODG_35,
     PRODG_37,

--- a/frontend/src/lib/i18n/locales/en/compilers.json
+++ b/frontend/src/lib/i18n/locales/en/compilers.json
@@ -145,6 +145,7 @@
     "mwcc_43_151": "4.3 build 151 (Wii MW 1.1)",
     "mwcc_43_172": "4.3 build 172 (Wii MW 1.3)",
     "mwcc_43_188": "4.3 build 188 (Wii MW 1.5)",
+    "mwcc_43_202": "4.3 build 202 (Wii MW 1.6)",
     "mwcc_43_213": "4.3 build 213 (Wii MW 1.7)",
     "mwcppc_23": "MWCPPC 2.3 (CodeWarrior Pro 5)",
     "mwcppc_24": "MWCPPC 2.4 (CodeWarrior Pro 6)",


### PR DESCRIPTION
This already exists in [compilers](https://github.com/decompme/compilers/tree/main/platforms/gc_wii/mwcc_43_202), but appears to have been missed here.