### PR TITLE
Rewrite NewScratchForm

### DIFF
--- a/frontend/src/app/(navfooter)/new/NewScratchForm.tsx
+++ b/frontend/src/app/(navfooter)/new/NewScratchForm.tsx
@@ -218,7 +218,7 @@ export default function NewScratchForm({
     const compilersTranslation = getTranslation("compilers");
     const compilerChoiceOptions = useMemo(() => {
         if (availableCompilers.length === 0) {
-            return { loading: "Loading..." };
+            return { "": "Loading..." };
         }
         return availableCompilers.reduce(
             (sum, id) => {

--- a/frontend/src/app/(navfooter)/new/NewScratchForm.tsx
+++ b/frontend/src/app/(navfooter)/new/NewScratchForm.tsx
@@ -184,10 +184,8 @@ export default function NewScratchForm({
 
     // 3. Select compiler based on local storage
     useEffect(() => {
-        if (!platform) return;
-
         // A platform will always have at least 1 available compiler
-        if (!availableCompilers) return;
+        if (availableCompilers.length === 0) return;
 
         setReady(true);
 
@@ -213,7 +211,7 @@ export default function NewScratchForm({
             );
             setCompiler(availableCompilers[0]);
         }
-    }, [availableCompilers, availablePresets]);
+    }, [platform, availableCompilers, availablePresets]);
 
     const compilersTranslation = getTranslation("compilers");
     const compilerChoiceOptions = useMemo(() => {

--- a/frontend/src/app/(navfooter)/new/NewScratchForm.tsx
+++ b/frontend/src/app/(navfooter)/new/NewScratchForm.tsx
@@ -146,14 +146,7 @@ export default function NewScratchForm({
         } else {
             localStorage.new_scratch_presetId = presetId;
         }
-    }, [
-        label,
-        asm,
-        context,
-        platform,
-        compilerId,
-        presetId,
-    ]);
+    }, [ready, label, asm, context, platform, compilerId, presetId]);
 
     // 1. Load platform from local storage on initial mount
     useEffect(() => {

--- a/frontend/src/app/(navfooter)/new/NewScratchForm.tsx
+++ b/frontend/src/app/(navfooter)/new/NewScratchForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useMemo, useReducer } from "react";
+import { useEffect, useState, useMemo, useReducer, useCallback } from "react";
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
@@ -81,8 +81,8 @@ export default function NewScratchForm({
 }) {
     const [asm, setAsm] = useState("");
     const [context, setContext] = useState("");
-    const [platform, setPlatform] = useState("");
-    const [compilerId, setCompilerId] = useState<string>();
+    const [platform, setPlatform] = useState<string>();
+    const [compilerId, setCompilerId] = useState<string>("");
     const [compilerFlags, setCompilerFlags] = useState<string>("");
     const [diffFlags, setDiffFlags] = useState<string[]>([]);
     const [libraries, setLibraries] = useState<api.Library[]>([]);
@@ -109,10 +109,9 @@ export default function NewScratchForm({
         trailing: true,
     });
 
-    const setPreset = (preset: api.Preset) => {
+    const setPreset = useCallback((preset: api.Preset) => {
         if (preset) {
             setPresetId(preset.id);
-            setPlatform(preset.platform);
             setCompilerId(preset.compiler);
             setCompilerFlags(preset.compiler_flags);
             setDiffFlags(preset.diff_flags);
@@ -124,46 +123,15 @@ export default function NewScratchForm({
             setDiffFlags([]);
             setLibraries([]);
         }
-    };
-    const setCompiler = (compiler?: string) => {
+    }, []);
+    const setCompiler = useCallback((compiler?: string) => {
         setCompilerId(compiler);
         setCompilerFlags("");
         setDiffFlags([]);
         setLibraries([]);
         setPresetId(undefined);
-    };
+    }, []);
 
-    // Load fields from localStorage
-    useEffect(() => {
-        try {
-            setLabel(localStorage.new_scratch_label ?? "");
-            setAsm(localStorage.new_scratch_asm ?? "");
-            setContext(localStorage.new_scratch_context ?? "");
-            const pid = Number.parseInt(localStorage.new_scratch_presetId);
-            if (!Number.isNaN(pid)) {
-                const preset = availablePresets[pid];
-                if (preset) {
-                    setPreset(preset);
-                }
-            } else {
-                setPlatform(localStorage.new_scratch_platform ?? "");
-                setCompilerId(localStorage.new_scratch_compilerId ?? undefined);
-                setCompilerFlags(localStorage.new_scratch_compilerFlags ?? "");
-                setDiffFlags(
-                    JSON.parse(localStorage.new_scratch_diffFlags ?? "[]"),
-                );
-                setLibraries(
-                    JSON.parse(localStorage.new_scratch_libraries ?? "[]"),
-                );
-            }
-            incrementValueVersion();
-        } catch (error) {
-            console.warn("bad localStorage", error);
-        }
-        setReady(true);
-    }, [availablePresets]);
-
-    // Update localStorage
     useEffect(() => {
         if (!ready) return;
 
@@ -172,34 +140,45 @@ export default function NewScratchForm({
         localStorage.new_scratch_context = context;
         localStorage.new_scratch_platform = platform;
         localStorage.new_scratch_compilerId = compilerId;
-        localStorage.new_scratch_compilerFlags = compilerFlags;
-        localStorage.new_scratch_diffFlags = JSON.stringify(diffFlags);
-        localStorage.new_scratch_libraries = JSON.stringify(libraries);
+
         if (presetId === undefined) {
             localStorage.removeItem("new_scratch_presetId");
         } else {
             localStorage.new_scratch_presetId = presetId;
         }
     }, [
-        ready,
         label,
         asm,
         context,
         platform,
         compilerId,
-        compilerFlags,
-        diffFlags,
-        libraries,
         presetId,
     ]);
 
-    // Use first available platform if no platform was selected or is unavailable
-    if (!platform || Object.keys(availablePlatforms).indexOf(platform) === -1) {
-        setPlatform(Object.keys(availablePlatforms)[0]);
-    }
+    // 1. Load platform from local storage on initial mount
+    useEffect(() => {
+        try {
+            const storedPlatform = localStorage.getItem("new_scratch_platform");
+            const platforms = Object.keys(availablePlatforms);
+            if (platforms.includes(storedPlatform)) {
+                setPlatform(storedPlatform);
+            } else {
+                // no local storage, or invalid value, remove it and set first platform
+                localStorage.removeItem("new_scratch_platform");
+                setPlatform(platforms[0]);
+            }
 
+            setLabel(localStorage.new_scratch_label ?? "");
+            setAsm(localStorage.new_scratch_asm ?? "");
+            setContext(localStorage.new_scratch_context ?? "");
+            incrementValueVersion();
+        } catch (error) {
+            console.warn("bad localStorage", error);
+        }
+    }, []);
+
+    // 2. Fetch compilers and presets for selected platform
     const platformDetails = usePlatform(platform);
-
     useEffect(() => {
         if (!platformDetails) return;
 
@@ -207,19 +186,38 @@ export default function NewScratchForm({
         setAvailablePresets(platformDetails.presets);
     }, [platformDetails]);
 
+    // 3. Select compiler based on local storage
     useEffect(() => {
-        if (!ready) return;
+        if (!platform) return;
 
-        if (presetId !== undefined || availableCompilers.includes(compilerId)) {
-            // User has specified a preset or valid compiler, don't override it
-            return;
+        // A platform will always have at least 1 available compiler
+        if (!availableCompilers) return;
+
+        setReady(true);
+
+        const pid = Number.parseInt(localStorage.new_scratch_presetId);
+        if (!Number.isNaN(pid)) {
+            const preset = availablePresets.filter((x) => x.id === pid)[0];
+            if (preset) {
+                setPreset(preset);
+                return;
+            }
         }
 
-        if (availableCompilers.length > 0) {
-            // Fall back to the first supported compiler and no flags...
+        // Remove invalid or missing presetId
+        localStorage.removeItem("new_scratch_presetId");
+
+        // Use compilerId from local storage if present and valid
+        const cid = localStorage.new_scratch_compilerId ?? "";
+        if (availableCompilers.includes(cid)) {
+            setCompiler(cid);
+        } else {
+            console.log(
+                `Falling back to first available compiler for ${platform}`,
+            );
             setCompiler(availableCompilers[0]);
         }
-    }, [ready, presetId, compilerId, availableCompilers]);
+    }, [availableCompilers, availablePresets]);
 
     const compilersTranslation = getTranslation("compilers");
     const compilerChoiceOptions = useMemo(() => {
@@ -295,7 +293,7 @@ export default function NewScratchForm({
                     value={platform}
                     onChange={(p) => {
                         setPlatform(p);
-                        setCompiler();
+                        setCompiler("");
                     }}
                 />
             </div>

--- a/frontend/src/app/(navfooter)/new/NewScratchForm.tsx
+++ b/frontend/src/app/(navfooter)/new/NewScratchForm.tsx
@@ -173,10 +173,13 @@ export default function NewScratchForm({
     // 2. Fetch compilers and presets for selected platform
     const platformDetails = usePlatform(platform);
     useEffect(() => {
-        if (!platformDetails) return;
-
-        setAvailableCompilers(platformDetails.compilers);
-        setAvailablePresets(platformDetails.presets);
+        if (platformDetails) {
+            setAvailableCompilers(platformDetails.compilers);
+            setAvailablePresets(platformDetails.presets);
+        } else {
+            setAvailableCompilers([]);
+            setAvailablePresets([]);
+        }
     }, [platformDetails]);
 
     // 3. Select compiler based on local storage

--- a/frontend/src/app/(navfooter)/new/NewScratchForm.tsx
+++ b/frontend/src/app/(navfooter)/new/NewScratchForm.tsx
@@ -214,6 +214,9 @@ export default function NewScratchForm({
 
     const compilersTranslation = getTranslation("compilers");
     const compilerChoiceOptions = useMemo(() => {
+        if (availableCompilers.length === 0) {
+            return { loading: "Loading..." };
+        }
         return availableCompilers.reduce(
             (sum, id) => {
                 sum[id] = compilersTranslation.t(id);

--- a/frontend/src/app/(navfooter)/new/NewScratchForm.tsx
+++ b/frontend/src/app/(navfooter)/new/NewScratchForm.tsx
@@ -89,7 +89,7 @@ export default function NewScratchForm({
     const [presetId, setPresetId] = useState<number | undefined>();
 
     const [availableCompilers, setAvailableCompilers] = useState<string[]>([]);
-    const [availablePresets, setAvailablePresets] = useState<api.Preset[]>([]);
+    const [availablePresets, setAvailablePresets] = useState<api.Preset[]>();
 
     const [duplicates, setDuplicates] = useState([]);
 
@@ -178,7 +178,7 @@ export default function NewScratchForm({
             setAvailablePresets(platformDetails.presets);
         } else {
             setAvailableCompilers([]);
-            setAvailablePresets([]);
+            setAvailablePresets(undefined);
         }
     }, [platformDetails]);
 

--- a/frontend/src/components/PlatformSelect/PlatformSelect.tsx
+++ b/frontend/src/components/PlatformSelect/PlatformSelect.tsx
@@ -21,8 +21,6 @@ export default function PlatformSelect({
     onChange,
     className,
 }: Props) {
-    if (!value) onChange("n64");
-
     return (
         <ul className={clsx(styles.container, className)}>
             {Object.entries(platforms).map(([key, platform]) => (

--- a/frontend/src/components/compiler/CompilerOpts.tsx
+++ b/frontend/src/components/compiler/CompilerOpts.tsx
@@ -11,7 +11,6 @@ import { TrashIcon } from "@primer/octicons-react";
 import Checkbox from "@/app/(navfooter)/settings/Checkbox";
 import Button from "@/components/Button";
 import Select2 from "@/components/Select2";
-import LoadingSpinner from "@/components/loading.svg";
 import * as api from "@/lib/api";
 import type { Library } from "@/lib/api/types";
 import getTranslation from "@/lib/i18n/translate";

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -351,7 +351,7 @@ export function useCompilation(
 }
 
 export function usePlatform(id: string | undefined): Platform | undefined {
-    const url = typeof id === "string" ? `/platform/${id}` : null;
+    const url = typeof id === "string" && id ? `/platform/${id}` : null;
     const { data } = useSWRImmutable(url, get, {
         refreshInterval: 1000 * 60 * 15, // 15 minutes
         onErrorRetry,


### PR DESCRIPTION
This PR rewrites the core of the scratch creation form from the ground up.

Key changes:

1. (unchanged) The form receives the list of available platforms via props.
2. On load, it checks local storage for a previously selected platform. If it's valid, it's used; otherwise, the first available platform is selected.
3. It then fetches the compilers and presets for the selected platform.
4. If a valid presetId is found in local storage, it sets the compiler, flags, and libraries accordingly.
5. If no valid preset is found, it checks for a stored compilerId and uses it if valid.
6. If no valid compiler is found, the first available compiler is selected.

Since users can't manually configure compiler flags, diff flags, or libraries when creating a scratch, there's no need to persist these in local storage — we derive them from the preset. If we support custom configuration in the future, we can reintroduce that logic.

Overall, this simplifies the form logic considerably by making **platform selection the primary driver** for subsequent state, rather than the preset. This makes the control flow easier to reason about and avoids edge case bugs.
