### PR TITLE
Add 4 new versions of SN 2.7.2 for Nintendo 64

### DIFF
--- a/backend/compilers/compilers.linux.yaml
+++ b/backend/compilers/compilers.linux.yaml
@@ -39,7 +39,11 @@ gc_wii:
 
 n64:
   - gcc2.7.2kmc
-  - gcc2.7.2sn
+  - gcc2.7.2sn0001
+  - gcc2.7.2sn0001-cxx
+  - gcc2.7.2sn0004
+  - gcc2.7.2sn0006
+  - gcc2.7.2sn0006-cxx
   - gcc2.7.2snew
   - gcc2.8.1pm
   - gcc2.8.1sn

--- a/backend/compilers/compilers.linux.yaml
+++ b/backend/compilers/compilers.linux.yaml
@@ -40,10 +40,8 @@ gc_wii:
 n64:
   - gcc2.7.2kmc
   - gcc2.7.2sn0001
-  - gcc2.7.2sn0001-cxx
   - gcc2.7.2sn0004
   - gcc2.7.2sn0006
-  - gcc2.7.2sn0006-cxx
   - gcc2.7.2snew
   - gcc2.8.1pm
   - gcc2.8.1sn

--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -882,8 +882,8 @@ CCN64_CPP_CXX = '/usr/bin/cpp -E -lang-c++ -undef -D__GNUC__=2 -D__cplusplus -Dm
 GCC272SN0001 = GCCCompiler(
     id="gcc2.7.2sn0001",
     platform=N64,
-    cc=CCN64_CPP_C +
-    '| ${WIBO} "${COMPILER_DIR}"/cc1n64.exe ${COMPILER_FLAGS} -o "$OUTPUT".s '
+    cc=CCN64_CPP_C
+    + '| ${WIBO} "${COMPILER_DIR}"/cc1n64.exe ${COMPILER_FLAGS} -o "$OUTPUT".s '
     '&& ${WIBO} "${COMPILER_DIR}"/asn64.exe -q "$OUTPUT".s -o "$OUTPUT".obj '
     '&& "${COMPILER_DIR}"/psyq-obj-parser "$OUTPUT".obj -o "$OUTPUT" -b -n -s',
 )
@@ -892,8 +892,8 @@ GCC272SN0001CXX = GCCCompiler(
     id="gcc2.7.2sn0001-cxx",
     base_compiler=GCC272SN0001,
     platform=N64,
-    cc=CCN64_CPP_CXX +
-    '| ${WIBO} "${COMPILER_DIR}"/cc1pln64.exe ${COMPILER_FLAGS} -o "$OUTPUT".s '
+    cc=CCN64_CPP_CXX
+    + '| ${WIBO} "${COMPILER_DIR}"/cc1pln64.exe ${COMPILER_FLAGS} -o "$OUTPUT".s '
     '&& ${WIBO} "${COMPILER_DIR}"/asn64.exe -q "$OUTPUT".s -o "$OUTPUT".obj '
     '&& "${COMPILER_DIR}"/psyq-obj-parser "$OUTPUT".obj -o "$OUTPUT" -b -n -s',
 )
