### PR TITLE
1298: Swap least and most compare fns

### DIFF
--- a/frontend/src/components/Sort.tsx
+++ b/frontend/src/components/Sort.tsx
@@ -18,9 +18,9 @@ export function produceSortFunction(sortMode: SortMode): (a: TerseScratch, b: Te
     case SortMode.LAST_UPDATED: // most recent first
         return (a, b) => new Date(b.last_updated).getTime() - new Date(a.last_updated).getTime()
     case SortMode.LEAST_MATCHED:
-        return compareScratchScores
-    case SortMode.MOST_MATCHED:
         return (a, b) => compareScratchScores(b, a)
+    case SortMode.MOST_MATCHED:
+        return compareScratchScores
     }
 }
 


### PR DESCRIPTION
Resolves #1298 

Swapped the compare functions associated with `LEAST_MATCHED` and `MOST_MATCHED`. Ordering appears correct now, this is from my local version with the change:

![image](https://github.com/user-attachments/assets/0021f7f9-1be7-48ac-a7eb-a6b4ae80e929)

This should also address the same pattern I was noticing when implementing a frontend sort for #1249. I can put a PR in for that as soon as this is resolved!


