### PR TITLE
Ubuntu 24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,6 +191,8 @@ jobs:
           docker build backend -t decompme_backend
       - name: Run tests
         run: |-
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_unconfined=0
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
           mkdir -p sandbox && chmod 777 sandbox
           mkdir -p local_files && chmod 777 local_files
           mkdir -p compilers && chmod 777 compilers

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,6 +202,11 @@ jobs:
             -v $(pwd)/libraries:/libraries \
             --security-opt apparmor=unconfined \
             --security-opt seccomp=unconfined \
+            --cap-drop all \
+            --cap-add setuid \
+            --cap-add setgid \
+            --cap-add setfcap \
+            --tmpfs /sandbox/tmp:exec,uid=1000,gid=1000,size=64M,mode=0700 \
             --entrypoint /bin/bash \
             -e COMPILER_BASE_PATH=/compilers \
             -e LIBRARY_BASE_PATH=/libraries \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,12 @@ jobs:
             wget \
             wine
 
+      # FIXME: clang needs libtinfo5 which is not available on Ubuntu 24.04
+      - name: Install libtinfo5 for clang
+        run: |-
+          wget http://security.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb
+          sudo apt install ./libtinfo5_6.3-2ubuntu0.1_amd64.deb
+
       - name: Install nsjail
         run: |-
           git clone --recursive --branch=3.4 https://github.com/google/nsjail

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
             wget \
             wine
 
-      # FIXME: clang needs libtinfo5 which is not available on Ubuntu 24.04
+      # NOTE: clang needs libtinfo5 which is not available on Ubuntu 24.04
       - name: Install libtinfo5 for clang
         run: |-
           wget http://security.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,90 +7,110 @@ on:
 jobs:
   full_test_and_build:
     name: full test and build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Install poetry
-        run: pipx install poetry
-      - name: Setup Python 3.10
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
-          cache: poetry
-          cache-dependency-path: backend/poetry.lock
-      - name: Install backend Python dependencies
-        run: cd backend && poetry install --no-root
       - name: Install apt dependencies (initial)
         run: |-
-          sudo dpkg --add-architecture i386
-          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
-          sudo apt-get update -qq
-          sudo apt-get install -yqq --allow-downgrades libc6:i386 libgcc-s1:i386 libstdc++6:i386 wine
-
-          sudo apt-get install \
+          sudo apt-get update
+          sudo apt-get install -y \
             ca-certificates \
-            curl \
-            gnupg \
-            lsb-release
-          sudo mkdir -p /etc/apt/keyrings
-          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-          echo \
-            "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
-            $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-          sudo apt-get update -qq
-          sudo apt-get install docker-ce docker-ce-cli containerd.io docker-compose-plugin
-
-          sudo apt-get install \
+            python-is-python3 \
+            python3 \
+            python3-pip \
+            python3.12-dev \
+            python3.12-venv \
+            software-properties-common
+      - name: Install apt dependencies (nsjail)
+        run: |-
+          sudo apt-get update
+          sudo apt-get install -y \
+            autoconf \
+            bison \
+            flex \
+            g++ \
+            gcc \
+            git \
+            libnl-route-3-dev \
+            libprotobuf-dev \
+            libtool \
+            make \
+            pkg-config \
+            protobuf-compiler
+      - name: Install apt dependencies (decomp.me)
+        run: |-
+          sudo dpkg --add-architecture i386
+          sudo add-apt-repository -y ppa:stsp-0/dj64
+          sudo add-apt-repository -y ppa:dosemu2/ppa
+          sudo apt-get update
+          sudo apt-get install -y -o APT::Immediate-Configure=false \
             binutils-aarch64-linux-gnu \
             binutils-arm-none-eabi \
             binutils-djgpp \
+            binutils-mingw-w64-i686 \
             binutils-mips-linux-gnu \
             binutils-powerpc-linux-gnu \
             binutils-sh-elf \
-            binutils-mingw-w64-i686 \
+            curl \
+            dj64 \
             dos2unix \
+            dosemu2 \
+            gcc-mips-linux-gnu \
+            git \
+            iptables \
             libarchive-tools \
