### PR TITLE
Update privacy policy

### DIFF
--- a/frontend/src/app/(navfooter)/privacy/page.tsx
+++ b/frontend/src/app/(navfooter)/privacy/page.tsx
@@ -132,8 +132,8 @@ export default function Page() {
                 information for improving existing decompilation tools and
                 developing new ones. We may also provide periodic public exports
                 of the site database for research in the field of decompilation.
-                These dumps will not contain any information that is not otherwise
-                publicly available on the site.
+                These dumps will not contain any information that is not
+                otherwise publicly available on the site.
             </p>
             <p className="my-4">
                 We make every effort to keep your data secure. In the case of a

--- a/frontend/src/app/(navfooter)/privacy/page.tsx
+++ b/frontend/src/app/(navfooter)/privacy/page.tsx
@@ -20,12 +20,13 @@ export default function Page() {
 
             <p className="mt-2 mb-6 text-gray-11 text-sm">
                 Changelog:
-
                 <ul className="mt-2 mb-6 px-4 text-gray-11 text-sm">
                     <li className="my-1">2022/1/13: Initial version</li>
                 </ul>
                 <ul className="mt-2 mb-6 px-4 text-gray-11 text-sm">
-                    <li className="my-1">2025/3/11: Update to clarify public data usage</li>
+                    <li className="my-1">
+                        2025/3/11: Update to clarify public data usage
+                    </li>
                 </ul>
             </p>
 

--- a/frontend/src/app/(navfooter)/privacy/page.tsx
+++ b/frontend/src/app/(navfooter)/privacy/page.tsx
@@ -15,7 +15,18 @@ export default function Page() {
             </h1>
 
             <p className="mt-2 mb-6 text-gray-11 text-sm">
-                Last updated January 13th 2022
+                Last updated March 11th 2025
+            </p>
+
+            <p className="mt-2 mb-6 text-gray-11 text-sm">
+                Changelog:
+
+                <ul className="mt-2 mb-6 px-4 text-gray-11 text-sm">
+                    <li className="my-1">2022/1/13: Initial version</li>
+                </ul>
+                <ul className="mt-2 mb-6 px-4 text-gray-11 text-sm">
+                    <li className="my-1">2025/3/11: Update to clarify public data usage</li>
+                </ul>
             </p>
 
             <p className="my-4">
@@ -118,8 +129,10 @@ export default function Page() {
                 features such as user profile pages and the scratch editor. We
                 also reserve the right to use any and all voluntarily-submited
                 information for improving existing decompilation tools and
-                developing new ones. This will not involve sharing information
-                with third parties.
+                developing new ones. In the future, we may provide open-source
+                dumps of the scratch database for research purposes. These dumps
+                will not contain any information that is not otherwise publicly
+                available on the site.
             </p>
             <p className="my-4">
                 We make every effort to keep your data secure. In the case of a

--- a/frontend/src/app/(navfooter)/privacy/page.tsx
+++ b/frontend/src/app/(navfooter)/privacy/page.tsx
@@ -130,10 +130,10 @@ export default function Page() {
                 features such as user profile pages and the scratch editor. We
                 also reserve the right to use any and all voluntarily-submited
                 information for improving existing decompilation tools and
-                developing new ones. In the future, we may provide open-source
-                dumps of the scratch database for research purposes. These dumps
-                will not contain any information that is not otherwise publicly
-                available on the site.
+                developing new ones. We may also provide perioic public exports
+                of the site database for research in the field of decompilation.
+                These dumps will not contain any information that is not otherwise
+                publicly available on the site.
             </p>
             <p className="my-4">
                 We make every effort to keep your data secure. In the case of a

--- a/frontend/src/app/(navfooter)/privacy/page.tsx
+++ b/frontend/src/app/(navfooter)/privacy/page.tsx
@@ -130,7 +130,7 @@ export default function Page() {
                 features such as user profile pages and the scratch editor. We
                 also reserve the right to use any and all voluntarily-submited
                 information for improving existing decompilation tools and
-                developing new ones. We may also provide perioic public exports
+                developing new ones. We may also provide periodic public exports
                 of the site database for research in the field of decompilation.
                 These dumps will not contain any information that is not otherwise
                 publicly available on the site.


### PR DESCRIPTION
Opening this as a PR for a bit and will merge if no one has any issues. This isn't much of a change in policy other than to remove the notion we won't share data with "third parties" because it's ambiguous what a third party would be, and it's also untrue that people not associated with the site should be able to access site data. 

For example, researchers wanting to improve decompilers by looking at the scratch database could easily be considered a third party, but this is also a totally valid use case for handling site data.

To reiterate, all  the data we're talking about is already publicly available on the site, visually and through the API. Nothing about the data in question involves private user info, authentication tokens, or anything of that nature.