### PR TITLE
Hot Module Replacement is a dev-only thing

### DIFF
--- a/nginx/production.conf
+++ b/nginx/production.conf
@@ -127,16 +127,6 @@ server {
         proxy_pass http://frontend:8080;
     }
 
-    location /_next/webpack-hmr {
-        proxy_intercept_errors on;
-        error_page 502 503 504 =200 /down.html;
-
-        proxy_pass http://frontend:8080/_next/webpack-hmr;
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
-    }
-
     # Avoid returning HTML from the /api endpoint if backend is unavailable
     location @backend_down {
         default_type application/json;


### PR DESCRIPTION
Per title. [HMR](https://webpack.js.org/concepts/hot-module-replacement/) is a development thing (for live edits).

I copy/pasted the nginx configuration block from the dev docker setup without much thought. and have subsequently engaged my brain...