+            libc6-dev-i386 \
+            libdevmapper1.02.1 \
+            libgpgme11 \
+            libnl-route-3-200 \
             libprotobuf-dev \
-            libnl-route-3-dev \
-            libncurses5 \
-            protobuf-compiler
-      - name: Install msdos assembler
+            libtinfo6 \
+            netcat-traditional \
+            unzip \
+            wget \
+            wine
+
+      - name: Install nsjail
         run: |-
-          wget https://github.com/OmniBlade/binutils-gdb/releases/download/omf-build/omftools.tar.gz
-          sudo tar xvzf omftools.tar.gz -C /usr/bin jwasm
-          wget https://github.com/decompals/binutils-omf/releases/download/v0.1/omftools-linux-x86_64.tar.gz
-          sudo tar xvzf omftools-linux-x86_64.tar.gz -C /usr/bin omf-nm omf-objdump
+          git clone --recursive --branch=3.4 https://github.com/google/nsjail
+          make -C nsjail
+          sudo cp nsjail/nsjail /usr/bin/
+
       - name: Install mips PS2 binutils
         run: |-
           wget https://github.com/decompals/binutils-mips-ps2-decompals/releases/download/v0.4/binutils-mips-ps2-decompals-linux-x86-64.tar.gz
           sudo tar xvzf binutils-mips-ps2-decompals-linux-x86-64.tar.gz -C /usr/bin mips-ps2-decompals-as mips-ps2-decompals-nm mips-ps2-decompals-objdump
-      - name: Install apt dependencies (cached)
-        uses: awalsh128/cache-apt-pkgs-action@v1
-        with:
-          packages: docker-ce docker-ce-cli containerd.io docker-compose-plugin binutils-aarch64-linux-gnu binutils-mips-linux-gnu binutils-powerpc-linux-gnu binutils-sh-elf dos2unix libprotobuf-dev libnl-route-3-dev libncurses5 protobuf-compiler wine software-properties-common
-          version: 1.0
-      - name: Install DOSEMU
-        run: |-
-          sudo add-apt-repository -y ppa:stsp-0/dj64
-          sudo add-apt-repository -y ppa:dosemu2/ppa
-          sudo apt-get update
-          sudo apt-get install -y dj64 dosemu2
-      - name: Install nsjail
-        run: |-
-          git clone --recursive --branch=3.1 https://github.com/google/nsjail
-          make -C nsjail
-          sudo cp nsjail/nsjail /usr/bin/
+
       - name: Install GC/Wii binutils
         run: |-
           curl -sSL https://github.com/encounter/gc-wii-binutils/releases/download/2.42-1/linux-`uname -m`.zip | \
             sudo bsdtar -xvf- -C /usr/bin
           sudo chmod +x /usr/bin/powerpc-eabi-*
-      - name: Cache compilers
-        uses: actions/cache@v4
+
+      - name: Install MSDOS binutils
+        run: |-
+          wget https://github.com/OmniBlade/binutils-gdb/releases/download/omf-build/omftools.tar.gz
+          sudo tar xvzf omftools.tar.gz -C /usr/bin jwasm
+          wget https://github.com/decompals/binutils-omf/releases/download/v0.1/omftools-linux-x86_64.tar.gz
+          sudo tar xvzf omftools-linux-x86_64.tar.gz -C /usr/bin omf-nm omf-objdump
+
+      - name: Install wibo
+        run: |-
+          wget https://github.com/decompals/wibo/releases/download/0.6.16/wibo && chmod +x wibo && sudo cp wibo /usr/bin/
+
+      - name: Install poetry
+        run: pipx install poetry
+
+      - uses: actions/checkout@v4
+
+      - name: Setup Python 3.12
+        uses: actions/setup-python@v5
         with:
-          path: backend/compilers/download_cache
-          key: ${{ runner.os }}-compilers-${{ hashFiles('backend/compilers/compilers.*.yaml') }}
+          python-version: "3.12"
+          cache: poetry
+          cache-dependency-path: backend/poetry.lock
+      - name: Install backend Python dependencies
+        run: cd backend && poetry install --no-root
+
       - name: Download compilers
         run: |-
           cd backend
@@ -99,9 +119,6 @@ jobs:
         run: |-
           cd backend
           poetry run python3 libraries/download.py
