### PR TITLE
Add extra sanity check to user.is_online()

### DIFF
--- a/backend/coreapp/models/profile.py
+++ b/backend/coreapp/models/profile.py
@@ -61,7 +61,7 @@ class Profile(models.Model):
 
     def is_online(self) -> bool:
         if self.last_request_date is None:
-            return False
+            return False  # type:ignore[unreachable]
         delta = timezone.now() - self.last_request_date
 
         # 2 mins

--- a/backend/coreapp/models/profile.py
+++ b/backend/coreapp/models/profile.py
@@ -60,6 +60,8 @@ class Profile(models.Model):
         return (hue, satuation, lightness)
 
     def is_online(self) -> bool:
+        if self.last_request_date is None:
+            return False
         delta = timezone.now() - self.last_request_date
 
         # 2 mins


### PR DESCRIPTION
So, I believe that `last_request_date` only actually set on profile.save() ... and for the Yandex bot that trawls/executes javascript we create a generic profile but do not save it.