### PR TITLE
objdiff: allow="clipboard-write"

### DIFF
--- a/frontend/src/components/Diff/ObjdiffPanel.tsx
+++ b/frontend/src/components/Diff/ObjdiffPanel.tsx
@@ -92,6 +92,7 @@ export default function ObjdiffPanel({
                 src={url}
                 title="objdiff"
                 style={{ width: "100%", height: "100%" }}
+                allow="clipboard-write"
             />
         </div>
     );


### PR DESCRIPTION
Fixes context menu -> copy in the experimental objdiff integration.