### PR TITLE
Disable SSR for settings pages

### DIFF
--- a/frontend/src/app/(navfooter)/settings/appearance/AppearanceSettings.tsx
+++ b/frontend/src/app/(navfooter)/settings/appearance/AppearanceSettings.tsx
@@ -1,9 +1,6 @@
 "use client";
 
-import dynamic from "next/dynamic";
-
 import ColorSchemePicker from "@/components/ColorSchemePicker";
-import LoadingSpinner from "@/components/loading.svg";
 import ThemePicker from "@/components/ThemePicker";
 import * as settings from "@/lib/settings";
 
@@ -12,16 +9,7 @@ import SliderField from "../SliderField";
 import TextField from "../TextField";
 import Checkbox from "../Checkbox";
 
-const DynamicExampleCodeMirror = dynamic(() => import("./ExampleCodeMirror"), {
-    loading: () => (
-        <div
-            className="flex animate-pulse items-center justify-center"
-            style={{ height: "400px" }}
-        >
-            <LoadingSpinner className="size-16 opacity-50" />
-        </div>
-    ),
-});
+import ExampleCodeMirror from "./ExampleCodeMirror";
 
 export default function AppearanceSettings() {
     const [theme, setTheme] = settings.useTheme();
@@ -93,7 +81,7 @@ export default function AppearanceSettings() {
                 <div className="mb-6">
                     <div className="font-semibold">Color scheme</div>
                     <div className="my-2 overflow-hidden rounded border border-gray-6">
-                        <DynamicExampleCodeMirror />
+                        <ExampleCodeMirror />
                     </div>
                     <ColorSchemePicker
                         scheme={codeColorScheme}

--- a/frontend/src/app/(navfooter)/settings/appearance/page.tsx
+++ b/frontend/src/app/(navfooter)/settings/appearance/page.tsx
@@ -1,4 +1,8 @@
-import AppearanceSettings from "./AppearanceSettings";
+import dynamic from "next/dynamic";
+
+const AppearanceSettings = dynamic(() => import("./AppearanceSettings"), {
+    ssr: false,
+});
 
 export const metadata = {
     title: "Appearance settings",

--- a/frontend/src/app/(navfooter)/settings/editor/page.tsx
+++ b/frontend/src/app/(navfooter)/settings/editor/page.tsx
@@ -1,4 +1,8 @@
-import EditorSettings from "./EditorSettings";
+import dynamic from "next/dynamic";
+
+const EditorSettings = dynamic(() => import("./EditorSettings"), {
+    ssr: false,
+});
 
 export const metadata = {
     title: "Editor settings",


### PR DESCRIPTION
SSR causes weird behavior on the settings pages: it will populate the page with the default values, and _only in some cases_ actually hydrate the client's settings values once loaded. This only happens if you navigate to one of these pages directly, or refresh while you're on one of the pages.

This causes errors in development mode too: if you navigate to `/settings/appearance` in dev mode, change the font size and refresh, you'll get an error about the SSR/client hydration mismatch.

This solution is outlined in the [Next.js documentation](https://nextjs.org/docs/messages/react-hydration-error#solution-2-disabling-ssr-on-specific-components) for that error.