### PR TITLE
Append 'include' dir to a library's include_dir

### DIFF
--- a/backend/coreapp/libraries.py
+++ b/backend/coreapp/libraries.py
@@ -17,7 +17,7 @@ class Library:
     version: str
 
     def get_include_path(self, platform: str) -> Path:
-        return LIBRARY_BASE_PATH / platform / self.name / self.version
+        return LIBRARY_BASE_PATH / platform / self.name / self.version / "include"
 
     def available(self, platform: str) -> bool:
         include_path = self.get_include_path(platform)


### PR DESCRIPTION
3/3 of the libraries on the site use the `include` directory, and we explicitly check that it exists in order to determine if a library is available.
- dx5 https://github.com/roblabla/directx-headers/tree/5.0/include
- dx8 https://github.com/roblabla/directx-headers/tree/main/include
- dx9 https://github.com/ifarbod/dxsdk9/tree/master/include