### PR TITLE
Allow -x flag to be passed to GCC PS1 compilers again

### DIFF
--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -421,7 +421,7 @@ PSYQ46 = GCCPS1Compiler(
 
 PS1_GCC = (
     '/usr/bin/cpp -E -lang-c -nostdinc "${INPUT}" -o "${INPUT}".i && '
-    'eval "${COMPILER_DIR}/gcc ${COMPILER_FLAGS} -c -pipe -B${COMPILER_DIR}/ -o \"${OUTPUT}\" \"${INPUT}\".i"'
+    'eval "${COMPILER_DIR}/gcc ${COMPILER_FLAGS} -c -pipe -B${COMPILER_DIR}/ -o "${OUTPUT}" "${INPUT}".i"'
 )
 
 GCC257_PSX = GCCPS1Compiler(

--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -421,7 +421,7 @@ PSYQ46 = GCCPS1Compiler(
 
 PS1_GCC = (
     '/usr/bin/cpp -E -lang-c -nostdinc "${INPUT}" -o "${INPUT}".i && '
-    'printf "%s" "${COMPILER_FLAGS}" | xargs -- ${COMPILER_DIR}/gcc -c -pipe -B${COMPILER_DIR}/ -o "${OUTPUT}" "${INPUT}.i"'
+    'eval "${COMPILER_DIR}/gcc ${COMPILER_FLAGS} -c -pipe -B${COMPILER_DIR}/ -o \"${OUTPUT}\" \"${INPUT}\".i"'
 )
 
 GCC257_PSX = GCCPS1Compiler(


### PR DESCRIPTION
I couldn't manage to inject anything into the COMPILER_FLAGS to invoke any bad behaviour.