### PR TITLE
Bump update-browserslist-db 'Browserslist: caniuse-lite is outdated'

### DIFF
--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2531,9 +2531,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001579, caniuse-lite@^1.0.30001587, caniuse-lite@^1.0.30001599:
-  version "1.0.30001599"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001599.tgz#571cf4f3f1506df9bf41fcbb6d10d5d017817bce"
-  integrity sha512-LRAQHZ4yT1+f9LemSMeqdMpMxZcc4RMWdj4tiFe3G8tNkWK+E58g+/tzotb5cU6TbcVJLr4fySiAW7XmxQvZQA==
+  version "1.0.30001660"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001660.tgz"
+  integrity sha512-GacvNTTuATm26qC74pt+ad1fW15mlQ/zuTzzY1ZoIzECTP8HURDfF43kNxPgf7H1jmelCBQTTbBNxdSXOA7Bqg==
 
 chalk@^2.4.2:
   version "2.4.2"


### PR DESCRIPTION
No meaningful change, just removes the warning when starting up

```
root@b94fba06266c:/frontend# npx update-browserslist-db@latest
Need to install the following packages:
update-browserslist-db@1.1.0
Ok to proceed? (y) y

Latest version:     1.0.30001660
Installed version:  1.0.30001599
Removing old caniuse-lite from lock file
Installing new caniuse-lite version
$ yarn add -W caniuse-lite
warning " > ansi-to-react@6.1.6" has incorrect peer dependency "react@^16.3.2 || ^17.0.0".
warning " > ansi-to-react@6.1.6" has incorrect peer dependency "react-dom@^16.3.2 || ^17.0.0".
warning "next-pwa > babel-loader@8.3.0" has unmet peer dependency "@babel/core@^7.0.0".
warning " > use-persisted-state@0.3.3" has incorrect peer dependency "react@^16.8.0 || ^17.0.0".
Cleaning package.json dependencies from caniuse-lite
$ yarn remove -W caniuse-lite
warning " > ansi-to-react@6.1.6" has incorrect peer dependency "react@^16.3.2 || ^17.0.0".
warning " > ansi-to-react@6.1.6" has incorrect peer dependency "react-dom@^16.3.2 || ^17.0.0".
warning "next-pwa > babel-loader@8.3.0" has unmet peer dependency "@babel/core@^7.0.0".
warning " > use-persisted-state@0.3.3" has incorrect peer dependency "react@^16.8.0 || ^17.0.0".
caniuse-lite has been successfully updated

No target browser changes
```