### PR TITLE
Expose configuration to allow db connections to be reused

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,6 +294,8 @@ jobs:
           echo 'POSTGRES_PASSWORD=decompme' >> docker.prod.env
           echo 'SECRET_KEY=secret-key-secret-key-secret-key-secret-key-secret-key-secret-key' >> docker.prod.env
           echo 'DATABASE_URL=psql://decompme:decompme@postgres:5432/decompme' >> docker.prod.env
+          echo 'CONN_MAX_AGE=60' >> docker.prod.env
+          echo 'CONN_HEALTH_CHECKS="true"' >> docker.prod.env
           echo 'SANDBOX_DISABLE_PROC="true"' >> docker.prod.env
           echo 'ALLOWED_HOSTS="backend,localhost,127.0.0.1"' >> docker.prod.env
           echo 'USE_SANDBOX_JAIL="on"' >> docker.prod.env

--- a/backend/decompme/settings.py
+++ b/backend/decompme/settings.py
@@ -45,6 +45,8 @@ env = environ.Env(
     SESSION_COOKIE_AGE=(int, 60 * 60 * 24 * 90),  # default: 90 days
     SESSION_EXPIRE_AFTER_LAST_ACTIVITY=(bool, True),
     SESSION_TIMEOUT_REDIRECT=(str, "/"),
+    CONN_MAX_AGE=(int, 0),  # default: a new connection for each request
+    CONN_HEALTH_CHECKS=(bool, False),
 )
 
 for stem in [".env.local", ".env"]:
@@ -115,7 +117,13 @@ TEMPLATES = [
 
 WSGI_APPLICATION = "decompme.wsgi.application"
 
-DATABASES = {"default": env.db()}
+DATABASES = {
+    "default": {
+        **env.db(),
+        "CONN_MAX_AGE": env("CONN_MAX_AGE"),
+        "CONN_HEALTH_CHECKS": env("CONN_HEALTH_CHECKS"),
+    },
+}
 
 # Password validation
 # https://docs.djangoproject.com/en/3.2/ref/settings/#auth-password-validators


### PR DESCRIPTION
Looking in sentry the typical (p75/p99) time to `connect()` from django to postgres is ~16ms. This seems high given both containers are on the same box, but there we go. Django allows connections to be reused (rather than closed at the end of each request which is the default behaviour), so I think we should give that a go and it should give a small (but effectively free) performance boost for every request made.

Will need the `docker.prod.env` file updated.