### PR TITLE
Allow 512k in-flight before buffering data to disk

### DIFF
--- a/nginx/production.conf
+++ b/nginx/production.conf
@@ -32,8 +32,9 @@ server {
 
     # Increase caches to avoid disk writes
     client_body_buffer_size 1M;
-    proxy_buffers 16 64k;
+    proxy_buffers 8 128k;
     proxy_buffer_size 128k;
+    proxy_busy_buffers_size 512k;
 
     # SSL
     ssl_certificate /etc/letsencrypt/live/decomp.me/fullchain.pem;


### PR DESCRIPTION
Tweak the buffers a little bit. This scratch sends the client a 800kb response to POST-ing `/compile`. So try and hold it in memory rather than writing to disk. Might need further tweaks, we shall see.

```
2025/06/10 07:11:24 [warn] 31#31: *57206 a client request body is buffered to a temporary file /var/cache/nginx/client_temp/0000002145, client: 162.158.166.228, server: decomp.me, request: "POST /api/scratch/kGIDp/compile HTTP/2.0", host: "decomp.me", referrer: "https://decomp.me/scratch/kGIDp"
2025/06/10 07:11:26 [warn] 31#31: *57206 a client request body is buffered to a temporary file /var/cache/nginx/client_temp/0000002146, client: 162.158.166.228, server: decomp.me, request: "POST /api/scratch/kGIDp/compile HTTP/2.0", host: "decomp.me", referrer: "https://decomp.me/scratch/kGIDp"
2025/06/10 07:12:51 [warn] 35#35: *57847 a client request body is buffered to a temporary file /var/cache/nginx/client_temp/0000002147, client: 162.158.166.253, server: decomp.me, request: "POST /api/scratch/kGIDp/compile HTTP/2.0", host: "decomp.me", referrer: "https://decomp.me/scratch/kGIDp"
2025/06/10 07:12:52 [warn] 35#35: *57847 a client request body is buffered to a temporary file /var/cache/nginx/client_temp/0000002148, client: 162.158.166.253, server: decomp.me, request: "POST /api/scratch/kGIDp/compile HTTP/2.0", host: "decomp.me", referrer: "https://decomp.me/scratch/kGIDp"
```

From my friend:
![image](https://github.com/user-attachments/assets/59c23f18-3020-4878-8d18-4bdc3d11aaa4)

![image](https://github.com/user-attachments/assets/c12c90f8-2e9a-41c7-b851-ba43bafd55a4)
