### PR TITLE
Try creating 'Temp' dir for wine

### DIFF
--- a/backend/coreapp/sandbox.py
+++ b/backend/coreapp/sandbox.py
@@ -49,7 +49,6 @@ class Sandbox(contextlib.AbstractContextManager["Sandbox"]):
         settings.SANDBOX_CHROOT_PATH.mkdir(parents=True, exist_ok=True)
         settings.WINEPREFIX.mkdir(parents=True, exist_ok=True)
 
-
         assert ":" not in str(self.path)
         assert ":" not in str(settings.WINEPREFIX)
 

--- a/backend/coreapp/sandbox.py
+++ b/backend/coreapp/sandbox.py
@@ -1,4 +1,5 @@
 import contextlib
+import getpass
 import logging
 import os
 import shlex
@@ -6,7 +7,6 @@ import subprocess
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any, Dict, List, Optional, Union
-import getpass
 
 from django.conf import settings
 
@@ -47,14 +47,15 @@ class Sandbox(contextlib.AbstractContextManager["Sandbox"]):
             return []
 
         settings.SANDBOX_CHROOT_PATH.mkdir(parents=True, exist_ok=True)
+        settings.WINEPREFIX.mkdir(parents=True, exist_ok=True)
+
 
         assert ":" not in str(self.path)
         assert ":" not in str(settings.WINEPREFIX)
 
-        wine_temp_dir = (
-            settings.WINEPREFIX / "drive_c" / "users" / getpass.getuser() / "Temp"
-        )
-        wine_temp_dir.mkdir(parents=True, exist_ok=True)
+        # wine-specific hacks
+        user = getpass.getuser()
+        (self.path / "Temp").mkdir(parents=True, exist_ok=True)
 
         # fmt: off
         wrapper = [
@@ -63,7 +64,7 @@ class Sandbox(contextlib.AbstractContextManager["Sandbox"]):
             "--chroot", str(settings.SANDBOX_CHROOT_PATH),
             "--bindmount", f"{self.path}:/tmp",
             "--bindmount", f"{self.path}:/run/user/{os.getuid()}",
-            "--bindmount", f"{self.path}:{wine_temp_dir}",
+            "--bindmount", f"{self.path}/Temp:/wine/drive_c/users/{user}/Temp",
             "--bindmount_ro", "/dev",
             "--bindmount_ro", "/bin",
             "--bindmount_ro", "/etc/alternatives",

--- a/backend/coreapp/sandbox.py
+++ b/backend/coreapp/sandbox.py
@@ -64,7 +64,6 @@ class Sandbox(contextlib.AbstractContextManager["Sandbox"]):
             "--chroot", str(settings.SANDBOX_CHROOT_PATH),
             "--bindmount", f"{self.path}:/tmp",
             "--bindmount", f"{self.path}:/run/user/{os.getuid()}",
-            "--bindmount", f"{self.path}/Temp:/wine/drive_c/users/{user}/Temp",
             "--bindmount_ro", "/dev",
             "--bindmount_ro", "/bin",
             "--bindmount_ro", "/etc/alternatives",
@@ -83,6 +82,7 @@ class Sandbox(contextlib.AbstractContextManager["Sandbox"]):
             "--rlimit_nofile", "soft",
             # the following are settings that can be removed once we are done with wine
             "--bindmount_ro", f"{settings.WINEPREFIX}:/wine",
+            "--bindmount", f"{self.path}/Temp:/wine/drive_c/users/{user}/Temp",
             "--env", "WINEDEBUG=-all",
             "--env", "WINEPREFIX=/wine",
         ]


### PR DESCRIPTION
Attempt to fix:

```
Compiler error: /tmp/object.o
pwd is /tmp
CCPSX 3.06.0015 (Win32, PSX version 3.02)
Error - could not create temporary file 'C:\users\ethteck\Temp\PQ2'
```

Might work. Probably wont. I hate CCPSX.