### PR TITLE
Don't lazy-load the Decompile tab

### DIFF
--- a/frontend/src/components/Scratch/Scratch.tsx
+++ b/frontend/src/components/Scratch/Scratch.tsx
@@ -403,7 +403,7 @@ export default function Scratch({
                                 </>
                             }
                         >
-                            {() => <DecompilationPanel scratch={scratch} />}
+                            <DecompilationPanel scratch={scratch} />
                         </Tab>
                     )
                 );


### PR DESCRIPTION
Closes #1536.

By returning a function the contents of the Decompile tab are called on every load (and thus /decompile endpoint is called). Instead return the component which allows the useEffect to work as intended.