### PR TITLE
Copy a bit less stuff when using dosemu

### DIFF
--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -327,11 +327,11 @@ CLANG_800 = ClangCompiler(
 
 # PS1
 PSYQ_MSDOS_CC = (
-    "echo \"\$_hdimage = '+0 ${COMPILER_DIR} +1'\" > .dosemurc && "
-    'cpp -P "${INPUT}" | unix2dos > object.oc && '
-    '(HOME="." /usr/bin/dosemu -quiet -dumb -f .dosemurc -K . -E "D:\\CC1PSX.EXE -quiet ${COMPILER_FLAGS} -o object.os object.oc") && '
-    '(HOME="." /usr/bin/dosemu -quiet -dumb -f .dosemurc -K . -E "D:\\ASPSX.EXE -quiet object.os -o object.oo") && '
-    '${COMPILER_DIR}/psyq-obj-parser object.oo -o "${OUTPUT}"'
+    "echo \"\$_hdimage = '+0 $(pwd) +1'\" > .dosemurc && "
+    'cpp -P "${INPUT}" | unix2dos > dos_src.c && '
+    '(HOME="$(pwd)" /usr/bin/dosemu -quiet -dumb -f .dosemurc -K "${COMPILER_DIR}" -E "CC1PSX.EXE -quiet ${COMPILER_FLAGS} D:\\dos_src.c -o D:\\output.s") && '
+    '(HOME="$(pwd)" /usr/bin/dosemu -quiet -dumb -f .dosemurc -K "${COMPILER_DIR}" -E "ASPSX.EXE -quiet D:\\output.s -o D:\\output.obj") && '
+    '${COMPILER_DIR}/psyq-obj-parser output.obj -o "${OUTPUT}"'
 )
 
 PSYQ_CC = (
@@ -496,13 +496,12 @@ GCC2723_MIPSEL = GCCPS1Compiler(
 
 # Saturn
 SATURN_CC = (
-    "echo \"\$_hdimage = '+0 ${COMPILER_DIR} +1'\" > .dosemurc && "
-    "cp -r ${COMPILER_DIR}/GO32.EXE . && "
+    "echo \"\$_hdimage = '+0 $(pwd) +1'\" > .dosemurc && "
     'cat "${INPUT}" | unix2dos > dos_src.c && '
-    '(HOME="." /usr/bin/dosemu -quiet -dumb -K . -E "D:\\CPP.EXE dos_src.c -o src_proc.c") && '
-    '(HOME="." /usr/bin/dosemu -quiet -dumb -K . -E "D:\\CC1.EXE -quiet ${COMPILER_FLAGS} src_proc.c -o cc1_out.asm") && '
-    '(HOME="." /usr/bin/dosemu -quiet -dumb -K . -E "D:\\AS.EXE cc1_out.asm -o as_out.o") && '
-    'sh-elf-objcopy -Icoff-sh -Oelf32-sh as_out.o "${OUTPUT}"'
+    '(HOME="$(pwd)" /usr/bin/dosemu -quiet -dumb -f .dosemurc -K "${COMPILER_DIR}" -E "CPP.EXE D:\\dos_src.c -o D:\\src_proc.c") && '
+    '(HOME="$(pwd)" /usr/bin/dosemu -quiet -dumb -f .dosemurc -K "${COMPILER_DIR}" -E "CC1.EXE -quiet ${COMPILER_FLAGS} D:\\src_proc.c -o D:\\output.s") && '
+    '(HOME="$(pwd)" /usr/bin/dosemu -quiet -dumb -f .dosemurc -K "${COMPILER_DIR}" -E "AS.EXE D:\\output.s -o D:\\output.o") && '
+    'sh-elf-objcopy -Icoff-sh -Oelf32-sh output.o "${OUTPUT}"'
 )
 
 CYGNUS_2_7_96Q3 = GCCSaturnCompiler(
@@ -1483,7 +1482,7 @@ WATCOM_110_CPP = WatcomCompiler(
 BORLAND_MSDOS_CC = (
     "echo \"\$_hdimage = '+0 ${COMPILER_DIR} +1'\" > .dosemurc && "
     'cat "${INPUT}" | unix2dos > dos_src.c && '
-    '(HOME="." /usr/bin/dosemu -quiet -dumb -f .dosemurc -K . -E "D:\\bin\\bcc.exe -ID:\\include ${COMPILER_FLAGS} -c -oout.o dos_src.c") && '
+    '(HOME="$(pwd)" /usr/bin/dosemu -quiet -dumb -f .dosemurc -K . -E "D:\\bin\\bcc.exe -ID:\\include ${COMPILER_FLAGS} -c -oout.o dos_src.c") && '
     'cp out.o "${OUTPUT}"'
 )
 

--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -327,10 +327,11 @@ CLANG_800 = ClangCompiler(
 
 # PS1
 PSYQ_MSDOS_CC = (
-    'cpp -P "$INPUT" | unix2dos > object.oc && cp ${COMPILER_DIR}/* . && '
-    '(HOME="." /usr/bin/dosemu -quiet -dumb -K . -E "CC1PSX.EXE -quiet ${COMPILER_FLAGS} -o object.os object.oc") && '
-    '(HOME="." /usr/bin/dosemu -quiet -dumb -K . -E "ASPSX.EXE -quiet object.os -o object.oo") && '
-    '${COMPILER_DIR}/psyq-obj-parser object.oo -o "$OUTPUT"'
+    "echo \"\$_hdimage = '+0 ${COMPILER_DIR} +1'\" > .dosemurc && "
+    'cpp -P "${INPUT}" | unix2dos > object.oc && '
+    '(HOME="." /usr/bin/dosemu -quiet -dumb -f .dosemurc -K . -E "D:\\CC1PSX.EXE -quiet ${COMPILER_FLAGS} -o object.os object.oc") && '
+    '(HOME="." /usr/bin/dosemu -quiet -dumb -f .dosemurc -K . -E "D:\\ASPSX.EXE -quiet object.os -o object.oo") && '
+    '${COMPILER_DIR}/psyq-obj-parser object.oo -o "${OUTPUT}"'
 )
 
 PSYQ_CC = (
@@ -495,13 +496,13 @@ GCC2723_MIPSEL = GCCPS1Compiler(
 
 # Saturn
 SATURN_CC = (
-    'cat "$INPUT" | unix2dos > dos_src.c && '
-    "cp -r ${COMPILER_DIR}/* . && "
-    '(HOME="." /usr/bin/dosemu -quiet -dumb -K . -E "CPP.EXE dos_src.c -o src_proc.c") && '
-    '(HOME="." /usr/bin/dosemu -quiet -dumb -K . -E "CC1.EXE -quiet ${COMPILER_FLAGS} src_proc.c -o cc1_out.asm") && '
-    '(HOME="." /usr/bin/dosemu -quiet -dumb -K . -E "AS.EXE cc1_out.asm -o as_out.o") && '
-    "sh-elf-objcopy -Icoff-sh -Oelf32-sh as_out.o && "
-    'cp as_out.o "$OUTPUT"'
+    "echo \"\$_hdimage = '+0 ${COMPILER_DIR} +1'\" > .dosemurc && "
+    "cp -r ${COMPILER_DIR}/GO32.EXE . && "
+    'cat "${INPUT}" | unix2dos > dos_src.c && '
+    '(HOME="." /usr/bin/dosemu -quiet -dumb -K . -E "D:\\CPP.EXE dos_src.c -o src_proc.c") && '
+    '(HOME="." /usr/bin/dosemu -quiet -dumb -K . -E "D:\\CC1.EXE -quiet ${COMPILER_FLAGS} src_proc.c -o cc1_out.asm") && '
+    '(HOME="." /usr/bin/dosemu -quiet -dumb -K . -E "D:\\AS.EXE cc1_out.asm -o as_out.o") && '
+    'sh-elf-objcopy -Icoff-sh -Oelf32-sh as_out.o "${OUTPUT}"'
 )
 
 CYGNUS_2_7_96Q3 = GCCSaturnCompiler(
@@ -1480,10 +1481,10 @@ WATCOM_110_CPP = WatcomCompiler(
 )
 
 BORLAND_MSDOS_CC = (
-    'cat "$INPUT" | unix2dos > dos_src.c && '
     "echo \"\$_hdimage = '+0 ${COMPILER_DIR} +1'\" > .dosemurc && "
+    'cat "${INPUT}" | unix2dos > dos_src.c && '
     '(HOME="." /usr/bin/dosemu -quiet -dumb -f .dosemurc -K . -E "D:\\bin\\bcc.exe -ID:\\include ${COMPILER_FLAGS} -c -oout.o dos_src.c") && '
-    'cp out.o "$OUTPUT"'
+    'cp out.o "${OUTPUT}"'
 )
 
 BORLAND_31_C = BorlandCompiler(


### PR DESCRIPTION
## Summary

The gist of this PR is that we now tell dosemu2 to mount the **current directory** (i.e. `/tmp` within the sandbox) as the `D:` drive (NOTE: The borland compiler mounted the `$COMPILER_DIR` as `D:` so that is a slightly different approach). 

This means we can *start* in the `${COMPILER_DIR}` using the `-K` and give relative paths to the executables we need to run, *and* give precise paths to the files we want to compile (i.e. `D:\\input.c`)

## Notes

I couldn't solve #1422 entirely, there is still 1 compiler that requires us to `cp -r` the files from COMPILER_DIR into the sandbox
- [ ] `DREAMCAST_CC` (uses Wine)
- [x] `SATURN_CC` (only need 1 file, but without GO32.EXE compilation fails with 'Cannot exec go32`