### PR TITLE
Ignore errors when cleaning up sandbox

### DIFF
--- a/backend/coreapp/sandbox.py
+++ b/backend/coreapp/sandbox.py
@@ -26,7 +26,7 @@ class Sandbox(contextlib.AbstractContextManager["Sandbox"]):
             settings.SANDBOX_TMP_PATH.mkdir(parents=True, exist_ok=True)
             tmpdir = str(settings.SANDBOX_TMP_PATH)
 
-        self.temp_dir = TemporaryDirectory(dir=tmpdir)
+        self.temp_dir = TemporaryDirectory(dir=tmpdir, ignore_cleanup_errors=True)
         self.path = Path(self.temp_dir.name)
         return self
 


### PR DESCRIPTION
The backend crashed on a scratch timeout (it was a Saturn scratch which invokes dosemu2). The crashed happened due to the sandbox cleanup function erroring. Not sure why?

More info at https://decompme.sentry.io/issues/6578749636?project=4504592976904192.