### PR TITLE
Add 'family' slug to track ultimate ancestor for a Scratch

### DIFF
--- a/backend/coreapp/migrations/0059_scratch_family_alter_scratch_parent.py
+++ b/backend/coreapp/migrations/0059_scratch_family_alter_scratch_parent.py
@@ -1,0 +1,34 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("coreapp", "0058_rename_gcc272sn_to_gcc272sn0004"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="scratch",
+            name="family",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="family_members",
+                to="coreapp.scratch",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="scratch",
+            name="parent",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="children",
+                to="coreapp.scratch",
+            ),
+        ),
+    ]

--- a/backend/coreapp/migrations/0060_populate_scratch_family.py
+++ b/backend/coreapp/migrations/0060_populate_scratch_family.py
@@ -1,0 +1,65 @@
+import logging
+
+from typing import Any
+
+from django.apps.registry import Apps
+
+from django.db import migrations
+from django.db.backends.base.schema import BaseDatabaseSchemaEditor
+
+
+logger = logging.getLogger(__name__)
+
+
+def set_family_field(apps: Apps, schema_editor: BaseDatabaseSchemaEditor) -> None:
+    Scratch = apps.get_model("coreapp", "Scratch")
+
+    cache: dict[str, Any] = {}
+
+    def find_root(scratch: Any) -> Any:
+        """Returns the top-most ancestor and caches results."""
+        if scratch.slug in cache:
+            return cache[scratch.slug]
+        visited = []
+        current = scratch
+        while current.parent is not None:
+            visited.append(current)
+            current = current.parent
+            if current.slug in cache:
+                current = cache[current.slug]
+                break
+        root = current
+        for s in visited:
+            cache[s.slug] = root
+        return root
+
+    updates = []
+
+    scratches = Scratch.objects.select_related("parent").all()
+
+    for i, scratch in enumerate(scratches, 1):
+        if i % 1000 == 0:
+            logger.info(f"Processed {i} scratches...")
+
+        if scratch.parent is None:
+            if scratch.family_id != scratch.slug:
+                scratch.family = scratch
+                updates.append(scratch)
+        else:
+            top = find_root(scratch)
+            if scratch.family_id != top.slug:
+                scratch.family = top
+                updates.append(scratch)
+
+    Scratch.objects.bulk_update(updates, ["family"])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("coreapp", "0059_scratch_family_alter_scratch_parent"),
+    ]
+
+    operations = [
+        migrations.RunPython(set_family_field),
+    ]

--- a/backend/coreapp/models/scratch.py
+++ b/backend/coreapp/models/scratch.py
@@ -71,6 +71,8 @@ class LibrariesField(models.JSONField):
 
     def from_db_value(self, *args: Any, **kwargs: Any) -> list[Library]:
         res = super().from_db_value(*args, **kwargs)
+        if res is None:
+            return []
         return [Library(name=lib["name"], version=lib["version"]) for lib in res]
 
 
@@ -97,7 +99,20 @@ class Scratch(models.Model):
     max_score = models.IntegerField(default=-1)
     match_override = models.BooleanField(default=False)
     libraries = LibrariesField(default=list, blank=True, null=True)
