### PR TITLE
Fix missing library section

### DIFF
--- a/frontend/src/components/compiler/CompilerOpts.tsx
+++ b/frontend/src/components/compiler/CompilerOpts.tsx
@@ -529,13 +529,13 @@ export function LibrariesSection({
     platform: string;
     className?: string;
 }) {
-    const supportedLibraries = api.useLibraries(platform);
-    if (supportedLibraries.length === 0) return;
+    const availableLibraries = api.useLibraries(platform);
+    if (availableLibraries.length === 0) return;
 
     return (
         <section className={className}>
             <LibrariesEditor
-                supportedLibraries={supportedLibraries}
+                availableLibraries={availableLibraries}
                 libraries={libraries}
                 setLibraries={setLibraries}
             />
@@ -544,18 +544,18 @@ export function LibrariesSection({
 }
 
 export function LibrariesEditor({
-    supportedLibraries,
+    availableLibraries,
     libraries,
     setLibraries,
 }: {
-    supportedLibraries: api.LibraryVersions[];
+    availableLibraries: api.LibraryVersions[];
     libraries: Library[];
     setLibraries: (libraries: Library[]) => void;
 }) {
     const librariesTranslations = getTranslation("libraries");
 
     const libraryVersions = (scratchlib: api.Library) => {
-        const lib = supportedLibraries.find(
+        const lib = availableLibraries.find(
             (lib) => lib.name === scratchlib.name,
         );
         if (lib != null) {
@@ -568,7 +568,7 @@ export function LibrariesEditor({
     };
 
     const addLibrary = (libName: string) => {
-        const lib = supportedLibraries.find((lib) => lib.name === libName);
+        const lib = availableLibraries.find((lib) => lib.name === libName);
         if (lib != null) {
             return setLibraryVersion(libName, lib.supported_versions[0]);
         }
@@ -597,7 +597,7 @@ export function LibrariesEditor({
         setLibraries(libs);
     };
 
-    const librariesSelectOptions = supportedLibraries
+    const librariesSelectOptions = availableLibraries
         // Filter out libraries that are already in the scratch
         .filter(
             (lib) =>

--- a/frontend/src/components/compiler/CompilerOpts.tsx
+++ b/frontend/src/components/compiler/CompilerOpts.tsx
@@ -393,15 +393,12 @@ export default function CompilerOpts({
                 </section>
             </OptsContext.Provider>
 
-            {value.libraries.length !== 0 && (
-                <section className={styles.section}>
-                    <LibrariesEditor
-                        libraries={value.libraries}
-                        setLibraries={setLibraries}
-                        platform={platform}
-                    />
-                </section>
-            )}
+            <LibrariesSection
+                className={styles.section}
+                libraries={value.libraries}
+                setLibraries={setLibraries}
+                platform={platform}
+            />
 
             <OptsContext.Provider value={diffOptsEditorProvider}>
                 <section className={styles.section}>
@@ -521,16 +518,40 @@ export function DiffOptsEditor({
     );
 }
 
-export function LibrariesEditor({
+export function LibrariesSection({
     libraries,
     setLibraries,
     platform,
+    className,
 }: {
     libraries: Library[];
     setLibraries: (libraries: Library[]) => void;
     platform: string;
+    className?: string;
 }) {
     const supportedLibraries = api.useLibraries(platform);
+    if (supportedLibraries.length === 0) return;
+
+    return (
+        <section className={className}>
+            <LibrariesEditor
+                supportedLibraries={supportedLibraries}
+                libraries={libraries}
+                setLibraries={setLibraries}
+            />
+        </section>
+    );
+}
+
+export function LibrariesEditor({
+    supportedLibraries,
+    libraries,
+    setLibraries,
+}: {
+    supportedLibraries: api.LibraryVersions[];
+    libraries: Library[];
+    setLibraries: (libraries: Library[]) => void;
+}) {
     const librariesTranslations = getTranslation("libraries");
 
     const libraryVersions = (scratchlib: api.Library) => {


### PR DESCRIPTION
On the live site you can only add/remove a library if a scratch already has a library set (i.e. via the preset). This isn't great, so change it so we will show available libraries if we have any for the given platform.