### PR TITLE
Switch prodg 3.5 and 3.7 compilers to ngccc driver

### DIFF
--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -1176,22 +1176,26 @@ MWCC_43_213 = MWCCWiiGCCompiler(
     cc=MWCCEPPC_CC,
 )
 
-PRODG_CC = (
-    'cpp -E "${INPUT}" -o "${INPUT}".i && '
-    "${WINE} ${COMPILER_DIR}/cc1.exe -quiet ${COMPILER_FLAGS} -o ${OUTPUT}.s ${INPUT}.i && "
-    "${WIBO} ${COMPILER_DIR}/NgcAs.exe ${OUTPUT}.s -o ${OUTPUT}"
+PRODG_NGC_CC = (
+    "SN_NGC_PATH=${COMPILER_DIR} ${WINE} ${COMPILER_DIR}/ngccc.exe ${COMPILER_FLAGS} -o ${OUTPUT} ${INPUT}"
 )
 
 PRODG_35 = GCCCompiler(
     id="prodg_35",
     platform=GC_WII,
-    cc=PRODG_CC,
+    cc=PRODG_NGC_CC,
 )
 
 PRODG_37 = GCCCompiler(
     id="prodg_37",
     platform=GC_WII,
-    cc=PRODG_CC,
+    cc=PRODG_NGC_CC,
+)
+
+PRODG_CC = (
+    'cpp -E "${INPUT}" -o "${INPUT}".i && '
+    "${WINE} ${COMPILER_DIR}/cc1.exe -quiet ${COMPILER_FLAGS} -o ${OUTPUT}.s ${INPUT}.i && "
+    "${WIBO} ${COMPILER_DIR}/NgcAs.exe ${OUTPUT}.s -o ${OUTPUT}"
 )
 
 PRODG_393 = GCCCompiler(

--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -1176,9 +1176,7 @@ MWCC_43_213 = MWCCWiiGCCompiler(
     cc=MWCCEPPC_CC,
 )
 
-PRODG_NGC_CC = (
-    "SN_NGC_PATH=${COMPILER_DIR} ${WINE} ${COMPILER_DIR}/ngccc.exe ${COMPILER_FLAGS} -o ${OUTPUT} ${INPUT}"
-)
+PRODG_NGC_CC = "SN_NGC_PATH=${COMPILER_DIR} ${WINE} ${COMPILER_DIR}/ngccc.exe ${COMPILER_FLAGS} -o ${OUTPUT} ${INPUT}"
 
 PRODG_35 = GCCCompiler(
     id="prodg_35",

--- a/frontend/src/lib/i18n/locales/en/compilers.json
+++ b/frontend/src/lib/i18n/locales/en/compilers.json
@@ -154,8 +154,8 @@
     "mwcc_43_213": "4.3 build 213 (Wii MW 1.7)",
     "mwcppc_23": "MWCPPC 2.3 (CodeWarrior Pro 5)",
     "mwcppc_24": "MWCPPC 2.4 (CodeWarrior Pro 6)",
-    "prodg_35": "ProDG 3.5 (gcc 2.95.2)",
-    "prodg_37": "ProDG 3.7 (gcc 2.95.2)",
+    "prodg_35": "ProDG 3.5 (gcc 2.95.2) [ngccc]",
+    "prodg_37": "ProDG 3.7 (gcc 2.95.2) [ngccc]",
     "prodg_393": "ProDG 3.9.3 (gcc 2.95.3)",
 
     "old_agbcc": "old_agbcc",


### PR DESCRIPTION
Addresses #1445 for 2/3 of the prodg compilers.