-    parent = models.ForeignKey("self", null=True, blank=True, on_delete=models.SET_NULL)
+    family = models.ForeignKey(
+        "self",
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="family_members",
+    )
+    parent = models.ForeignKey(
+        "self",
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="children",
+    )
     owner = models.ForeignKey(Profile, null=True, blank=True, on_delete=models.SET_NULL)
     claim_token = models.CharField(
         max_length=64, blank=True, null=True, default=gen_claim_token
@@ -114,13 +129,16 @@ class Scratch(models.Model):
     def __hash__(self) -> int:
         return hash((self.slug, self.last_updated))
 
+    def save(self, *args: Any, **kwargs: Any) -> None:
+        if not self.family:
+            if self.parent and self.parent.family:
+                self.family = self.parent.family
+            else:
+                self.family = self
+        super().save(*args, **kwargs)
+
     def is_claimable(self) -> bool:
         return self.owner is None
-
-    def all_parents(self) -> "List[Scratch]":
-        if self.parent is None:
-            return []
-        return [self.parent] + self.parent.all_parents()
 
 
 class ScratchAdmin(admin.ModelAdmin[Scratch]):

--- a/backend/coreapp/views/scratch.py
+++ b/backend/coreapp/views/scratch.py
@@ -559,8 +559,6 @@ class ScratchViewSet(
     def family(self, request: Request, pk: str) -> Response:
         scratch: Scratch = self.get_object()
 
-        parent_slugs = [p.slug for p in scratch.all_parents()]
-
         if is_contentful_asm(scratch.target_assembly.source_asm):
             assert scratch.target_assembly.source_asm is not None
 
@@ -568,7 +566,8 @@ class ScratchViewSet(
                 Q(
                     target_assembly__source_asm__hash=scratch.target_assembly.source_asm.hash
                 )
-                | Q(slug__in=parent_slugs)
+                | Q(family_id=scratch.family_id)
+                | Q(parent_id=scratch.parent_id)
             ).order_by("creation_time")
         elif (
             scratch.target_assembly.elf_object is not None
@@ -579,11 +578,14 @@ class ScratchViewSet(
                     target_assembly__hash=scratch.target_assembly.hash,
                     diff_label=scratch.diff_label,
                 )
-                | Q(slug__in=parent_slugs)
+                | Q(family_id=scratch.family_id)
+                | Q(parent_id=scratch.parent_id)
             ).order_by("creation_time")
         else:
             family = Scratch.objects.filter(
-                Q(slug=scratch.slug) | Q(slug__in=parent_slugs)
+                Q(slug=scratch.slug)
+                | Q(family_id=scratch.family_id)
+                | Q(parent_id=scratch.parent_id)
             )
 
         return Response(

--- a/backend/coreapp/views/scratch.py
+++ b/backend/coreapp/views/scratch.py
@@ -575,7 +575,9 @@ class ScratchViewSet(
         else:
             scratch_filter = Q(slug=scratch.slug)
 
-        scratch_filter |= Q(family_id=scratch.family_id)
+        if scratch.family:
+            scratch_filter |= Q(family_id=scratch.family_id)
+
         if scratch.parent is not None:
             scratch_filter |= Q(parent_id=scratch.parent_id)
 

--- a/backend/coreapp/views/scratch.py
+++ b/backend/coreapp/views/scratch.py
@@ -561,32 +561,25 @@ class ScratchViewSet(
 
         if is_contentful_asm(scratch.target_assembly.source_asm):
             assert scratch.target_assembly.source_asm is not None
-
-            family = Scratch.objects.filter(
-                Q(
-                    target_assembly__source_asm__hash=scratch.target_assembly.source_asm.hash
-                )
-                | Q(family_id=scratch.family_id)
-                | Q(parent_id=scratch.parent_id)
-            ).order_by("creation_time")
+            scratch_filter = Q(
+                target_assembly__source_asm__hash=scratch.target_assembly.source_asm.hash
+            )
         elif (
             scratch.target_assembly.elf_object is not None
             and len(scratch.target_assembly.elf_object) > 0
         ):
-            family = Scratch.objects.filter(
-                Q(
-                    target_assembly__hash=scratch.target_assembly.hash,
-                    diff_label=scratch.diff_label,
-                )
-                | Q(family_id=scratch.family_id)
-                | Q(parent_id=scratch.parent_id)
-            ).order_by("creation_time")
-        else:
-            family = Scratch.objects.filter(
-                Q(slug=scratch.slug)
-                | Q(family_id=scratch.family_id)
-                | Q(parent_id=scratch.parent_id)
+            scratch_filter = Q(
+                target_assembly__hash=scratch.target_assembly.hash,
+                diff_label=scratch.diff_label,
             )
+        else:
+            scratch_filter = Q(slug=scratch.slug)
+
+        scratch_filter |= Q(family_id=scratch.family_id)
+        if scratch.parent is not None:
+            scratch_filter |= Q(parent_id=scratch.parent_id)
+
+        family = Scratch.objects.filter(scratch_filter).order_by("creation_time")
 
         return Response(
             TerseScratchSerializer(family, many=True, context={"request": request}).data


### PR DESCRIPTION
The idea here is to avoid the N+1 query when trying to find related scratches. We keep track of the ultimate parent of each scratch upon creation/forking so that it's a simple lookup to find the family.

If the ultimate parent scratch gets deleted, then we'll fall back to using the immediate parent of the scratch. I think this is a fair trade-off in terms of usability vs performance; ideally people don't delete family scratches if they're interested in tracking the family.