### PR TITLE
Allow scratch name to be highlighted and copied for non-owners

### DIFF
--- a/frontend/src/components/Scratch/ScratchToolbar.module.scss
+++ b/frontend/src/components/Scratch/ScratchToolbar.module.scss
@@ -176,3 +176,9 @@ $padding: 4px;
         width: 20px;
     }
 }
+
+// Allow highlighting and copying the scratch name
+.scratchName {
+    cursor: text;
+    user-select: text;
+}

--- a/frontend/src/components/Scratch/ScratchToolbar.module.scss
+++ b/frontend/src/components/Scratch/ScratchToolbar.module.scss
@@ -51,9 +51,8 @@ $padding: 4px;
 
     text-align: center;
 
-    &.editable {
-        cursor: text;
-    }
+    cursor: text;
+    user-select: text;
 
     &[contenteditable] {
         text-overflow: initial;
@@ -175,10 +174,4 @@ $padding: 4px;
     .owner::before {
         width: 20px;
     }
-}
-
-// Allow highlighting and copying the scratch name
-.scratchName {
-    cursor: text;
-    user-select: text;
 }

--- a/frontend/src/components/Scratch/ScratchToolbar.tsx
+++ b/frontend/src/components/Scratch/ScratchToolbar.tsx
@@ -115,7 +115,7 @@ function ScratchName({ name, onChange }: { name: string, onChange?: (name: strin
         />
     } else {
         return <div
-            className={classNames(styles.name, { [styles.editable]: !!onChange })}
+            className={classNames(styles.name, styles.scratchName, { [styles.editable]: !!onChange })}
             onClick={() => {
                 if (onChange)
                     setEditing(true)

--- a/frontend/src/components/Scratch/ScratchToolbar.tsx
+++ b/frontend/src/components/Scratch/ScratchToolbar.tsx
@@ -115,7 +115,7 @@ function ScratchName({ name, onChange }: { name: string, onChange?: (name: strin
         />
     } else {
         return <div
-            className={classNames(styles.name, styles.scratchName, { [styles.editable]: !!onChange })}
+            className={classNames(styles.name, { [styles.editable]: !!onChange })}
             onClick={() => {
                 if (onChange)
                     setEditing(true)


### PR DESCRIPTION
This pull request includes changes to the `ScratchToolbar` component to improve the user experience by allowing the scratch name to be highlighted and copied.

Improvements to user experience:

* [`frontend/src/components/Scratch/ScratchToolbar.module.scss`](diffhunk://#diff-91431468f8d5c4d3be20016d8821f41b2c1945a4dfa9ce4957b044e7bc19f95aR179-R184): Added a new CSS class `.scratchName` to enable text selection and cursor indication for the scratch name.
* [`frontend/src/components/Scratch/ScratchToolbar.tsx`](diffhunk://#diff-1409658d54045b7b96096e2e6a348556ad8c6763a3b9e237d188d81c783d3110L118-R118): Updated the `ScratchName` component to use the new `.scratchName` class, allowing the scratch name to be highlighted and copied.

Fixes #1354 