### PR TITLE
Bump binutils-omf to 0.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
         run: |-
           wget https://github.com/OmniBlade/binutils-gdb/releases/download/omf-build/omftools.tar.gz
           sudo tar xvzf omftools.tar.gz -C /usr/bin jwasm
-          wget https://github.com/decompals/binutils-omf/releases/download/v0.3/omftools-linux-x86_64.tar.gz
+          wget https://github.com/decompals/binutils-omf/releases/download/v0.4/omftools-linux-x86_64.tar.gz
           sudo tar xvzf omftools-linux-x86_64.tar.gz -C /usr/bin omf-nm omf-objdump
 
       - name: Install wibo

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -102,7 +102,7 @@ RUN curl -sSL "https://github.com/encounter/gc-wii-binutils/releases/download/2.
 RUN wget "https://github.com/OmniBlade/binutils-gdb/releases/download/omf-build/omftools.tar.gz" \
     && tar xvzf omftools.tar.gz -C /usr/bin jwasm \
     && rm omftools.tar.gz \
-    && wget "https://github.com/decompals/binutils-omf/releases/download/v0.3/omftools-linux-x86_64.tar.gz" \
+    && wget "https://github.com/decompals/binutils-omf/releases/download/v0.4/omftools-linux-x86_64.tar.gz" \
     && tar xvzf omftools-linux-x86_64.tar.gz -C /usr/bin omf-nm omf-objdump \
     && rm omftools-linux-x86_64.tar.gz
 


### PR DESCRIPTION
Already updated prod:
```bash
$ mkdir /tmp/omf
$ cd /tmp/omf
$ wget "https://github.com/decompals/binutils-omf/releases/download/v0.4/omftools-linux-x86_64.tar.gz"
$ sudo tar xvzf omftools-linux-x86_64.tar.gz -C /usr/bin omf-nm omf-objdump
[sudo] password for mark: 
omf-nm
omf-objdump
```