### PR TITLE
Fix scratches being grouped into the same family even if targeting different functions in the same object

### DIFF
--- a/backend/coreapp/views/scratch.py
+++ b/backend/coreapp/views/scratch.py
@@ -201,6 +201,7 @@ def family_etag(request: Request, pk: Optional[str] = None) -> Optional[str]:
         ):
             family = Scratch.objects.filter(
                 target_assembly__hash=scratch.target_assembly.hash,
+                diff_label=scratch.diff_label,
             )
         else:
             family = Scratch.objects.filter(slug=scratch.slug)
@@ -573,6 +574,7 @@ class ScratchViewSet(
         ):
             family = Scratch.objects.filter(
                 target_assembly__hash=scratch.target_assembly.hash,
+                diff_label=scratch.diff_label,
             ).order_by("creation_time")
         else:
             family = Scratch.objects.filter(slug=scratch.slug)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -25,7 +25,7 @@ Dependencies:
 - Python >=3.10
 - Node.js >=14
 - [Yarn](https://yarnpkg.com/getting-started/install)
-- [Poetry](https://python-poetry.org/docs/master/#installing-with-the-official-installer)
+- [Poetry](https://python-poetry.org/docs/#installing-with-the-official-installer)
 
 ---
 Create a file to hold environment variables:
@@ -38,7 +38,7 @@ touch .env.local
 cd backend
 ```
 
-* Install Python dependencies with [poetry](https://python-poetry.org/docs/master/#installing-with-the-official-installer)
+* Install Python dependencies with [poetry](https://python-poetry.org/docs/#installing-with-the-official-installer)
 ```shell
 poetry install
 ```


### PR DESCRIPTION
This changes the family tab of scratches created via objdiff to filter out scratches that target another diff label in the same object. This fixes the bug where objdiff scratches would always show scratches for unrelated functions in the family tab and the "This function has been matched" header bar at the top.

Fixes #1281 and https://github.com/encounter/objdiff/issues/77

Note: I only tested this very briefly on a local database, it seems to get the right behavior on the object I tested but I can't test on the live database.