### PR TITLE
Add traceback in logs if asm-differ throws an Exception

### DIFF
--- a/backend/coreapp/diff_wrapper.py
+++ b/backend/coreapp/diff_wrapper.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import subprocess
 import shlex
@@ -236,9 +235,10 @@ class DiffWrapper:
                 None, elf_object, basedump, config
             )
         except AssertionError as e:
-            logger.exception("Error preprocessing dump")
+            logger.exception("Error preprocessing dump: %s", e)
             raise DiffError(f"Error preprocessing dump: {e}")
         except Exception as e:
+            logger.exception("Error preprocessing dump: %s", e)
             raise DiffError(f"Error preprocessing dump: {e}")
 
         return basedump
@@ -281,6 +281,7 @@ class DiffWrapper:
                 objdump_flags,
             )
         except Exception as e:
+            logger.exception("Error dumping target assembly: %s", e)
             raise DiffError(f"Error dumping target assembly: {e}")
         try:
             mydump = DiffWrapper.get_dump(
@@ -292,6 +293,7 @@ class DiffWrapper:
         try:
             result = DiffWrapper.run_diff(basedump, mydump, config)
         except Exception as e:
+            logger.exception("Error running asm-differ: %s", e)
             raise DiffError(f"Error running asm-differ: {e}")
 
         return DiffResult(result)


### PR DESCRIPTION
Rather than just showing this error in the UI
```
Diff error: Error running asm-differ: invalid literal for int() with base 0: ' lr}'
```
Show this in the server logs too to help pinpoint the failure:
```
backend-1   | 09:27:36 ERROR Error running asm-differ: invalid literal for int() with base 0: ' lr}'
backend-1   | Traceback (most recent call last):
backend-1   |   File "/backend/coreapp/diff_wrapper.py", line 295, in diff
backend-1   |     result = DiffWrapper.run_diff(basedump, mydump, config)
backend-1   |   File "/backend/coreapp/diff_wrapper.py", line 249, in run_diff
backend-1   |     base_lines = asm_differ.process(basedump, config)
backend-1   |   File "/backend/virtualenvs/backend-yStQQXE7-py3.10/lib/python3.10/site-packages/diff.py", line 2908, in process
backend-1   |     original, reloc_symbol = processor.process_reloc(reloc_row, original)
backend-1   |   File "/backend/virtualenvs/backend-yStQQXE7-py3.10/lib/python3.10/site-packages/diff.py", line 1915, in process_reloc
backend-1   |     repl = row.split()[-1] + reloc_addend_from_imm(imm, before, self.config.arch)
backend-1   |   File "/backend/virtualenvs/backend-yStQQXE7-py3.10/lib/python3.10/site-packages/diff.py", line 2735, in reloc_addend_from_imm
backend-1   |     addend = int(imm, 0)
backend-1   | ValueError: invalid literal for int() with base 0: ' lr}'
```