### PR TITLE
Bump nginx buffer, use http/1.1

### DIFF
--- a/nginx/development.conf
+++ b/nginx/development.conf
@@ -4,6 +4,7 @@ server {
     listen 80;
     listen [::]:80;
     client_max_body_size 5M;
+    client_body_buffer_size 1M;
 
     server_name decomp.local www.decomp.local;
 
@@ -25,6 +26,8 @@ server {
     }
 
     location @proxy_api {
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
         proxy_set_header X-Forwarded-Proto https;
         proxy_set_header X-Url-Scheme $scheme;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -34,6 +37,8 @@ server {
     }
 
     location @proxy_frontend {
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
         proxy_set_header X-Forwarded-Proto https;
         proxy_set_header X-Url-Scheme $scheme;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/nginx/production.conf
+++ b/nginx/production.conf
@@ -30,6 +30,11 @@ server {
     client_max_body_size 5M;
     ignore_invalid_headers on;
 
+    # Increase caches to avoid disk writes
+    client_body_buffer_size 1M;
+    proxy_buffers 16 64k;
+    proxy_buffer_size 128k;
+
     # SSL
     ssl_certificate /etc/letsencrypt/live/decomp.me/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/decomp.me/privkey.pem;
@@ -68,6 +73,8 @@ server {
     }
 
     location @proxy_api {
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
         proxy_set_header X-Forwarded-Proto https;
         proxy_set_header X-Url-Scheme $scheme;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -77,6 +84,8 @@ server {
     }
 
     location @proxy_frontend {
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
         proxy_set_header X-Forwarded-Proto https;
         proxy_set_header X-Url-Scheme $scheme;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
By default nginx uses http/1.0 to talk to the proxied services, so bump to 1.1 which allows for a few performance enhancements.

the increase in the buffers should prevent these log messages:
```
2025/06/10 06:59:34 [warn] 25#25: *55853 a client request body is buffered to a temporary file /var/cache/nginx/client_temp/0000002070, client: 172.69.135.139, server: decomp.me, request: "POST /api/scratch HTTP/2.0", host: "decomp.me"
2025/06/10 06:59:34 [warn] 25#25: *55853 an upstream response is buffered to a temporary file /var/cache/nginx/proxy_temp/1/07/0000002071 while reading upstream, client: 172.69.135.139, server: decomp.me, request: "POST /api/scratch HTTP/2.0", upstream: "http://172.17.0.1:8000/api/scratch", host: "decomp.me"
...
2025/06/10 07:00:44 [warn] 25#25: *56012 a client request body is buffered to a temporary file /var/cache/nginx/client_temp/0000002097, client: 172.69.135.61, server: decomp.me, request: "POST /api/scratch/BGZTu/compile HTTP/2.0", host: "decomp.me", referrer: "https://decomp.me/scratch/BGZTu"
2025/06/10 07:00:45 [warn] 25#25: *56011 a client request body is buffered to a temporary file /var/cache/nginx/client_temp/0000002098, client: 172.69.135.62, server: decomp.me, request: "POST /api/scratch/BGZTu/compile HTTP/2.0", host: "decomp.me", referrer: "https://decomp.me/scratch/BGZTu"
2025/06/10 07:00:46 [warn] 25#25: *56012 a client request body is buffered to a temporary file /var/cache/nginx/client_temp/0000002099, client: 172.69.135.61, server: decomp.me, request: "POST /api/scratch/BGZTu/compile HTTP/2.0", host: "decomp.me", referrer: "https://decomp.me/scratch/BGZTu"
2025/06/10 07:00:52 [warn] 25#25: *56012 a client request body is buffered to a temporary file /var/cache/nginx/client_temp/0000002100, client: 172.69.135.61, server: decomp.me, request: "PATCH /api/scratch/BGZTu HTTP/2.0", host: "decomp.me", referrer: "https://decomp.me/scratch/BGZTu"
```