### PR TITLE
Tweak last updated

### DIFF
--- a/backend/coreapp/middleware.py
+++ b/backend/coreapp/middleware.py
@@ -99,9 +99,11 @@ def set_user_profile(
                 request.path,
             )
 
-        # Update last seen timestamp
+        # Update last seen timestamp if more than a minute since last updated
+        last_request_date = profile.last_request_date or now()
         profile.last_request_date = now()
-        profile.save(update_fields=["last_request_date"])
+        if (profile.last_request_date - last_request_date).total_seconds() > 60:
+            profile.save(update_fields=["last_request_date"])
 
         request.profile = profile
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -410,7 +410,7 @@ export function usePresets(platform: string): Preset[] {
 
     const url = typeof platform === "string" ? "/preset" : null;
     const { data } = useSWRImmutable([url, platform], getByPlatform, {
-        refreshInterval: 1000 * 60 * 1, // 1 minute
+        refreshInterval: 1000 * 60 * 5, // 5 minutes
         onErrorRetry,
     });
 
@@ -420,7 +420,7 @@ export function usePresets(platform: string): Preset[] {
 export function usePreset(id: number | undefined): PresetBase | undefined {
     const url = typeof id === "number" ? `/preset/${id}/name` : null;
     const { data } = useSWRImmutable(url, get, {
-        refreshInterval: 1000 * 60 * 1, // 1 minute
+        refreshInterval: 1000 * 60 * 5, // 5 minutes
         onErrorRetry,
     });
     return data;


### PR DESCRIPTION
Given we treat a user as "online" if they've done something in the last 2 minutes, it seems excessive to update their `last_updated_date` so often (especially as *every* API request will update the time)

Also tweak the presets to refresh every 5 minutes, hitting F5 or a fresh navigation to the site will clear all SWR cache anyway, so I don't think anyone will notice :)