### PR TITLE
Fix N+1 scratch list

### DIFF
--- a/backend/coreapp/serializers.py
+++ b/backend/coreapp/serializers.py
@@ -35,7 +35,11 @@ def serialize_profile(profile: Profile) -> Dict[str, Any]:
     else:
         user = profile.user
 
-        gh_user: Optional[GitHubUser] = GitHubUser.objects.filter(user=user).first()
+        gh_user: Optional[GitHubUser] = getattr(user, "github", None)
+        if not gh_user:
+            # NOTE: All models with an "owner" should fetch related "owner__user__github"
+            # in order to avoid N+1 queries when a Profile is serialized for each object.
+            gh_user = GitHubUser.objects.filter(user=user).first()
 
         return {
             "is_anonymous": False,

--- a/backend/coreapp/views/scratch.py
+++ b/backend/coreapp/views/scratch.py
@@ -278,7 +278,11 @@ class ScratchViewSet(
         default=1.0 - (F("score") / Cast("max_score", FloatField())),
     )
 
-    queryset = Scratch.objects.all().annotate(match_percent=match_percent)
+    queryset = (
+        Scratch.objects.all()
+        .select_related("owner__user__github")
+        .annotate(match_percent=match_percent)
+    )
     pagination_class = ScratchPagination
     filterset_fields = ["platform", "compiler", "preset"]
     filter_backends = [

--- a/backend/coreapp/views/user.py
+++ b/backend/coreapp/views/user.py
@@ -57,7 +57,9 @@ class CurrentUserScratchList(generics.ListAPIView):  # type: ignore
     def get_queryset(self) -> QuerySet[Scratch]:
         if self.request.profile.id is None:
             return Scratch.objects.none()
-        return ScratchViewSet.queryset.filter(owner__id=self.request.profile.id)
+        return ScratchViewSet.queryset.filter(
+            owner__id=self.request.profile.id
+        ).select_related("owner__user__github")
 
 
 class UserScratchList(generics.ListAPIView):  # type: ignore
@@ -77,7 +79,7 @@ class UserScratchList(generics.ListAPIView):  # type: ignore
     def get_queryset(self) -> QuerySet[Scratch]:
         return ScratchViewSet.queryset.filter(
             owner__user__username=self.kwargs["username"]
-        )
+        ).select_related("owner__user__github")
 
 
 @api_view(["GET"])  # type: ignore

--- a/backend/coreapp/views/user.py
+++ b/backend/coreapp/views/user.py
@@ -57,9 +57,7 @@ class CurrentUserScratchList(generics.ListAPIView):  # type: ignore
     def get_queryset(self) -> QuerySet[Scratch]:
         if self.request.profile.id is None:
             return Scratch.objects.none()
-        return ScratchViewSet.queryset.filter(
-            owner__id=self.request.profile.id
-        ).select_related("owner__user__github")
+        return ScratchViewSet.queryset.filter(owner__id=self.request.profile.id)
 
 
 class UserScratchList(generics.ListAPIView):  # type: ignore
@@ -79,7 +77,7 @@ class UserScratchList(generics.ListAPIView):  # type: ignore
     def get_queryset(self) -> QuerySet[Scratch]:
         return ScratchViewSet.queryset.filter(
             owner__user__username=self.kwargs["username"]
-        ).select_related("owner__user__github")
+        )
 
 
 @api_view(["GET"])  # type: ignore


### PR DESCRIPTION
Ensure we prefetch the github user (via user) to avoid this craziness:
![image](https://github.com/user-attachments/assets/292e5233-b69f-4746-8823-62914d841b7e)
