### PR TITLE
Adjust `font-variant-ligatures` usage

### DIFF
--- a/frontend/src/app/(navfooter)/settings/appearance/AppearanceSettings.tsx
+++ b/frontend/src/app/(navfooter)/settings/appearance/AppearanceSettings.tsx
@@ -82,7 +82,7 @@ export default function AppearanceSettings() {
                             <>
                                 Use typographic ligatures (e.g.,{" "}
                                 <kbd>{"->"}</kbd>, <kbd>{"=="}</kbd>) if
-                                supported by the current font.
+                                supported by the current font and browser.
                             </>
                         }
                         checked={fontLigatures}

--- a/frontend/src/app/ThemeProvider.tsx
+++ b/frontend/src/app/ThemeProvider.tsx
@@ -44,9 +44,15 @@ export default function ThemeProvider() {
     const [fontLigatures] = settings.useFontLigatures();
     useEffect(() => {
         if (fontLigatures) {
-            document.body.style.setProperty("font-variant-ligatures", "normal");
+            document.body.style.setProperty(
+                "font-variant-ligatures",
+                "contextual",
+            );
         } else {
-            document.body.style.setProperty("font-variant-ligatures", "none");
+            document.body.style.setProperty(
+                "font-variant-ligatures",
+                "no-contextual",
+            );
         }
     }, [fontLigatures]);
 


### PR DESCRIPTION
I researched the values of `font-variant-ligatures` a little more and determined that this is more precise: since we apply this property to the whole page, we don't want to disable _all_ ligatures, which can be used by the UI font for legibility purposes. Specifically, the contextual (or `calt`) ligatures are what we want to enable/disable, so this makes it explicit.

Additionally, Safari doesn't seem to support the contextual ligatures, so I modified the setting description slightly to avoid confusion.