### PR TITLE
Stick thousands separators in num_scratches on preset page

### DIFF
--- a/frontend/src/app/(navfooter)/platform/[id]/page.tsx
+++ b/frontend/src/app/(navfooter)/platform/[id]/page.tsx
@@ -65,7 +65,7 @@ export default async function Page({ params }: { params: { id: number } }) {
                     url={`/scratch?platform=${platform.id}&page_size=20`}
                     item={ScratchItemPlatformList}
                     isSortable={true}
-                    title={`Scratches (${platform.num_scratches})`}
+                    title={`Scratches (${platform.num_scratches.toLocaleString("en-US")})`}
                 />
             </section>
         </main>

--- a/frontend/src/app/(navfooter)/preset/[id]/page.tsx
+++ b/frontend/src/app/(navfooter)/preset/[id]/page.tsx
@@ -70,7 +70,7 @@ export default async function Page({ params }: { params: { id: number } }) {
                     url={`/scratch?preset=${preset.id}&page_size=20`}
                     item={ScratchItemPresetList}
                     isSortable={true}
-                    title={`Scratches (${preset.num_scratches})`}
+                    title={`Scratches (${preset.num_scratches.toLocaleString("en-US")})`}
                 />
             </section>
         </main>

--- a/frontend/src/components/PresetList.tsx
+++ b/frontend/src/components/PresetList.tsx
@@ -117,7 +117,7 @@ export function PresetItem({
                 </div>
                 <div className="flex-1 text-right text-gray-11">
                     {preset.num_scratches > 1
-                        ? `${preset.num_scratches.toLocaleString()} scratches`
+                        ? `${preset.num_scratches.toLocaleString("en-US")} scratches`
                         : preset.num_scratches > 0
                           ? `${preset.num_scratches} scratch`
                           : "No scratches"}

--- a/frontend/src/components/PresetList.tsx
+++ b/frontend/src/components/PresetList.tsx
@@ -117,7 +117,7 @@ export function PresetItem({
                 </div>
                 <div className="flex-1 text-right text-gray-11">
                     {preset.num_scratches > 1
-                        ? `${preset.num_scratches} scratches`
+                        ? `${preset.num_scratches.toLocaleString()} scratches`
                         : preset.num_scratches > 0
                           ? `${preset.num_scratches} scratch`
                           : "No scratches"}


### PR DESCRIPTION
We have some presets with thousands of scratches, so stick a `,` in the number to avoid `3596` like below:

![image](https://github.com/user-attachments/assets/bb6bfde2-088e-4cd0-814f-64f7362d9224)
