### PR TITLE
Bugfix API 'preset?search=xxx' behaviour

### DIFF
--- a/backend/coreapp/views/preset.py
+++ b/backend/coreapp/views/preset.py
@@ -58,7 +58,7 @@ class PresetViewSet(ModelViewSet):  # type: ignore
         filters.SearchFilter,
         filters.OrderingFilter,
     ]
-    search_fields = ["id", "name", "platform", "compiler", "owner"]
+    search_fields = ["id", "name", "platform", "compiler"]
     ordering_fields = ["creation_time", "id", "name", "compiler", "num_scratches"]
 
     def get_serializer_class(self) -> type[serializers.ModelSerializer[Preset]]:

--- a/backend/coreapp/views/preset.py
+++ b/backend/coreapp/views/preset.py
@@ -58,7 +58,7 @@ class PresetViewSet(ModelViewSet):  # type: ignore
         filters.SearchFilter,
         filters.OrderingFilter,
     ]
-    search_fields = ["id", "name", "platform", "compiler"]
+    search_fields = ["id", "name", "platform", "compiler", "owner__user__username"]
     ordering_fields = ["creation_time", "id", "name", "compiler", "num_scratches"]
 
     def get_serializer_class(self) -> type[serializers.ModelSerializer[Preset]]:


### PR DESCRIPTION
the `owner` field throws an `icontains` error (similar to [this](https://stackoverflow.com/questions/76406530/i-am-getting-this-error-django-core-exceptions-fielderror-unsupported-lookup-i)),need to be more specific and pick the username field.

screenshot from local testing:
![image](https://github.com/user-attachments/assets/99cdfc53-842b-4580-8766-89776aa2776d)

