### PR TITLE
Switch a few PSYQ compilers to use CCPSX.EXE

### DIFF
--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -325,11 +325,12 @@ PSYQ_MSDOS_CC = (
     '(HOME="." /usr/bin/dosemu -quiet -dumb -f ${COMPILER_DIR}/dosemurc -K . -E "ASPSX.EXE -quiet object.os -o object.oo") && '
     '${COMPILER_DIR}/psyq-obj-parser object.oo -o "$OUTPUT"'
 )
+
 PSYQ_CC = (
-    'cpp -P "$INPUT" | unix2dos | '
-    '${WIBO} ${COMPILER_DIR}/CC1PSX.EXE -quiet ${COMPILER_FLAGS} -o "$OUTPUT".s && '
-    '${WIBO} ${COMPILER_DIR}/ASPSX.EXE -quiet "$OUTPUT".s -o "$OUTPUT".obj && '
-    '${COMPILER_DIR}/psyq-obj-parser "$OUTPUT".obj -o "$OUTPUT"'
+    'cpp -P "${INPUT}" | unix2dos | '
+    '${WIBO} ${COMPILER_DIR}/CC1PSX.EXE -quiet ${COMPILER_FLAGS} -o "${OUTPUT}".s && '
+    '${WIBO} ${COMPILER_DIR}/ASPSX.EXE -quiet "${OUTPUT}".s -o "${OUTPUT}"bj && '
+    '${COMPILER_DIR}/psyq-obj-parser "${OUTPUT}"bj -o "${OUTPUT}"'
 )
 
 PSYQ_263_221 = GCCPS1Compiler(
@@ -362,39 +363,13 @@ PSYQ40 = GCCPS1Compiler(
     cc=PSYQ_CC,
 )
 
-PSYQ41 = GCCPS1Compiler(
-    id="psyq4.1",
-    platform=PS1,
-    cc=PSYQ_CC,
-)
-
 PSYQ43 = GCCPS1Compiler(
     id="psyq4.3",
     platform=PS1,
     cc=PSYQ_CC,
 )
 
-PSYQ44 = GCCPS1Compiler(
-    id="psyq4.4",
-    platform=PS1,
-    cc=PSYQ_CC,
-)
-
-PSYQ45 = GCCPS1Compiler(
-    id="psyq4.5",
-    platform=PS1,
-    cc=PSYQ_CC,
-)
-
-PSYQ46 = GCCPS1Compiler(
-    id="psyq4.6",
-    platform=PS1,
-    cc=PSYQ_CC,
-)
-
 PSYQ_CCPSX = (
-    "echo ${OUTPUT} && "
-    "echo pwd is $(pwd) && "
     'echo "[ccpsx]" >> SN.INI && '
     'echo "compiler_path=${COMPILER_DIR//\\//\\\\}" >> SN.INI && '
     'echo "assembler_path=${COMPILER_DIR//\\//\\\\}" >> SN.INI && '
@@ -403,9 +378,26 @@ PSYQ_CCPSX = (
     '${COMPILER_DIR}/psyq-obj-parser "${OUTPUT}"bj -o "${OUTPUT}"'
 )
 
-PSYQ44_CCPSX = GCCPS1Compiler(
-    id="psyq4.4-ccpsx",
-    base_compiler=PSYQ44,
+PSYQ41 = GCCPS1Compiler(
+    id="psyq4.1",
+    platform=PS1,
+    cc=PSYQ_CCPSX,
+)
+
+PSYQ44 = GCCPS1Compiler(
+    id="psyq4.4",
+    platform=PS1,
+    cc=PSYQ_CCPSX,
+)
+
+PSYQ45 = GCCPS1Compiler(
+    id="psyq4.5",
+    platform=PS1,
+    cc=PSYQ_CCPSX,
+)
+
+PSYQ46 = GCCPS1Compiler(
+    id="psyq4.6",
     platform=PS1,
     cc=PSYQ_CCPSX,
 )
@@ -1507,7 +1499,6 @@ _all_compilers: List[Compiler] = [
     PSYQ44,
     PSYQ45,
     PSYQ46,
-    PSYQ44_CCPSX,
     GCC257_PSX,
     GCC263_PSX,
     GCC260_MIPSEL,

--- a/frontend/src/lib/i18n/locales/en/compilers.json
+++ b/frontend/src/lib/i18n/locales/en/compilers.json
@@ -186,15 +186,13 @@
     "psyq3.5": "PSYQ3.5 (gcc 2.6.0 + aspsx 2.34)",
     "psyq3.6": "PSYQ3.6 (gcc 2.7.2 + aspsx 2.34)",
     "psyq4.0": "PSYQ4.0 (gcc 2.7.2 + aspsx 2.56)",
-    "psyq4.1": "PSYQ4.1 (gcc 2.7.2-970404 + aspsx 2.67)",
+    "psyq4.1": "gcc 2.7.2-970404 + aspsx 2.67 (CCPSX)",
     "psyq4.3": "PSYQ4.3 (gcc 2.8.0 + aspsx 2.77)",
-    "psyq4.4": "PSYQ4.4 (gcc 2.8.1 + aspsx 2.79)",
-    "psyq4.5": "PSYQ4.5 (gcc 2.91.66 + aspsx 2.81)",
-    "psyq4.6": "PSYQ4.6 (gcc 2.95.2 + aspsx 2.86)",
+    "psyq4.4": "gcc 2.8.1 + aspsx 2.79 (CCPSX)",
+    "psyq4.5": "gcc 2.91.66 + aspsx 2.81 (CCPSX)",
+    "psyq4.6": "gcc 2.95.2 + aspsx 2.86 (CCPSX)",
 
     "psyq_263_221": "gcc 2.6.3 + aspsx 2.21",
-
-    "psyq4.4-ccpsx": "CCPSX (PSYQ4.4: gcc 2.8.1 + aspsx 2.79)",
 
     "mwccpsp_3.0.1_121": "MWCC 1.0 (3.0.1 121)",
     "mwccpsp_3.0.1_134": "MWCC 1.0 Hotfix 2 (3.0.1 134)",


### PR DESCRIPTION
It doesn't work for:
- the DOS compilers like 3.3/3.5.3/6 (I couldn't figure it out)
- PSYQ4.0 (error executing CCPSX.EXE)
- PSYQ4.3 (there is no CCPSX.EXE, will need to update the download link / Docker image)