-      - name: Install wibo
-        run: |-
-          wget https://github.com/decompals/wibo/releases/download/0.6.16/wibo && chmod +x wibo && sudo cp wibo /usr/bin/
 
       - name: Run backend tests
         run: |-
@@ -141,10 +158,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install poetry
         run: pipx install poetry
-      - name: Setup Python 3.10
+      - name: Setup Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.12"
           cache: poetry
           cache-dependency-path: backend/poetry.lock
       - name: Install Poetry
@@ -160,19 +177,12 @@ jobs:
 
   backend_test_docker:
     name: backend tests (docker)
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Build decompme_backend image
         run: |-
-          docker build backend \
-            -t decompme_backend \
-            --build-arg ENABLE_MSDOS_SUPPORT=YES \
-            --build-arg ENABLE_GC_WII_SUPPORT=YES \
-            --build-arg ENABLE_PS2_SUPPORT=YES \
-            --build-arg ENABLE_SATURN_SUPPORT=YES \
-            --build-arg ENABLE_DREAMCAST_SUPPORT=YES \
-            --build-arg ENABLE_WIN32_SUPPORT=YES
+          docker build backend -t decompme_backend
       - name: Run tests
         run: |-
           mkdir -p sandbox && chmod 777 sandbox
@@ -204,7 +214,7 @@ jobs:
 
   frontend_lint:
     name: biome
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Setup Node.js 20
@@ -220,15 +230,15 @@ jobs:
 
   mypy:
     name: mypy
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Install poetry
         run: pipx install poetry
-      - name: Setup Python 3.10
+      - name: Setup Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.12"
           cache: poetry
           cache-dependency-path: backend/poetry.lock
       - run: |-
@@ -238,7 +248,7 @@ jobs:
 
   black:
     name: black
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: psf/black@stable

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 ubuntu:22.04 as base
+FROM --platform=linux/amd64 ubuntu:24.04 AS base
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -7,8 +7,8 @@ RUN apt-get update && apt-get install -y \
         python-is-python3 \
         python3 \
         python3-pip \
-        python3.10-dev \
-        python3.10-venv \
+        python3.12-dev \
+        python3.12-venv \
         software-properties-common
 
 
@@ -28,7 +28,7 @@ RUN apt-get -y update && apt-get install -y \
         pkg-config \
         protobuf-compiler
 
-RUN git clone "https://github.com/google/nsjail" --recursive --branch 3.1 /nsjail \
+RUN git clone "https://github.com/google/nsjail" --recursive --branch 3.4 /nsjail \
     && cd /nsjail \
     && make
 
@@ -60,15 +60,15 @@ RUN dpkg --add-architecture i386 \
         libgpgme11 \
         libnl-route-3-200 \
         libprotobuf-dev \
