### PR TITLE
Oops

### DIFF
--- a/backend/housekeeping.py
+++ b/backend/housekeeping.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import argparse
 import os
 import datetime

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -87,8 +87,8 @@ services:
     image: postgres:17
     env_file:
       - docker.prod.env
-    ports:
-      - "5432:5432"
+    # ports:
+    #   - "5432:5432"
     restart: on-failure
     volumes:
       - ./postgres:/var/lib/postgresql/data

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -87,8 +87,8 @@ services:
     image: postgres:17
     env_file:
       - docker.prod.env
-    # ports:
-    #   - "5432:5432"
+    ports:
+      - "5432:5432"
     restart: on-failure
     volumes:
       - ./postgres:/var/lib/postgresql/data

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -49,4 +49,5 @@ services:
       - "80:80"
     volumes:
       - ./nginx/development.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./frontend/down.html:/var/www/down.html:ro
       - ./backend/media:/media

--- a/nginx/development.conf
+++ b/nginx/development.conf
@@ -6,6 +6,8 @@ server {
     client_max_body_size 5M;
     client_body_buffer_size 1M;
 
+    root /var/www/;
+
     server_name decomp.local www.decomp.local;
 
     location / {
@@ -26,6 +28,9 @@ server {
     }
 
     location @proxy_api {
+        proxy_intercept_errors on;
+        error_page 502 503 504 =200 @backend_down;
+
         proxy_http_version 1.1;
         proxy_set_header Connection "";
         proxy_set_header X-Forwarded-Proto https;
@@ -37,6 +42,9 @@ server {
     }
 
     location @proxy_frontend {
+        proxy_intercept_errors on;
+        error_page 502 503 504 =200 /down.html;
+
         proxy_http_version 1.1;
         proxy_set_header Connection "";
         proxy_set_header X-Forwarded-Proto https;
@@ -48,9 +56,18 @@ server {
     }
 
     location /_next/webpack-hmr {
+        proxy_intercept_errors on;
+        error_page 502 503 504 =200 /down.html;
+
         proxy_pass http://frontend:8080/_next/webpack-hmr;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
+    }
+
+    # Avoid returning HTML from the /api endpoint if backend is unavailable
+    location @backend_down {
+        default_type application/json;
+        return 200 '';
     }
 }

--- a/nginx/production.conf
+++ b/nginx/production.conf
@@ -66,7 +66,6 @@ server {
         image/png
         image/svg+xml
         text/css
-        text/html
         text/plain
         text/xml;
 

--- a/nginx/production.conf
+++ b/nginx/production.conf
@@ -17,7 +17,7 @@ log_format latency_log '$http_cf_connecting_ip - [$remote_addr | $time_local] '
                        'rt=$request_time '
                        'urt=$upstream_response_time '
                        'uht=$upstream_header_time '
-                       'uct=$upstream_connect_time'
+                       'uct=$upstream_connect_time';
 
 # {{HTTPS_SERVER_BLOCK_START}}
 server {

--- a/nginx/production.conf
+++ b/nginx/production.conf
@@ -75,8 +75,6 @@ server {
     }
 
     location /api {
-        proxy_intercept_errors on;
-        error_page 502 503 504 =200 @backend_down;
         try_files /dummy.html @proxy_api;
     }
 
@@ -93,6 +91,9 @@ server {
     }
 
     location @proxy_api {
+        proxy_intercept_errors on;
+        error_page 502 503 504 =200 @backend_down;
+
         proxy_http_version 1.1;
         proxy_set_header Connection "";
         proxy_set_header X-Forwarded-Proto https;
@@ -104,6 +105,9 @@ server {
     }
 
     location @proxy_frontend {
+        proxy_intercept_errors on;
+        error_page 502 503 504 =200 /down.html;
+
         proxy_http_version 1.1;
         proxy_set_header Connection "";
         proxy_set_header X-Forwarded-Proto https;
@@ -115,6 +119,9 @@ server {
     }
 
     location /_next/webpack-hmr {
+        proxy_intercept_errors on;
+        error_page 502 503 504 =200 /down.html;
+
         proxy_pass http://frontend:8080/_next/webpack-hmr;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
@@ -124,7 +131,7 @@ server {
     # Avoid returning HTML from the /api endpoint if backend is unavailable
     location @backend_down {
         default_type application/json;
-        return 200 '{}';
+        return 200 '';
     }
 }
 # {{HTTPS_SERVER_BLOCK_END}}


### PR DESCRIPTION
This is dumb:
1. missed the semicolon off the end of the logging when copy/pasting.
2. backend couldn't connect to the postgres db without the ports exposed... As I write this I realise it might actually be a `ufw` thing as I cannot reproduce locally where i don't have ufw running. So let me add a rule, and remove the 2nd part of this PR.