### PR TITLE
Optimise Preset's num_scratches annotation

### DIFF
--- a/backend/coreapp/views/preset.py
+++ b/backend/coreapp/views/preset.py
@@ -50,7 +50,7 @@ class PresetFilterSet(django_filters.FilterSet):
 
 class PresetViewSet(ModelViewSet):  # type: ignore
     permission_classes = [IsAdminUser | IsOwnerOrReadOnly]
-    queryset = Preset.objects.all().annotate(num_scratches=Count("scratch"))
+    queryset = Preset.objects.all().annotate(num_scratches=Count("scratch__preset__id"))
     pagination_class = PresetPagination
     filterset_class = PresetFilterSet
     filter_backends = [


### PR DESCRIPTION
I need someone with a bigger brain to confirm whether this is better or not.

```py
$ /home/ethteck/.local/bin/poetry run ./manage.py shell
Python 3.12.3 (main, Jan 17 2025, 18:03:48) [GCC 13.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
(InteractiveConsole)
>>> from django.apps import apps
>>> Preset = apps.get_model("coreapp", "Preset")
>>> from django.db.models import Count
>>> print(Preset.objects.all().annotate(num_scratches=Count("scratch")).explain())
HashAggregate  (cost=24066.05..24067.67 rows=162 width=187)
  Group Key: coreapp_preset.id
  ->  Hash Right Join  (cost=8.64..23344.52 rows=144306 width=184)
        Hash Cond: (coreapp_scratch.preset_id = coreapp_preset.id)
        ->  Seq Scan on coreapp_scratch  (cost=0.00..22951.06 rows=144306 width=13)
        ->  Hash  (cost=6.62..6.62 rows=162 width=179)
              ->  Seq Scan on coreapp_preset  (cost=0.00..6.62 rows=162 width=179)
>>> print(Preset.objects.all().annotate(num_scratches=Count("scratch__preset__id")).explain())
GroupAggregate  (cost=0.44..17830.09 rows=162 width=187)
  Group Key: coreapp_preset.id
  ->  Merge Left Join  (cost=0.44..17106.94 rows=144306 width=187)
        Merge Cond: (coreapp_preset.id = coreapp_scratch.preset_id)
        ->  Index Scan using coreapp_preset_pkey on coreapp_preset  (cost=0.14..18.58 rows=162 width=179)
        ->  Index Only Scan using coreapp_scratch_preset_fk_id_428fb0c7 on coreapp_scratch  (cost=0.29..34083.43 rows=144306 width=8)
>>> 
```