### PR TITLE
Update default font & increase size

### DIFF
--- a/frontend/src/app/(navfooter)/credits/page.tsx
+++ b/frontend/src/app/(navfooter)/credits/page.tsx
@@ -14,12 +14,14 @@ const OTHER_PROJECTS = {
     m2c: "https://github.com/matt-kempster/m2c",
     "psyq-obj-parser":
         "https://github.com/grumpycoders/pcsx-redux/tree/main/tools/psyq-obj-parser",
+    objdiff: "https://github.com/encounter/objdiff-web",
     Django: "https://www.djangoproject.com/",
     "Django REST Framework": "https://www.django-rest-framework.org/",
     "Next.js": "https://nextjs.org/",
     React: "https://reactjs.org/",
     "Tailwind CSS": "https://tailwindcss.com/",
     SWR: "https://swr.vercel.app/",
+    "JetBrains Mono": "https://www.jetbrains.com/lp/mono/",
 };
 const ICON_SOURCES = {
     Octicons: "https://primer.style/octicons/",

--- a/frontend/src/app/(navfooter)/settings/appearance/AppearanceSettings.tsx
+++ b/frontend/src/app/(navfooter)/settings/appearance/AppearanceSettings.tsx
@@ -10,12 +10,13 @@ import * as settings from "@/lib/settings";
 import Section from "../Section";
 import SliderField from "../SliderField";
 import TextField from "../TextField";
+import Checkbox from "../Checkbox";
 
 const DynamicExampleCodeMirror = dynamic(() => import("./ExampleCodeMirror"), {
     loading: () => (
         <div
             className="flex animate-pulse items-center justify-center"
-            style={{ height: "200px" }}
+            style={{ height: "400px" }}
         >
             <LoadingSpinner className="size-16 opacity-50" />
         </div>
@@ -26,6 +27,7 @@ export default function AppearanceSettings() {
     const [theme, setTheme] = settings.useTheme();
     const [fontSize, setFontSize] = settings.useCodeFontSize();
     const [monospaceFont, setMonospaceFont] = settings.useMonospaceFont();
+    const [fontLigatures, setFontLigatures] = settings.useFontLigatures();
     const [codeLineHeight, setCodeLineHeight] = settings.useCodeLineHeight();
     const [codeColorScheme, setCodeColorScheme] = settings.useCodeColorScheme();
 
@@ -66,10 +68,25 @@ export default function AppearanceSettings() {
                         description="The font family to use for code. The first valid comma-separated value will be used."
                         value={monospaceFont ?? ""}
                         onChange={setMonospaceFont}
-                        placeholder="ui-monospace"
+                        placeholder="JetBrains Mono"
                         inputStyle={{
-                            fontFamily: `${monospaceFont ?? "ui-monospace"}, monospace`,
+                            fontFamily: `${monospaceFont ?? "JetBrains Mono"}, monospace`,
                         }}
+                    />
+                </div>
+
+                <div className="mb-6 max-w-xl">
+                    <Checkbox
+                        label="Enable ligatures"
+                        description={
+                            <>
+                                Use typographic ligatures (e.g.,{" "}
+                                <kbd>{"->"}</kbd>, <kbd>{"=="}</kbd>) if
+                                supported by the current font.
+                            </>
+                        }
+                        checked={fontLigatures}
+                        onChange={setFontLigatures}
                     />
                 </div>
 

--- a/frontend/src/app/(navfooter)/settings/appearance/ExampleCodeMirror.tsx
+++ b/frontend/src/app/(navfooter)/settings/appearance/ExampleCodeMirror.tsx
@@ -112,7 +112,7 @@ void step_game_loop(void) {
 
 export default function ExampleCodeMirror() {
     return (
-        <div className="overflow-hidden [&_.cm-editor]:h-[200px]">
+        <div className="overflow-hidden [&_.cm-editor]:h-[400px]">
             <CodeMirror
                 value={EXAMPLE_C_CODE}
                 valueVersion={0}

--- a/frontend/src/app/ThemeProvider.tsx
+++ b/frontend/src/app/ThemeProvider.tsx
@@ -41,6 +41,15 @@ export default function ThemeProvider() {
         }
     }, [monospaceFont]);
 
+    const [fontLigatures] = settings.useFontLigatures();
+    useEffect(() => {
+        if (fontLigatures) {
+            document.body.style.setProperty("font-variant-ligatures", "normal");
+        } else {
+            document.body.style.setProperty("font-variant-ligatures", "none");
+        }
+    }, [fontLigatures]);
+
     const [codeLineHeight] = settings.useCodeLineHeight();
     useEffect(() => {
         document.body.style.removeProperty("--code-line-height");

--- a/frontend/src/app/globals.scss
+++ b/frontend/src/app/globals.scss
@@ -1,4 +1,5 @@
 @use "./theme.scss" as theme;
+@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&display=swap');
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -6,7 +7,7 @@
 :root {
     --link: #58a6ff;
     --danger: #f00;
-    --monospace: "Menlo", "Monaco", monospace;
+    --monospace: "JetBrains Mono", "Menlo", "Monaco", monospace;
     --font-ui: -apple-system, "BlinkMacSystemFont", "Segoe UI", "Helvetica", "Arial", sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
 
     @include theme.theme(#951fd9, #ffffff);

--- a/frontend/src/components/Diff/ObjdiffPanel.tsx
+++ b/frontend/src/components/Diff/ObjdiffPanel.tsx
@@ -3,6 +3,7 @@ import { getColors } from "@/lib/codemirror/color-scheme";
 import {
     useCodeColorScheme,
     useCodeFontSize,
+    useFontLigatures,
     useIsSiteThemeDark,
     useMonospaceFont,
 } from "@/lib/settings";
@@ -17,6 +18,7 @@ export default function ObjdiffPanel({
     const colors = getColors(useCodeColorScheme()[0]);
     const [codeFont] = useMonospaceFont();
     const [codeFontSize] = useCodeFontSize();
+    const [fontLigatures] = useFontLigatures();
 
     const objdiffFrame = useRef<HTMLIFrameElement>(null);
     const latestCompilation = useRef<api.Compilation | null>(compilation);
@@ -24,6 +26,7 @@ export default function ObjdiffPanel({
     const latestColors = useRef(colors);
     const latestCodeFont = useRef(codeFont);
     const latestCodeFontSize = useRef(codeFontSize);
+    const latestFontLigatures = useRef(fontLigatures);
 
     useEffect(() => {
         const iframeWindow = objdiffFrame.current?.contentWindow;
@@ -43,6 +46,7 @@ export default function ObjdiffPanel({
                         colors: latestColors.current,
                         codeFont: latestCodeFont.current,
                         codeFontSize: latestCodeFontSize.current,
+                        fontLigatures: latestFontLigatures.current,
                     } as InboundMessage,
                     "*",
                 );
@@ -74,6 +78,7 @@ export default function ObjdiffPanel({
                 colors,
                 codeFont,
                 codeFontSize,
+                fontLigatures,
             } as InboundMessage,
             "*",
         );

--- a/frontend/src/lib/settings.ts
+++ b/frontend/src/lib/settings.ts
@@ -9,6 +9,7 @@ const autoRecompile = createPersistedState<boolean>("autoRecompile");
 const autoRecompileDelay = createPersistedState<number>("autoRecompileDelay");
 const codeFontSize = createPersistedState<number>("codeFontSize");
 const monospaceFont = createPersistedState<string | undefined>("monospaceFont");
+const fontLigatures = createPersistedState<boolean>("fontLigatures");
 const codeLineHeight = createPersistedState<number>("codeLineHeight");
 const codeColorScheme = createPersistedState<ColorScheme>("codeColorScheme");
 const languageServerEnabled = createPersistedState<boolean>(
@@ -32,8 +33,9 @@ export enum ThreeWayDiffBase {
 export const useTheme = () => theme("auto");
 export const useAutoRecompileSetting = () => autoRecompile(true);
 export const useAutoRecompileDelaySetting = () => autoRecompileDelay(500);
-export const useCodeFontSize = () => codeFontSize(11);
+export const useCodeFontSize = () => codeFontSize(13);
 export const useMonospaceFont = () => monospaceFont(undefined);
+export const useFontLigatures = () => fontLigatures(true);
 export const useCodeLineHeight = () => codeLineHeight(1.5);
 export const useCodeColorScheme = () => codeColorScheme("Frog Dark");
 export const useLanguageServerEnabled = () => languageServerEnabled(false);

--- a/frontend/src/lib/settings.ts
+++ b/frontend/src/lib/settings.ts
@@ -35,7 +35,7 @@ export const useAutoRecompileSetting = () => autoRecompile(true);
 export const useAutoRecompileDelaySetting = () => autoRecompileDelay(500);
 export const useCodeFontSize = () => codeFontSize(13);
 export const useMonospaceFont = () => monospaceFont(undefined);
-export const useFontLigatures = () => fontLigatures(true);
+export const useFontLigatures = () => fontLigatures(false);
 export const useCodeLineHeight = () => codeLineHeight(1.5);
 export const useCodeColorScheme = () => codeColorScheme("Frog Dark");
 export const useLanguageServerEnabled = () => languageServerEnabled(false);


### PR DESCRIPTION
This pulls in [JetBrains Mono](https://www.jetbrains.com/lp/mono/) as a variable web font (2 KiB) and uses it as the default font family. The default size is updated from 11px to 13px to improve legibility.

Additionally, an appearance setting "Enable ligatures" is added, allowing users to disable the font ligatures that are included in JetBrains Mono (or their own configured font).

<p align="center">Before / After (Appearance Settings)</p>
<p align="center">
  <img src="https://github.com/user-attachments/assets/f65beca2-d556-4cf6-b5ec-cf52f241cebf" alt="Before" width="45%" style="margin-right: 10px" />
  <img src="https://github.com/user-attachments/assets/dbad49cd-800d-432f-af18-a158e0a0a684" alt="After" width="45%" />
</p>

<p align="center">Before / After (Scratch)</p>
<p align="center">
  <img src="https://github.com/user-attachments/assets/96c97639-b20b-4e36-9367-5506e975c683" alt="Before" width="45%" style="margin-right: 10px" />
  <img src="https://github.com/user-attachments/assets/e1b7ebd2-1e74-4301-99b2-ae49a19517fa" alt="After" width="45%" />
</p>

Note that my default `monospace` font is configured to `Noto Sans Mono`, which is similar to JetBrains Mono, so you won't see much difference in the font in these comparisons. It will be more apparent if the monospace font is not configured at a system level.

Rationale:
- Currently, the default font-family is `Menlo, Monaco, monospace`, which are macOS fonts. This means most users will fall back to `monospace`, which is up to the user agent to choose. Instead, we can unify this across platforms by pulling in a small (2 KiB) web font.
- 11px is very small and hurts readability. 13px is a more reasonable default.

FYI, I'm not committed to JetBrains Mono in particular, if anyone has other suggestions.