-        libtinfo5 \
-        netcat \
+        libtinfo6 \
+        netcat-traditional \
         unzip \
         wget \
         wine \
     && rm -rf /var/lib/apt/lists/*
 
 RUN curl -sSL https://install.python-poetry.org/ | \
-    POETRY_VERSION=1.8.4 POETRY_HOME=/etc/poetry python3.10 -
+    POETRY_VERSION=1.8.4 POETRY_HOME=/etc/poetry python3.12 -
 
 COPY --from=nsjail /nsjail/nsjail /bin/nsjail
 
@@ -99,17 +99,16 @@ WORKDIR /backend
 
 ENV WINEPREFIX=/tmp/wine
 
-# Create a non-root user & /sandbox with correct ownership
-RUN useradd --create-home user \
-    && mkdir -p /sandbox \
-    && chown -R user:user /sandbox \
+# Ensure /sandbox and wine dirs have correct ownership
+RUN mkdir -p /sandbox \
+    && chown -R ubuntu:ubuntu /sandbox \
     && mkdir -p "${WINEPREFIX}" \
-    && chown user:user "${WINEPREFIX}"
+    && chown ubuntu:ubuntu "${WINEPREFIX}"
 
 # Switch to non-root user
-USER user
+USER ubuntu
 
-# Initialize wine files to /home/user/.wine
+# Initialize wine files to /home/ubuntu/.wine
 RUN wineboot --init
 
 ENV PATH="$PATH:/etc/poetry/bin"

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -67,6 +67,10 @@ RUN dpkg --add-architecture i386 \
         wine \
     && rm -rf /var/lib/apt/lists/*
 
+RUN wget http://security.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb \
+    && apt install ./libtinfo5_6.3-2ubuntu0.1_amd64.deb \
+    && rm libtinfo5_6.3-2ubuntu0.1_amd64.deb
+
 RUN curl -sSL https://install.python-poetry.org/ | \
     POETRY_VERSION=1.8.4 POETRY_HOME=/etc/poetry python3.12 -
 

--- a/backend/coreapp/compiler_wrapper.py
+++ b/backend/coreapp/compiler_wrapper.py
@@ -113,6 +113,7 @@ class CompilerWrapper:
             r"### .*\.exe Driver Error:.*\n?",
             r"#   Cannot find my executable .*\n?",
             r"### MWCPPC\.exe Driver Error:.*\n?",
+            r"Fontconfig error:.*\n?",
         ]
 
         for str in filter_strings:

--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -326,11 +326,20 @@ CLANG_800 = ClangCompiler(
 )
 
 # PS1
+PSYQ_COMPILE_BAT = "\r\n".join(
+    [
+        "@echo off",
+        "SET TMPDIR=D:\\Temp",
+        "CC1PSX.EXE -quiet ${COMPILER_FLAGS} D:\\dos_src.c -o D:\\output.s",
+        "EXIT /B",
+    ]
+)
 PSYQ_MSDOS_CC = (
     "echo \"\\$_hdimage = '+0 $(pwd) +1'\" > .dosemurc && "
+    f'echo "{PSYQ_COMPILE_BAT}" >> COMPILE.BAT && '
     '/usr/bin/cpp -E "${INPUT}" | unix2dos > dos_src.c && '
-    '(HOME="$(pwd)" /usr/bin/dosemu -dumb -f .dosemurc -K "${COMPILER_DIR}" -E "CC1PSX.EXE -quiet ${COMPILER_FLAGS} D:\\dos_src.c -o D:\\output.s") && '
-    '(HOME="$(pwd)" /usr/bin/dosemu -dumb -f .dosemurc -K "${COMPILER_DIR}" -E "ASPSX.EXE -quiet D:\\output.s -o D:\\output.obj") && '
+    '(HOME=. /usr/bin/dosemu -f .dosemurc -quiet -dumb -K ${COMPILER_DIR} -E "D:\\COMPILE.BAT") && '
+    '(HOME=. /usr/bin/dosemu -f .dosemurc -quiet -dumb -K ${COMPILER_DIR} -E "ASPSX.EXE -quiet D:\\output.s -o D:\\output.obj") && '
     '${COMPILER_DIR}/psyq-obj-parser output.obj -o "${OUTPUT}"'
 )
 
@@ -498,9 +507,9 @@ GCC2723_MIPSEL = GCCPS1Compiler(
 SATURN_CC = (
     "echo \"\\$_hdimage = '+0 $(pwd) +1'\" > .dosemurc && "
     'cat "${INPUT}" | unix2dos > dos_src.c && '
-    '(HOME="$(pwd)" /usr/bin/dosemu -dumb -f .dosemurc -K "${COMPILER_DIR}" -E "CPP.EXE D:\\dos_src.c -o D:\\src_proc.c") && '
-    '(HOME="$(pwd)" /usr/bin/dosemu -dumb -f .dosemurc -K "${COMPILER_DIR}" -E "CC1.EXE -quiet ${COMPILER_FLAGS} D:\\src_proc.c -o D:\\output.s") && '
-    '(HOME="$(pwd)" /usr/bin/dosemu -dumb -f .dosemurc -K "${COMPILER_DIR}" -E "AS.EXE D:\\output.s -o D:\\output.o") && '
+    '(HOME="$(pwd)" /usr/bin/dosemu -quiet -dumb -f .dosemurc -K "${COMPILER_DIR}" -E "CPP.EXE D:\\dos_src.c -o D:\\src_proc.c") && '
+    '(HOME="$(pwd)" /usr/bin/dosemu -quiet -dumb -f .dosemurc -K "${COMPILER_DIR}" -E "CC1.EXE -quiet ${COMPILER_FLAGS} D:\\src_proc.c -o D:\\output.s") && '
+    '(HOME="$(pwd)" /usr/bin/dosemu -quiet -dumb -f .dosemurc -K "${COMPILER_DIR}" -E "AS.EXE D:\\output.s -o D:\\output.o") && '
     'sh-elf-objcopy -Icoff-sh -Oelf32-sh output.o "${OUTPUT}"'
 )
 
@@ -1484,7 +1493,7 @@ WATCOM_110_CPP = WatcomCompiler(
 BORLAND_MSDOS_CC = (
     "echo \"\\$_hdimage = '+0 ${COMPILER_DIR} +1'\" > .dosemurc && "
     'cat "${INPUT}" | unix2dos > dos_src.c && '
-    '(HOME="$(pwd)" /usr/bin/dosemu -dumb -f .dosemurc -K . -E "D:\\bin\\bcc.exe -ID:\\include ${COMPILER_FLAGS} -c -oout.o dos_src.c") && '
+    '(HOME="$(pwd)" /usr/bin/dosemu -quiet -dumb -f .dosemurc -K . -E "D:\\bin\\bcc.exe -ID:\\include ${COMPILER_FLAGS} -c -oout.o dos_src.c") && '
     'cp out.o "${OUTPUT}"'
 )
 

--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -327,15 +327,15 @@ CLANG_800 = ClangCompiler(
 
 # PS1
 PSYQ_MSDOS_CC = (
-    "echo \"\$_hdimage = '+0 $(pwd) +1'\" > .dosemurc && "
-    'cpp -P "${INPUT}" | unix2dos > dos_src.c && '
-    '(HOME="$(pwd)" /usr/bin/dosemu -quiet -dumb -f .dosemurc -K "${COMPILER_DIR}" -E "CC1PSX.EXE -quiet ${COMPILER_FLAGS} D:\\dos_src.c -o D:\\output.s") && '
-    '(HOME="$(pwd)" /usr/bin/dosemu -quiet -dumb -f .dosemurc -K "${COMPILER_DIR}" -E "ASPSX.EXE -quiet D:\\output.s -o D:\\output.obj") && '
+    "echo \"\\$_hdimage = '+0 $(pwd) +1'\" > .dosemurc && "
+    '/usr/bin/cpp -E "${INPUT}" | unix2dos > dos_src.c && '
+    '(HOME="$(pwd)" /usr/bin/dosemu -dumb -f .dosemurc -K "${COMPILER_DIR}" -E "CC1PSX.EXE -quiet ${COMPILER_FLAGS} D:\\dos_src.c -o D:\\output.s") && '
+    '(HOME="$(pwd)" /usr/bin/dosemu -dumb -f .dosemurc -K "${COMPILER_DIR}" -E "ASPSX.EXE -quiet D:\\output.s -o D:\\output.obj") && '
     '${COMPILER_DIR}/psyq-obj-parser output.obj -o "${OUTPUT}"'
 )
 
 PSYQ_CC = (
-    'cpp -P "${INPUT}" | unix2dos | '
+    '/usr/bin/cpp -P "${INPUT}" | unix2dos | '
     '${WIBO} ${COMPILER_DIR}/CC1PSX.EXE -quiet ${COMPILER_FLAGS} -o "${OUTPUT}".s && '
     '${WIBO} ${COMPILER_DIR}/ASPSX.EXE -quiet "${OUTPUT}".s -o "${OUTPUT}"bj && '
     '${COMPILER_DIR}/psyq-obj-parser "${OUTPUT}"bj -o "${OUTPUT}"'
@@ -411,7 +411,7 @@ PSYQ46 = GCCPS1Compiler(
 )
 
 PS1_GCC = (
-    'cpp -E -lang-c -nostdinc "${INPUT}" -o "${INPUT}".i && '
+    '/usr/bin/cpp -E -lang-c -nostdinc "${INPUT}" -o "${INPUT}".i && '
     'printf "%s" "${COMPILER_FLAGS}" | xargs -- ${COMPILER_DIR}/gcc -c -pipe -B${COMPILER_DIR}/ -o "${OUTPUT}" "${INPUT}.i"'
 )
 
@@ -496,11 +496,11 @@ GCC2723_MIPSEL = GCCPS1Compiler(
 
 # Saturn
 SATURN_CC = (
-    "echo \"\$_hdimage = '+0 $(pwd) +1'\" > .dosemurc && "
+    "echo \"\\$_hdimage = '+0 $(pwd) +1'\" > .dosemurc && "
     'cat "${INPUT}" | unix2dos > dos_src.c && '
-    '(HOME="$(pwd)" /usr/bin/dosemu -quiet -dumb -f .dosemurc -K "${COMPILER_DIR}" -E "CPP.EXE D:\\dos_src.c -o D:\\src_proc.c") && '
-    '(HOME="$(pwd)" /usr/bin/dosemu -quiet -dumb -f .dosemurc -K "${COMPILER_DIR}" -E "CC1.EXE -quiet ${COMPILER_FLAGS} D:\\src_proc.c -o D:\\output.s") && '
-    '(HOME="$(pwd)" /usr/bin/dosemu -quiet -dumb -f .dosemurc -K "${COMPILER_DIR}" -E "AS.EXE D:\\output.s -o D:\\output.o") && '
+    '(HOME="$(pwd)" /usr/bin/dosemu -dumb -f .dosemurc -K "${COMPILER_DIR}" -E "CPP.EXE D:\\dos_src.c -o D:\\src_proc.c") && '
+    '(HOME="$(pwd)" /usr/bin/dosemu -dumb -f .dosemurc -K "${COMPILER_DIR}" -E "CC1.EXE -quiet ${COMPILER_FLAGS} D:\\src_proc.c -o D:\\output.s") && '
+    '(HOME="$(pwd)" /usr/bin/dosemu -dumb -f .dosemurc -K "${COMPILER_DIR}" -E "AS.EXE D:\\output.s -o D:\\output.o") && '
     'sh-elf-objcopy -Icoff-sh -Oelf32-sh output.o "${OUTPUT}"'
 )
 
@@ -846,7 +846,7 @@ GCC281PM = GCCCompiler(
 GCC272SN = GCCCompiler(
     id="gcc2.7.2sn",
     platform=N64,
-    cc='cpp -P "$INPUT" | ${WIBO} "${COMPILER_DIR}"/cc1n64.exe -quiet -G0 -mcpu=vr4300 -mips3 -mhard-float -meb ${COMPILER_FLAGS} -o "$OUTPUT".s && ${WIBO} "${COMPILER_DIR}"/asn64.exe -q -G0 "$OUTPUT".s -o "$OUTPUT".obj && "${COMPILER_DIR}"/psyq-obj-parser "$OUTPUT".obj -o "$OUTPUT" -b -n',
+    cc='/usr/bin/cpp -P "$INPUT" | ${WIBO} "${COMPILER_DIR}"/cc1n64.exe -quiet -G0 -mcpu=vr4300 -mips3 -mhard-float -meb ${COMPILER_FLAGS} -o "$OUTPUT".s && ${WIBO} "${COMPILER_DIR}"/asn64.exe -q -G0 "$OUTPUT".s -o "$OUTPUT".obj && "${COMPILER_DIR}"/psyq-obj-parser "$OUTPUT".obj -o "$OUTPUT" -b -n',
 )
 
 GCC272SNEW = GCCCompiler(
@@ -858,7 +858,7 @@ GCC272SNEW = GCCCompiler(
 GCC281SN = GCCCompiler(
     id="gcc2.8.1sn",
     platform=N64,
-    cc='cpp -E -lang-c -undef -D__GNUC__=2 -Dmips -D__mips__ -D__mips -Dn64 -D__n64__ -D__n64 -D_PSYQ -D__EXTENSIONS__ -D_MIPSEB -D__CHAR_UNSIGNED__ "$INPUT" '
+    cc='/usr/bin/cpp -E -lang-c -undef -D__GNUC__=2 -Dmips -D__mips__ -D__mips -Dn64 -D__n64__ -D__n64 -D_PSYQ -D__EXTENSIONS__ -D_MIPSEB -D__CHAR_UNSIGNED__ "$INPUT" '
     '| ${WIBO} "${COMPILER_DIR}"/cc1n64.exe ${COMPILER_FLAGS} -o "$OUTPUT".s '
     '&& ${WIBO} "${COMPILER_DIR}"/asn64.exe -q -G0 "$OUTPUT".s -o "$OUTPUT".obj '
     '&& "${COMPILER_DIR}"/psyq-obj-parser "$OUTPUT".obj -o "$OUTPUT" -b -n',
@@ -868,7 +868,7 @@ GCC281SNCXX = GCCCompiler(
     id="gcc2.8.1sn-cxx",
     base_compiler=GCC281SN,
     platform=N64,
-    cc='cpp -E -lang-c++ -undef -D__GNUC__=2 -D__cplusplus -Dmips -D__mips__ -D__mips -Dn64 -D__n64__ -D__n64 -D_PSYQ -D__EXTENSIONS__ -D_MIPSEB -D__CHAR_UNSIGNED__ -D_LANGUAGE_C_PLUS_PLUS "$INPUT" '
+    cc='/usr/bin/cpp -E -lang-c++ -undef -D__GNUC__=2 -D__cplusplus -Dmips -D__mips__ -D__mips -Dn64 -D__n64__ -D__n64 -D_PSYQ -D__EXTENSIONS__ -D_MIPSEB -D__CHAR_UNSIGNED__ -D_LANGUAGE_C_PLUS_PLUS "$INPUT" '
     '| ${WIBO} "${COMPILER_DIR}"/cc1pln64.exe ${COMPILER_FLAGS} -o "$OUTPUT".s '
     '&& ${WIBO} "${COMPILER_DIR}"/asn64.exe -q -G0 "$OUTPUT".s -o "$OUTPUT".obj '
     '&& "${COMPILER_DIR}"/psyq-obj-parser "$OUTPUT".obj -o "$OUTPUT" -b -n',
@@ -1191,7 +1191,7 @@ PRODG_37 = GCCCompiler(
 )
 
 PRODG_CC = (
-    'cpp -E "${INPUT}" -o "${INPUT}".i && '
+    '/usr/bin/cpp -E "${INPUT}" -o "${INPUT}".i && '
     "${WINE} ${COMPILER_DIR}/cc1.exe -quiet ${COMPILER_FLAGS} -o ${OUTPUT}.s ${INPUT}.i && "
     "${WIBO} ${COMPILER_DIR}/NgcAs.exe ${OUTPUT}.s -o ${OUTPUT}"
 )
@@ -1482,9 +1482,9 @@ WATCOM_110_CPP = WatcomCompiler(
 )
 
 BORLAND_MSDOS_CC = (
-    "echo \"\$_hdimage = '+0 ${COMPILER_DIR} +1'\" > .dosemurc && "
+    "echo \"\\$_hdimage = '+0 ${COMPILER_DIR} +1'\" > .dosemurc && "
     'cat "${INPUT}" | unix2dos > dos_src.c && '
-    '(HOME="$(pwd)" /usr/bin/dosemu -quiet -dumb -f .dosemurc -K . -E "D:\\bin\\bcc.exe -ID:\\include ${COMPILER_FLAGS} -c -oout.o dos_src.c") && '
+    '(HOME="$(pwd)" /usr/bin/dosemu -dumb -f .dosemurc -K . -E "D:\\bin\\bcc.exe -ID:\\include ${COMPILER_FLAGS} -c -oout.o dos_src.c") && '
     'cp out.o "${OUTPUT}"'
 )
 

--- a/backend/coreapp/sandbox.py
+++ b/backend/coreapp/sandbox.py
@@ -86,13 +86,14 @@ class Sandbox(contextlib.AbstractContextManager["Sandbox"]):
             "--bindmount", f"{self.path}/Temp:/wine/drive_c/users/{user}/Temp",
             "--env", "WINEDEBUG=-all",
             "--env", "WINEPREFIX=/wine",
+            "--verbose",
         ]
         # fmt: on
         if settings.SANDBOX_DISABLE_PROC:
             wrapper.append("--disable_proc")  # needed for running inside Docker
 
-        if not settings.DEBUG:
-            wrapper.append("--really_quiet")
+        # if not settings.DEBUG:
+        #     wrapper.append("--really_quiet")
         for mount in mounts:
             wrapper.extend(["--bindmount_ro", str(mount)])
         for key in env:

--- a/backend/coreapp/sandbox.py
+++ b/backend/coreapp/sandbox.py
@@ -73,6 +73,7 @@ class Sandbox(contextlib.AbstractContextManager["Sandbox"]):
             "--bindmount_ro", "/lib64",
             "--bindmount_ro", "/usr",
             "--bindmount_ro", "/proc",
+            "--bindmount_ro", "/sys",
             "--bindmount", f"{self.path}:/var/tmp",
             "--bindmount_ro", str(settings.COMPILER_BASE_PATH),
             "--bindmount_ro", str(settings.LIBRARY_BASE_PATH),

--- a/backend/coreapp/sandbox.py
+++ b/backend/coreapp/sandbox.py
@@ -86,14 +86,13 @@ class Sandbox(contextlib.AbstractContextManager["Sandbox"]):
             "--bindmount", f"{self.path}/Temp:/wine/drive_c/users/{user}/Temp",
             "--env", "WINEDEBUG=-all",
             "--env", "WINEPREFIX=/wine",
-            "--verbose",
         ]
         # fmt: on
         if settings.SANDBOX_DISABLE_PROC:
             wrapper.append("--disable_proc")  # needed for running inside Docker
 
-        # if not settings.DEBUG:
-        #     wrapper.append("--really_quiet")
+        if not settings.DEBUG:
+            wrapper.append("--really_quiet")
         for mount in mounts:
             wrapper.extend(["--bindmount_ro", str(mount)])
         for key in env:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '2'
 services:
   postgres:
     image: postgres:13


### PR DESCRIPTION
**Notes**
- This PR also cleans up `ci.yaml`, bringing it more in-line with the steps in the Dockerfile
- For some reason calling `cpp` (`which cpp` tells me its `/bin/cpp`) gives a different behaviour to calling `/usr/bin/cpp` (which is the same binary) - it tries to execute system `cc1` (it is ignoring the -E arg completely). Giving the full path to `cpp` corrects this weirdness.

**Known Issues:**
- [x] All tests fail when running docker under Ubuntu 24.04 (with sandbox enabled)

**Appendix**
Demonstrating the dumbness of `cpp`:
```
ubuntu@f21440c3d414:/backend$ ls -al /usr/bin/cpp
lrwxrwxrwx 1 root root 6 Jan 31  2024 /usr/bin/cpp -> cpp-13
ubuntu@f21440c3d414:/backend$ ls -al /bin/cpp
lrwxrwxrwx 1 root root 6 Jan 31  2024 /bin/cpp -> cpp-13
ubuntu@f21440c3d414:/backend$ ll /usr/bin/cpp-13
lrwxrwxrwx 1 root root 23 Sep  4 14:44 /usr/bin/cpp-13 -> x86_64-linux-gnu-cpp-13*
ubuntu@f21440c3d414:/backend$ ll /bin/cpp-13
lrwxrwxrwx 1 root root 23 Sep  4 14:44 /bin/cpp-13 -> x86_64-linux-gnu-cpp-13*
ubuntu@f21440c3d414:/backend$ ll /usr/bin/x86_64-linux-gnu-cpp-13
-rwxr-xr-x 1 root root 1027128 Sep  4 14:44 /usr/bin/x86_64-linux-gnu-cpp-13*
ubuntu@f21440c3d414:/backend$ ll /bin/x86_64-linux-gnu-cpp-13
-rwxr-xr-x 1 root root 1027128 Sep  4 14:44 /bin/x86_64-linux-gnu-cpp-13*
ubuntu@f21440c3d414:/backend$ sha256sum /usr/bin/x86_64-linux-gnu-cpp-13 /bin/x86_64-linux-gnu-cpp-13
a1d872b2ddb58bfdce21e16e2ecfdf9ca4aec921f7106523101759bfaa913c6f  /usr/bin/x86_64-linux-gnu-cpp-13
a1d872b2ddb58bfdce21e16e2ecfdf9ca4aec921f7106523101759bfaa913c6f  /bin/x86_64-linux-gnu-cpp-13
```