### PR TITLE
Remove legacyBehavior from Breadcrumbs Link

### DIFF
--- a/frontend/src/components/Breadcrumbs.tsx
+++ b/frontend/src/components/Breadcrumbs.tsx
@@ -24,18 +24,14 @@ export default function Breadcrumbs({ pages, className }: Props) {
             <ol>
                 {pages.map((page, index) => {
                     const isLast = index === pages.length - 1;
-
-                    const a = (
-                        <a aria-current={isLast ? "page" : undefined}>
-                            {page.label}
-                        </a>
-                    );
-
                     return (
                         <li key={page.href || index}>
                             {page.href ? (
-                                <Link href={page.href} legacyBehavior>
-                                    {a}
+                                <Link
+                                    href={page.href}
+                                    aria-current={isLast ? "page" : undefined}
+                                >
+                                    {page.label}
                                 </Link>
                             ) : (
                                 page.label


### PR DESCRIPTION
Kinda moot because we only use breadcrumbs in the scratch toolbar, and the final items isnt a link (it's the editable scratch name)... but this clears the next.js warnings.