@@ -907,8 +907,8 @@ GCC272SN0004 = GCCCompiler(
 GCC272SN0006 = GCCCompiler(
     id="gcc2.7.2sn0006",
     platform=N64,
-    cc=CCN64_CPP_C +
-    '| ${WIBO} "${COMPILER_DIR}"/cc1n64.exe ${COMPILER_FLAGS} -o "$OUTPUT".s '
+    cc=CCN64_CPP_C
+    + '| ${WIBO} "${COMPILER_DIR}"/cc1n64.exe ${COMPILER_FLAGS} -o "$OUTPUT".s '
     '&& ${WIBO} "${COMPILER_DIR}"/asn64.exe -q -G0 "$OUTPUT".s -o "$OUTPUT".obj '
     '&& "${COMPILER_DIR}"/psyq-obj-parser "$OUTPUT".obj -o "$OUTPUT" -b -n -s',
 )
@@ -917,8 +917,8 @@ GCC272SN0006CXX = GCCCompiler(
     id="gcc2.7.2sn0006-cxx",
     base_compiler=GCC272SN0006,
     platform=N64,
-    cc=CCN64_CPP_CXX +
-    '| ${WIBO} "${COMPILER_DIR}"/cc1pln64.exe ${COMPILER_FLAGS} -o "$OUTPUT".s '
+    cc=CCN64_CPP_CXX
+    + '| ${WIBO} "${COMPILER_DIR}"/cc1pln64.exe ${COMPILER_FLAGS} -o "$OUTPUT".s '
     '&& ${WIBO} "${COMPILER_DIR}"/asn64.exe -q -G0 "$OUTPUT".s -o "$OUTPUT".obj '
     '&& "${COMPILER_DIR}"/psyq-obj-parser "$OUTPUT".obj -o "$OUTPUT" -b -n -s',
 )
@@ -932,8 +932,8 @@ GCC272SNEW = GCCCompiler(
 GCC281SN = GCCCompiler(
     id="gcc2.8.1sn",
     platform=N64,
-    cc=CCN64_CPP_C +
-    '| ${WIBO} "${COMPILER_DIR}"/cc1n64.exe ${COMPILER_FLAGS} -o "$OUTPUT".s '
+    cc=CCN64_CPP_C
+    + '| ${WIBO} "${COMPILER_DIR}"/cc1n64.exe ${COMPILER_FLAGS} -o "$OUTPUT".s '
     '&& ${WIBO} "${COMPILER_DIR}"/asn64.exe -q -G0 "$OUTPUT".s -o "$OUTPUT".obj '
     '&& "${COMPILER_DIR}"/psyq-obj-parser "$OUTPUT".obj -o "$OUTPUT" -b -n',
 )
@@ -942,8 +942,8 @@ GCC281SNCXX = GCCCompiler(
     id="gcc2.8.1sn-cxx",
     base_compiler=GCC281SN,
     platform=N64,
-    cc=CCN64_CPP_CXX +
-    '| ${WIBO} "${COMPILER_DIR}"/cc1pln64.exe ${COMPILER_FLAGS} -o "$OUTPUT".s '
+    cc=CCN64_CPP_CXX
+    + '| ${WIBO} "${COMPILER_DIR}"/cc1pln64.exe ${COMPILER_FLAGS} -o "$OUTPUT".s '
     '&& ${WIBO} "${COMPILER_DIR}"/asn64.exe -q -G0 "$OUTPUT".s -o "$OUTPUT".obj '
     '&& "${COMPILER_DIR}"/psyq-obj-parser "$OUTPUT".obj -o "$OUTPUT" -b -n',
 )

--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -876,10 +876,48 @@ GCC281PM = GCCCompiler(
     cc='"${COMPILER_DIR}"/gcc -G0 -c -B "${COMPILER_DIR}"/ $COMPILER_FLAGS "$INPUT" -o "$OUTPUT"',
 )
 
-GCC272SN = GCCCompiler(
-    id="gcc2.7.2sn",
+GCC272SN0001 = GCCCompiler(
+    id="gcc2.7.2sn0001",
+    platform=N64,
+    cc='/usr/bin/cpp -E -lang-c -undef -D__GNUC__=2 -Dmips -D__mips__ -D__mips -Dn64 -D__n64__ -D__n64 -D_PSYQ -D__EXTENSIONS__ -D_MIPSEB -D__CHAR_UNSIGNED__ "$INPUT" '
+    '| ${WIBO} "${COMPILER_DIR}"/cc1n64.exe ${COMPILER_FLAGS} -o "$OUTPUT".s '
+    '&& ${WIBO} "${COMPILER_DIR}"/asn64.exe -q "$OUTPUT".s -o "$OUTPUT".obj '
+    '&& "${COMPILER_DIR}"/psyq-obj-parser "$OUTPUT".obj -o "$OUTPUT" -b -n -s',
+)
+
+GCC272SN0001CXX = GCCCompiler(
+    id="gcc2.7.2sn0001-cxx",
+    base_compiler=GCC272SN0001,
+    platform=N64,
+    cc='/usr/bin/cpp -E -lang-c++ -undef -D__GNUC__=2 -D__cplusplus -Dmips -D__mips__ -D__mips -Dn64 -D__n64__ -D__n64 -D_PSYQ -D__EXTENSIONS__ -D_MIPSEB -D__CHAR_UNSIGNED__ -D_LANGUAGE_C_PLUS_PLUS "$INPUT" '
+    '| ${WIBO} "${COMPILER_DIR}"/cc1pln64.exe ${COMPILER_FLAGS} -o "$OUTPUT".s '
+    '&& ${WIBO} "${COMPILER_DIR}"/asn64.exe -q "$OUTPUT".s -o "$OUTPUT".obj '
+    '&& "${COMPILER_DIR}"/psyq-obj-parser "$OUTPUT".obj -o "$OUTPUT" -b -n -s',
+)
+
+GCC272SN0004 = GCCCompiler(
+    id="gcc2.7.2sn0004",
     platform=N64,
     cc='/usr/bin/cpp -P "$INPUT" | ${WIBO} "${COMPILER_DIR}"/cc1n64.exe -quiet -G0 -mcpu=vr4300 -mips3 -mhard-float -meb ${COMPILER_FLAGS} -o "$OUTPUT".s && ${WIBO} "${COMPILER_DIR}"/asn64.exe -q -G0 "$OUTPUT".s -o "$OUTPUT".obj && "${COMPILER_DIR}"/psyq-obj-parser "$OUTPUT".obj -o "$OUTPUT" -b -n',
+)
+
+GCC272SN0006 = GCCCompiler(
+    id="gcc2.7.2sn0006",
+    platform=N64,
+    cc='/usr/bin/cpp -E -lang-c -undef -D__GNUC__=2 -Dmips -D__mips__ -D__mips -Dn64 -D__n64__ -D__n64 -D_PSYQ -D__EXTENSIONS__ -D_MIPSEB -D__CHAR_UNSIGNED__ "$INPUT" '
+    '| ${WIBO} "${COMPILER_DIR}"/cc1n64.exe ${COMPILER_FLAGS} -o "$OUTPUT".s '
+    '&& ${WIBO} "${COMPILER_DIR}"/asn64.exe -q -G0 "$OUTPUT".s -o "$OUTPUT".obj '
+    '&& "${COMPILER_DIR}"/psyq-obj-parser "$OUTPUT".obj -o "$OUTPUT" -b -n -s',
+)
+
+GCC272SN0006CXX = GCCCompiler(
+    id="gcc2.7.2sn0006-cxx",
+    base_compiler=GCC272SN0006,
+    platform=N64,
+    cc='/usr/bin/cpp -E -lang-c++ -undef -D__GNUC__=2 -D__cplusplus -Dmips -D__mips__ -D__mips -Dn64 -D__n64__ -D__n64 -D_PSYQ -D__EXTENSIONS__ -D_MIPSEB -D__CHAR_UNSIGNED__ -D_LANGUAGE_C_PLUS_PLUS "$INPUT" '
+    '| ${WIBO} "${COMPILER_DIR}"/cc1pln64.exe ${COMPILER_FLAGS} -o "$OUTPUT".s '
+    '&& ${WIBO} "${COMPILER_DIR}"/asn64.exe -q -G0 "$OUTPUT".s -o "$OUTPUT".obj '
+    '&& "${COMPILER_DIR}"/psyq-obj-parser "$OUTPUT".obj -o "$OUTPUT" -b -n -s',
 )
 
 GCC272SNEW = GCCCompiler(
@@ -1650,7 +1688,11 @@ _all_compilers: List[Compiler] = [
     IDO71,
     MIPS_PRO_744,
     GCC272KMC,
-    GCC272SN,
+    GCC272SN0001,
+    GCC272SN0001CXX,
+    GCC272SN0004,
+    GCC272SN0006,
+    GCC272SN0006CXX,
     GCC272SNEW,
     GCC281PM,
     GCC281SN,

--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -876,13 +876,10 @@ GCC281PM = GCCCompiler(
     cc='"${COMPILER_DIR}"/gcc -G0 -c -B "${COMPILER_DIR}"/ $COMPILER_FLAGS "$INPUT" -o "$OUTPUT"',
 )
 
-CCN64_C_CPP = '/usr/bin/cpp -E -lang-c -undef -D__GNUC__=2 -Dmips -D__mips__ -D__mips -Dn64 -D__n64__ -D__n64 -D_PSYQ -D__EXTENSIONS__ -D_MIPSEB -D__CHAR_UNSIGNED__ "$INPUT" '
-CCN64_CXX_CPP = '/usr/bin/cpp -E -lang-c++ -undef -D__GNUC__=2 -D__cplusplus -Dmips -D__mips__ -D__mips -Dn64 -D__n64__ -D__n64 -D_PSYQ -D__EXTENSIONS__ -D_MIPSEB -D__CHAR_UNSIGNED__ -D_LANGUAGE_C_PLUS_PLUS "$INPUT" '
-
 GCC272SN0001 = GCCCompiler(
     id="gcc2.7.2sn0001",
     platform=N64,
-    cc=CCN64_C_CPP
+    cc='/usr/bin/cpp -E -lang-c -undef -D__GNUC__=2 -Dmips -D__mips__ -D__mips -Dn64 -D__n64__ -D__n64 -D_PSYQ -D__EXTENSIONS__ -D_MIPSEB -D__CHAR_UNSIGNED__ "$INPUT" '
     '| ${WIBO} "${COMPILER_DIR}"/cc1n64.exe ${COMPILER_FLAGS} -o "$OUTPUT".s '
     '&& ${WIBO} "${COMPILER_DIR}"/asn64.exe -q "$OUTPUT".s -o "$OUTPUT".obj '
     '&& "${COMPILER_DIR}"/psyq-obj-parser "$OUTPUT".obj -o "$OUTPUT" -b -n -s',
@@ -892,7 +889,7 @@ GCC272SN0001CXX = GCCCompiler(
     id="gcc2.7.2sn0001-cxx",
     base_compiler=GCC272SN0001,
     platform=N64,
-    cc=CCN64_CXX_CPP
+    cc='/usr/bin/cpp -E -lang-c++ -undef -D__GNUC__=2 -D__cplusplus -Dmips -D__mips__ -D__mips -Dn64 -D__n64__ -D__n64 -D_PSYQ -D__EXTENSIONS__ -D_MIPSEB -D__CHAR_UNSIGNED__ -D_LANGUAGE_C_PLUS_PLUS "$INPUT" '
     '| ${WIBO} "${COMPILER_DIR}"/cc1pln64.exe ${COMPILER_FLAGS} -o "$OUTPUT".s '
     '&& ${WIBO} "${COMPILER_DIR}"/asn64.exe -q "$OUTPUT".s -o "$OUTPUT".obj '
     '&& "${COMPILER_DIR}"/psyq-obj-parser "$OUTPUT".obj -o "$OUTPUT" -b -n -s',
@@ -907,7 +904,7 @@ GCC272SN0004 = GCCCompiler(
 GCC272SN0006 = GCCCompiler(
     id="gcc2.7.2sn0006",
     platform=N64,
-    cc=CCN64_C_CPP
+    cc='/usr/bin/cpp -E -lang-c -undef -D__GNUC__=2 -Dmips -D__mips__ -D__mips -Dn64 -D__n64__ -D__n64 -D_PSYQ -D__EXTENSIONS__ -D_MIPSEB -D__CHAR_UNSIGNED__ "$INPUT" '
     '| ${WIBO} "${COMPILER_DIR}"/cc1n64.exe ${COMPILER_FLAGS} -o "$OUTPUT".s '
     '&& ${WIBO} "${COMPILER_DIR}"/asn64.exe -q -G0 "$OUTPUT".s -o "$OUTPUT".obj '
     '&& "${COMPILER_DIR}"/psyq-obj-parser "$OUTPUT".obj -o "$OUTPUT" -b -n -s',
@@ -917,7 +914,7 @@ GCC272SN0006CXX = GCCCompiler(
     id="gcc2.7.2sn0006-cxx",
     base_compiler=GCC272SN0006,
     platform=N64,
-    cc=CCN64_CXX_CPP
+    cc='/usr/bin/cpp -E -lang-c++ -undef -D__GNUC__=2 -D__cplusplus -Dmips -D__mips__ -D__mips -Dn64 -D__n64__ -D__n64 -D_PSYQ -D__EXTENSIONS__ -D_MIPSEB -D__CHAR_UNSIGNED__ -D_LANGUAGE_C_PLUS_PLUS "$INPUT" '
     '| ${WIBO} "${COMPILER_DIR}"/cc1pln64.exe ${COMPILER_FLAGS} -o "$OUTPUT".s '
     '&& ${WIBO} "${COMPILER_DIR}"/asn64.exe -q -G0 "$OUTPUT".s -o "$OUTPUT".obj '
     '&& "${COMPILER_DIR}"/psyq-obj-parser "$OUTPUT".obj -o "$OUTPUT" -b -n -s',
@@ -932,7 +929,7 @@ GCC272SNEW = GCCCompiler(
 GCC281SN = GCCCompiler(
     id="gcc2.8.1sn",
     platform=N64,
-    cc=CCN64_C_CPP
+    cc='/usr/bin/cpp -E -lang-c -undef -D__GNUC__=2 -Dmips -D__mips__ -D__mips -Dn64 -D__n64__ -D__n64 -D_PSYQ -D__EXTENSIONS__ -D_MIPSEB -D__CHAR_UNSIGNED__ "$INPUT" '
     '| ${WIBO} "${COMPILER_DIR}"/cc1n64.exe ${COMPILER_FLAGS} -o "$OUTPUT".s '
     '&& ${WIBO} "${COMPILER_DIR}"/asn64.exe -q -G0 "$OUTPUT".s -o "$OUTPUT".obj '
     '&& "${COMPILER_DIR}"/psyq-obj-parser "$OUTPUT".obj -o "$OUTPUT" -b -n',
@@ -942,7 +939,7 @@ GCC281SNCXX = GCCCompiler(
     id="gcc2.8.1sn-cxx",
     base_compiler=GCC281SN,
     platform=N64,
-    cc=CCN64_CXX_CPP
+    cc='/usr/bin/cpp -E -lang-c++ -undef -D__GNUC__=2 -D__cplusplus -Dmips -D__mips__ -D__mips -Dn64 -D__n64__ -D__n64 -D_PSYQ -D__EXTENSIONS__ -D_MIPSEB -D__CHAR_UNSIGNED__ -D_LANGUAGE_C_PLUS_PLUS "$INPUT" '
     '| ${WIBO} "${COMPILER_DIR}"/cc1pln64.exe ${COMPILER_FLAGS} -o "$OUTPUT".s '
     '&& ${WIBO} "${COMPILER_DIR}"/asn64.exe -q -G0 "$OUTPUT".s -o "$OUTPUT".obj '
     '&& "${COMPILER_DIR}"/psyq-obj-parser "$OUTPUT".obj -o "$OUTPUT" -b -n',

--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -876,10 +876,13 @@ GCC281PM = GCCCompiler(
     cc='"${COMPILER_DIR}"/gcc -G0 -c -B "${COMPILER_DIR}"/ $COMPILER_FLAGS "$INPUT" -o "$OUTPUT"',
 )
 
+CCN64_CPP_C = '/usr/bin/cpp -E -lang-c -undef -D__GNUC__=2 -Dmips -D__mips__ -D__mips -Dn64 -D__n64__ -D__n64 -D_PSYQ -D__EXTENSIONS__ -D_MIPSEB -D__CHAR_UNSIGNED__ "$INPUT" '
+CCN64_CPP_CXX = '/usr/bin/cpp -E -lang-c++ -undef -D__GNUC__=2 -D__cplusplus -Dmips -D__mips__ -D__mips -Dn64 -D__n64__ -D__n64 -D_PSYQ -D__EXTENSIONS__ -D_MIPSEB -D__CHAR_UNSIGNED__ -D_LANGUAGE_C_PLUS_PLUS "$INPUT" '
+
 GCC272SN0001 = GCCCompiler(
     id="gcc2.7.2sn0001",
     platform=N64,
-    cc='/usr/bin/cpp -E -lang-c -undef -D__GNUC__=2 -Dmips -D__mips__ -D__mips -Dn64 -D__n64__ -D__n64 -D_PSYQ -D__EXTENSIONS__ -D_MIPSEB -D__CHAR_UNSIGNED__ "$INPUT" '
+    cc=CCN64_CPP_C +
     '| ${WIBO} "${COMPILER_DIR}"/cc1n64.exe ${COMPILER_FLAGS} -o "$OUTPUT".s '
     '&& ${WIBO} "${COMPILER_DIR}"/asn64.exe -q "$OUTPUT".s -o "$OUTPUT".obj '
     '&& "${COMPILER_DIR}"/psyq-obj-parser "$OUTPUT".obj -o "$OUTPUT" -b -n -s',
@@ -889,7 +892,7 @@ GCC272SN0001CXX = GCCCompiler(
     id="gcc2.7.2sn0001-cxx",
     base_compiler=GCC272SN0001,
     platform=N64,
-    cc='/usr/bin/cpp -E -lang-c++ -undef -D__GNUC__=2 -D__cplusplus -Dmips -D__mips__ -D__mips -Dn64 -D__n64__ -D__n64 -D_PSYQ -D__EXTENSIONS__ -D_MIPSEB -D__CHAR_UNSIGNED__ -D_LANGUAGE_C_PLUS_PLUS "$INPUT" '
+    cc=CCN64_CPP_CXX +
     '| ${WIBO} "${COMPILER_DIR}"/cc1pln64.exe ${COMPILER_FLAGS} -o "$OUTPUT".s '
     '&& ${WIBO} "${COMPILER_DIR}"/asn64.exe -q "$OUTPUT".s -o "$OUTPUT".obj '
     '&& "${COMPILER_DIR}"/psyq-obj-parser "$OUTPUT".obj -o "$OUTPUT" -b -n -s',
@@ -904,7 +907,7 @@ GCC272SN0004 = GCCCompiler(
 GCC272SN0006 = GCCCompiler(
     id="gcc2.7.2sn0006",
     platform=N64,
-    cc='/usr/bin/cpp -E -lang-c -undef -D__GNUC__=2 -Dmips -D__mips__ -D__mips -Dn64 -D__n64__ -D__n64 -D_PSYQ -D__EXTENSIONS__ -D_MIPSEB -D__CHAR_UNSIGNED__ "$INPUT" '
+    cc=CCN64_CPP_C +
     '| ${WIBO} "${COMPILER_DIR}"/cc1n64.exe ${COMPILER_FLAGS} -o "$OUTPUT".s '
     '&& ${WIBO} "${COMPILER_DIR}"/asn64.exe -q -G0 "$OUTPUT".s -o "$OUTPUT".obj '
     '&& "${COMPILER_DIR}"/psyq-obj-parser "$OUTPUT".obj -o "$OUTPUT" -b -n -s',
@@ -914,7 +917,7 @@ GCC272SN0006CXX = GCCCompiler(
     id="gcc2.7.2sn0006-cxx",
     base_compiler=GCC272SN0006,
     platform=N64,
-    cc='/usr/bin/cpp -E -lang-c++ -undef -D__GNUC__=2 -D__cplusplus -Dmips -D__mips__ -D__mips -Dn64 -D__n64__ -D__n64 -D_PSYQ -D__EXTENSIONS__ -D_MIPSEB -D__CHAR_UNSIGNED__ -D_LANGUAGE_C_PLUS_PLUS "$INPUT" '
+    cc=CCN64_CPP_CXX +
     '| ${WIBO} "${COMPILER_DIR}"/cc1pln64.exe ${COMPILER_FLAGS} -o "$OUTPUT".s '
     '&& ${WIBO} "${COMPILER_DIR}"/asn64.exe -q -G0 "$OUTPUT".s -o "$OUTPUT".obj '
     '&& "${COMPILER_DIR}"/psyq-obj-parser "$OUTPUT".obj -o "$OUTPUT" -b -n -s',
@@ -929,7 +932,7 @@ GCC272SNEW = GCCCompiler(
 GCC281SN = GCCCompiler(
     id="gcc2.8.1sn",
     platform=N64,
-    cc='/usr/bin/cpp -E -lang-c -undef -D__GNUC__=2 -Dmips -D__mips__ -D__mips -Dn64 -D__n64__ -D__n64 -D_PSYQ -D__EXTENSIONS__ -D_MIPSEB -D__CHAR_UNSIGNED__ "$INPUT" '
+    cc=CCN64_CPP_C +
     '| ${WIBO} "${COMPILER_DIR}"/cc1n64.exe ${COMPILER_FLAGS} -o "$OUTPUT".s '
     '&& ${WIBO} "${COMPILER_DIR}"/asn64.exe -q -G0 "$OUTPUT".s -o "$OUTPUT".obj '
     '&& "${COMPILER_DIR}"/psyq-obj-parser "$OUTPUT".obj -o "$OUTPUT" -b -n',
@@ -939,7 +942,7 @@ GCC281SNCXX = GCCCompiler(
     id="gcc2.8.1sn-cxx",
     base_compiler=GCC281SN,
     platform=N64,
-    cc='/usr/bin/cpp -E -lang-c++ -undef -D__GNUC__=2 -D__cplusplus -Dmips -D__mips__ -D__mips -Dn64 -D__n64__ -D__n64 -D_PSYQ -D__EXTENSIONS__ -D_MIPSEB -D__CHAR_UNSIGNED__ -D_LANGUAGE_C_PLUS_PLUS "$INPUT" '
+    cc=CCN64_CPP_CXX +
     '| ${WIBO} "${COMPILER_DIR}"/cc1pln64.exe ${COMPILER_FLAGS} -o "$OUTPUT".s '
     '&& ${WIBO} "${COMPILER_DIR}"/asn64.exe -q -G0 "$OUTPUT".s -o "$OUTPUT".obj '
     '&& "${COMPILER_DIR}"/psyq-obj-parser "$OUTPUT".obj -o "$OUTPUT" -b -n',

--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -876,10 +876,13 @@ GCC281PM = GCCCompiler(
     cc='"${COMPILER_DIR}"/gcc -G0 -c -B "${COMPILER_DIR}"/ $COMPILER_FLAGS "$INPUT" -o "$OUTPUT"',
 )
 
+CCN64_C_CPP = '/usr/bin/cpp -E -lang-c -undef -D__GNUC__=2 -Dmips -D__mips__ -D__mips -Dn64 -D__n64__ -D__n64 -D_PSYQ -D__EXTENSIONS__ -D_MIPSEB -D__CHAR_UNSIGNED__ "$INPUT" '
+CCN64_CXX_CPP = '/usr/bin/cpp -E -lang-c++ -undef -D__GNUC__=2 -D__cplusplus -Dmips -D__mips__ -D__mips -Dn64 -D__n64__ -D__n64 -D_PSYQ -D__EXTENSIONS__ -D_MIPSEB -D__CHAR_UNSIGNED__ -D_LANGUAGE_C_PLUS_PLUS "$INPUT" '
+
 GCC272SN0001 = GCCCompiler(
     id="gcc2.7.2sn0001",
     platform=N64,
-    cc='/usr/bin/cpp -E -lang-c -undef -D__GNUC__=2 -Dmips -D__mips__ -D__mips -Dn64 -D__n64__ -D__n64 -D_PSYQ -D__EXTENSIONS__ -D_MIPSEB -D__CHAR_UNSIGNED__ "$INPUT" '
+    cc=CCN64_C_CPP
     '| ${WIBO} "${COMPILER_DIR}"/cc1n64.exe ${COMPILER_FLAGS} -o "$OUTPUT".s '
     '&& ${WIBO} "${COMPILER_DIR}"/asn64.exe -q "$OUTPUT".s -o "$OUTPUT".obj '
     '&& "${COMPILER_DIR}"/psyq-obj-parser "$OUTPUT".obj -o "$OUTPUT" -b -n -s',
@@ -889,7 +892,7 @@ GCC272SN0001CXX = GCCCompiler(
     id="gcc2.7.2sn0001-cxx",
     base_compiler=GCC272SN0001,
     platform=N64,
-    cc='/usr/bin/cpp -E -lang-c++ -undef -D__GNUC__=2 -D__cplusplus -Dmips -D__mips__ -D__mips -Dn64 -D__n64__ -D__n64 -D_PSYQ -D__EXTENSIONS__ -D_MIPSEB -D__CHAR_UNSIGNED__ -D_LANGUAGE_C_PLUS_PLUS "$INPUT" '
+    cc=CCN64_CXX_CPP
     '| ${WIBO} "${COMPILER_DIR}"/cc1pln64.exe ${COMPILER_FLAGS} -o "$OUTPUT".s '
     '&& ${WIBO} "${COMPILER_DIR}"/asn64.exe -q "$OUTPUT".s -o "$OUTPUT".obj '
     '&& "${COMPILER_DIR}"/psyq-obj-parser "$OUTPUT".obj -o "$OUTPUT" -b -n -s',
@@ -904,7 +907,7 @@ GCC272SN0004 = GCCCompiler(
 GCC272SN0006 = GCCCompiler(
     id="gcc2.7.2sn0006",
     platform=N64,
-    cc='/usr/bin/cpp -E -lang-c -undef -D__GNUC__=2 -Dmips -D__mips__ -D__mips -Dn64 -D__n64__ -D__n64 -D_PSYQ -D__EXTENSIONS__ -D_MIPSEB -D__CHAR_UNSIGNED__ "$INPUT" '
+    cc=CCN64_C_CPP
     '| ${WIBO} "${COMPILER_DIR}"/cc1n64.exe ${COMPILER_FLAGS} -o "$OUTPUT".s '
     '&& ${WIBO} "${COMPILER_DIR}"/asn64.exe -q -G0 "$OUTPUT".s -o "$OUTPUT".obj '
     '&& "${COMPILER_DIR}"/psyq-obj-parser "$OUTPUT".obj -o "$OUTPUT" -b -n -s',
@@ -914,7 +917,7 @@ GCC272SN0006CXX = GCCCompiler(
     id="gcc2.7.2sn0006-cxx",
     base_compiler=GCC272SN0006,
     platform=N64,
-    cc='/usr/bin/cpp -E -lang-c++ -undef -D__GNUC__=2 -D__cplusplus -Dmips -D__mips__ -D__mips -Dn64 -D__n64__ -D__n64 -D_PSYQ -D__EXTENSIONS__ -D_MIPSEB -D__CHAR_UNSIGNED__ -D_LANGUAGE_C_PLUS_PLUS "$INPUT" '
+    cc=CCN64_CXX_CPP
     '| ${WIBO} "${COMPILER_DIR}"/cc1pln64.exe ${COMPILER_FLAGS} -o "$OUTPUT".s '
     '&& ${WIBO} "${COMPILER_DIR}"/asn64.exe -q -G0 "$OUTPUT".s -o "$OUTPUT".obj '
     '&& "${COMPILER_DIR}"/psyq-obj-parser "$OUTPUT".obj -o "$OUTPUT" -b -n -s',
@@ -929,7 +932,7 @@ GCC272SNEW = GCCCompiler(
 GCC281SN = GCCCompiler(
     id="gcc2.8.1sn",
     platform=N64,
-    cc='/usr/bin/cpp -E -lang-c -undef -D__GNUC__=2 -Dmips -D__mips__ -D__mips -Dn64 -D__n64__ -D__n64 -D_PSYQ -D__EXTENSIONS__ -D_MIPSEB -D__CHAR_UNSIGNED__ "$INPUT" '
+    cc=CCN64_C_CPP
     '| ${WIBO} "${COMPILER_DIR}"/cc1n64.exe ${COMPILER_FLAGS} -o "$OUTPUT".s '
     '&& ${WIBO} "${COMPILER_DIR}"/asn64.exe -q -G0 "$OUTPUT".s -o "$OUTPUT".obj '
     '&& "${COMPILER_DIR}"/psyq-obj-parser "$OUTPUT".obj -o "$OUTPUT" -b -n',
@@ -939,7 +942,7 @@ GCC281SNCXX = GCCCompiler(
     id="gcc2.8.1sn-cxx",
     base_compiler=GCC281SN,
     platform=N64,
-    cc='/usr/bin/cpp -E -lang-c++ -undef -D__GNUC__=2 -D__cplusplus -Dmips -D__mips__ -D__mips -Dn64 -D__n64__ -D__n64 -D_PSYQ -D__EXTENSIONS__ -D_MIPSEB -D__CHAR_UNSIGNED__ -D_LANGUAGE_C_PLUS_PLUS "$INPUT" '
+    cc=CCN64_CXX_CPP
     '| ${WIBO} "${COMPILER_DIR}"/cc1pln64.exe ${COMPILER_FLAGS} -o "$OUTPUT".s '
     '&& ${WIBO} "${COMPILER_DIR}"/asn64.exe -q -G0 "$OUTPUT".s -o "$OUTPUT".obj '
     '&& "${COMPILER_DIR}"/psyq-obj-parser "$OUTPUT".obj -o "$OUTPUT" -b -n',

--- a/backend/coreapp/migrations/0058_rename_gcc272sn_to_gcc272sn0004.py
+++ b/backend/coreapp/migrations/0058_rename_gcc272sn_to_gcc272sn0004.py
@@ -1,0 +1,45 @@
+import django.db.migrations.operations.special
+from django.apps.registry import Apps
+from django.db import migrations
+from django.db.backends.base.schema import BaseDatabaseSchemaEditor
+
+
+def rename_compilers(apps: Apps, schema_editor: BaseDatabaseSchemaEditor) -> None:
+    """
+    Migrate the compiler ID 'gcc2.7.2sn' to 'gcc2.7.2sn0004'
+    """
+
+    compiler_map = {
+        "gcc2.7.2sn": "gcc2.7.2sn0004",
+    }
+
+    Scratch = apps.get_model("coreapp", "Scratch")
+    for row in (
+        Scratch.objects.only("compiler")
+        .filter(platform="n64")
+        .filter(compiler="gcc2.7.2sn")
+    ):
+        if row.compiler in compiler_map:
+            row.compiler = compiler_map[row.compiler]
+            row.save(update_fields=["compiler"])
+
+    Preset = apps.get_model("coreapp", "Preset")
+    for row in (
+        Preset.objects.all().filter(platform="n64").filter(compiler="gcc2.7.2sn")
+    ):
+        if row.compiler in compiler_map:
+            row.compiler = compiler_map[row.compiler]
+            row.save(update_fields=["compiler"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("coreapp", "0057_rename_ps1_mipsel_compilers"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            code=rename_compilers,
+            reverse_code=django.db.migrations.operations.special.RunPython.noop,
+        )
+    ]

--- a/frontend/src/lib/i18n/locales/en/compilers.json
+++ b/frontend/src/lib/i18n/locales/en/compilers.json
@@ -66,7 +66,11 @@
     "egcs_1.1.2-4c": "EGCS 1.1.2-4 (gcc egcs-2.91.66, decompals)",
 
     "gcc2.7.2kmc": "GCC 2.7.2 (KMC)",
-    "gcc2.7.2sn": "GCC 2.7.2 (SN)",
+    "gcc2.7.2sn0001": "GCC 2.7.2 (SN) (Build 0001)",
+    "gcc2.7.2sn0001-cxx": "GCC 2.7.2 (SN) (Build 0001) (C++)",
+    "gcc2.7.2sn0004": "GCC 2.7.2 (SN) (Build 0004-cygnus)",
+    "gcc2.7.2sn0006": "GCC 2.7.2 (SN) (Build 0006-cygnus)",
+    "gcc2.7.2sn0006-cxx": "GCC 2.7.2 (SN) (Build 0006-cygnus) (C++)",
     "gcc2.7.2snew": "GCC 2.7.2 (SN, experimental)",
     "gcc2.8.1sn": "GCC 2.8.1 (SN)",
     "gcc2.8.1sn-cxx": "GCC 2.8.1 (SN) (C++)",


### PR DESCRIPTION
This adds 2 previously lost SN 2.7.2 versions and their C++ versions, totalling 4 new compilers for the N64. The previous version of SN 2.7.2 has also been renamed to reflect its build compared to these builds. Note that for build 0001 to work, a recently updated `psyq-obj-parser` is needed to handle the GP relocations. The cygnus builds (0004/6) disable `-G` by default and even seem to block its usage, so `-G0` seems fine to use for them.

Also note that the compilers currently have no download links, this should be updated once they have a home.