### PR TITLE
Refresh stats every 60s

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -500,7 +500,7 @@ export interface Stats {
 
 export function useStats(): Stats | undefined {
     const { data, error } = useSWR<Stats>("/stats", get, {
-        refreshInterval: 1000 * 5, // 5 seconds
+        refreshInterval: 1000 * 60, // 60 seconds
     });
 
     if (error) {


### PR DESCRIPTION
Query takes ~100ms because it's doing an accurate .count() on 3 tables, bumping to 60 second refresh (currently 5). We can revisit this as/when we move to an 'activity log' (which ideally would be websocket rather than a poll)