### PR TITLE
Win32 Platform tweaks

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -54,6 +54,7 @@ RUN apt-get -y update && apt-get install -y \
     libnl-route-3-200 \
     libprotobuf-dev \
     libtinfo5 \
+    nasm \
     netcat \
     software-properties-common \
     unzip \

--- a/backend/coreapp/diff_wrapper.py
+++ b/backend/coreapp/diff_wrapper.py
@@ -133,7 +133,7 @@ class DiffWrapper:
 
     @staticmethod
     def parse_objdump_flags(diff_flags: List[str]) -> List[str]:
-        known_objdump_flags = ["-Mno-aliases"]
+        known_objdump_flags = ["-Mno-aliases", "-Mintel", "-Matt"]
         known_objdump_flag_prefixes = ["-Mreg-names=", "--disassemble="]
         ret = []
 

--- a/backend/coreapp/flags.py
+++ b/backend/coreapp/flags.py
@@ -323,3 +323,10 @@ COMMON_WATCOM_FLAGS: Flags = [
     Checkbox("watcom_signedchar", "-j"),
     Checkbox("watcom_fpu", "-fpi87"),
 ]
+
+COMMON_X86_DIFF_FLAGS: Flags = [
+    FlagSet(
+        id="x86_asm_syntax",
+        flags=["-Mintel", "-Matt"],
+    ),
+]

--- a/backend/coreapp/platforms.py
+++ b/backend/coreapp/platforms.py
@@ -4,7 +4,12 @@ from typing import Any, Dict, OrderedDict
 from pathlib import Path
 import functools
 
-from coreapp.flags import COMMON_DIFF_FLAGS, COMMON_MIPS_DIFF_FLAGS, Flags
+from coreapp.flags import (
+    COMMON_DIFF_FLAGS,
+    COMMON_MIPS_DIFF_FLAGS,
+    COMMON_X86_DIFF_FLAGS,
+    Flags,
+)
 from coreapp.models.preset import Preset
 from coreapp.models.scratch import Scratch
 from rest_framework.exceptions import APIException
@@ -92,6 +97,7 @@ WIN32 = Platform(
     assemble_cmd='i686-w64-mingw32-as --32 -mmnemonic=intel -msyntax=intel -mnaked-reg -o "$OUTPUT" "$PRELUDE" "$INPUT"',
     objdump_cmd="i686-w64-mingw32-objdump",
     nm_cmd="i686-w64-mingw32-nm",
+    diff_flags=COMMON_DIFF_FLAGS + COMMON_X86_DIFF_FLAGS,
 )
 
 SWITCH = Platform(

--- a/backend/coreapp/platforms.py
+++ b/backend/coreapp/platforms.py
@@ -94,7 +94,7 @@ WIN32 = Platform(
     name="Windows (9x/NT)",
     description="x86 (32bit)",
     arch="i686",
-    assemble_cmd='i686-w64-mingw32-as --32 -mmnemonic=intel -msyntax=intel -mnaked-reg -o "$OUTPUT" "$PRELUDE" "$INPUT"',
+    assemble_cmd='nasm -g -f elf32 -o "$OUTPUT" "$INPUT"',
     objdump_cmd="i686-w64-mingw32-objdump",
     nm_cmd="i686-w64-mingw32-nm",
     diff_flags=COMMON_DIFF_FLAGS + COMMON_X86_DIFF_FLAGS,

--- a/frontend/src/lib/i18n/locales/en/compilers.json
+++ b/frontend/src/lib/i18n/locales/en/compilers.json
@@ -461,5 +461,8 @@
 
     "diff_algorithm": "Diff algorithm",
     "diff_algorithm.-DIFFlevenshtein": "Levenshtein",
-    "diff_algorithm.-DIFFdifflib": "difflib"
+    "diff_algorithm.-DIFFdifflib": "difflib",
+    "x86_asm_syntax": "Assembly syntax",
+    "x86_asm_syntax.-Mintel": "Intel",
+    "x86_asm_syntax.-Matt": "AT&T"
 }


### PR DESCRIPTION
Hello guys, 

I made a couple of changes that I think can be useful for the rest of the community.

### X86 Assembly Syntax choice
By default, the win32 platform displays assembly in the AT&T syntax.
However, most of the tools that I use, Ghidra and x64dbg show assembly in the Intel syntax.

I have added a flag on the Diff section for Win32 to able able to select the preferred syntax for a scratch.

### Replace GNU AS with NASM
The reason to do this is that GNU AS doesn't support the name mangling that the MSVC uses, so it makes it impossible to match C++ names, as they cannot be in the original assembly code.
NASM doesn't have this limitation and allows us to use the MSVC mangled names.