### PR TITLE
Fast return from useCompareExtension when compareTo is undefined

### DIFF
--- a/frontend/src/lib/codemirror/useCompareExtension.ts
+++ b/frontend/src/lib/codemirror/useCompareExtension.ts
@@ -139,6 +139,8 @@ export default function useCompareExtension(
 ): Extension {
     const [compartment] = useState(new Compartment());
 
+    if (typeof compareTo === "undefined") return [];
+
     // Update targetString facet when compareTo changes
     useEffect(() => {
         if (viewRef.current) {

--- a/frontend/src/lib/codemirror/useCompareExtension.ts
+++ b/frontend/src/lib/codemirror/useCompareExtension.ts
@@ -139,8 +139,6 @@ export default function useCompareExtension(
 ): Extension {
     const [compartment] = useState(new Compartment());
 
-    if (typeof compareTo === "undefined") return [];
-
     // Update targetString facet when compareTo changes
     useEffect(() => {
         if (viewRef.current) {
@@ -149,6 +147,8 @@ export default function useCompareExtension(
             });
         }
     }, [compartment, compareTo, viewRef]);
+
+    if (typeof compareTo === "undefined") return [];
 
     return [
         diffGutter,


### PR DESCRIPTION
This is a slight band-aid for #1538. The issue of unnecessary horizontal scrollbars won't occur when there is no parent scratch to compare the current scratch / context to.