### PR TITLE
Add DXSDK 9.0 to win32 libraries

### DIFF
--- a/backend/libraries/libraries.yaml
+++ b/backend/libraries/libraries.yaml
@@ -8,3 +8,7 @@ win32:
       git:
         url: https://github.com/roblabla/directx-headers
         branch: main
+    '9.0':
+      git:
+        url: https://github.com/ifarbod/dxsdk9
+        branch: master


### PR DESCRIPTION
For #1570 - we need DX 9 in order to compile the code on the website.