### PR TITLE
Remove abi flag from PS2 assemble_cmd

### DIFF
--- a/backend/coreapp/platforms.py
+++ b/backend/coreapp/platforms.py
@@ -181,7 +181,7 @@ PS2 = Platform(
     name="PlayStation 2",
     description="MIPS (little-endian)",
     arch="mipsee",
-    assemble_cmd='mips-ps2-decompals-as -EL -march=r5900 -mabi=eabi -o "$OUTPUT" "$PRELUDE" "$INPUT"',
+    assemble_cmd='mips-ps2-decompals-as -EL -march=r5900 -o "$OUTPUT" "$PRELUDE" "$INPUT"',
     objdump_cmd="mips-ps2-decompals-objdump",
     nm_cmd="mips-ps2-decompals-nm",
     diff_flags=COMMON_DIFF_FLAGS + COMMON_MIPS_DIFF_FLAGS,


### PR DESCRIPTION
With the recent gp_rel workaround added to splat (`use_gp_rel_macro_nonmatching: False`) previous `addiu $rt, $gp, SYMBOL` instructions are now `la $rt, (SYMBOL)`, this pseudo expands to `daddiu $rt, $gp, SYMBOL` when the ABI is set to eabi, which is not what it expanded to with the original assemblers.
This PR removes the ABI flag so the pseudo expands to the more appropriate encoding, 