### PR TITLE
Add decompals fork of EGCS 1.1.2-4

### DIFF
--- a/backend/compilers/compilers.darwin.yaml
+++ b/backend/compilers/compilers.darwin.yaml
@@ -3,6 +3,7 @@ n64:
   - ido7.1
   - gcc2.7.2kmc
   - gcc2.8.1pm
+  - egcs_1.1.2-4c
 switch:
   -  clang-4.0.1
   -  clang-8.0.0

--- a/backend/compilers/compilers.linux.yaml
+++ b/backend/compilers/compilers.linux.yaml
@@ -47,6 +47,7 @@ n64:
   - ido7.1
   - mips_pro_744
   - egcs_1.1.2-4
+  - egcs_1.1.2-4c
   - gcc4.4.0-mips64-elf
 
 n3ds:

--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -873,6 +873,12 @@ EGCS1124 = GCCCompiler(
     cc='COMPILER_PATH="${COMPILER_DIR}" "${COMPILER_DIR}"/mips-linux-gcc -c -G 0 -fno-PIC -mgp32 -mfp32 -mcpu=4300 -nostdinc ${COMPILER_FLAGS} "${INPUT}" -o "${OUTPUT}"',
 )
 
+EGCS1124C = GCCCompiler(
+    id="egcs_1.1.2-4c",
+    platform=N64,
+    cc='COMPILER_PATH="${COMPILER_DIR}" "${COMPILER_DIR}"/gcc -c -G 0 -fno-PIC -mgp32 -mfp32 -mcpu=4300 -nostdinc ${COMPILER_FLAGS} "${INPUT}" -o "${OUTPUT}"',
+)
+
 GCC440MIPS64ELF = GCCCompiler(
     id="gcc4.4.0-mips64-elf",
     platform=N64,
@@ -1579,6 +1585,7 @@ _all_compilers: List[Compiler] = [
     GCC281SN,
     GCC281SNCXX,
     EGCS1124,
+    EGCS1124C,
     GCC440MIPS64ELF,
     # IRIX
     IDO53_IRIX,

--- a/frontend/src/lib/i18n/locales/en/compilers.json
+++ b/frontend/src/lib/i18n/locales/en/compilers.json
@@ -59,6 +59,7 @@
     "mwcps2-3.0.1b210-060308": "MWCPS2 3.0.1b210 (Built 060308)",
 
     "egcs_1.1.2-4": "EGCS 1.1.2-4 (gcc egcs-2.91.66)",
+    "egcs_1.1.2-4c": "EGCS 1.1.2-4 (gcc egcs-2.91.66, decompals)",
 
     "gcc2.7.2kmc": "GCC 2.7.2 (KMC)",
     "gcc2.7.2sn": "GCC 2.7.2 (SN)",


### PR DESCRIPTION
This has some new features over the stock version (e.g. anonymous unions) which we'd like to use for OoT iQue. I managed to test this locally but I don't really know what I'm doing here

Compiler added in https://github.com/decompme/compilers/pull/26
Fixes #1402 