### PR TITLE
Stop spamming sentry with clangd 'Aborted() ...' errors

### DIFF
--- a/frontend/src/instrumentation-client.ts
+++ b/frontend/src/instrumentation-client.ts
@@ -13,6 +13,11 @@ if (isSentryEnabled) {
         ),
 
         debug: false,
+
+        ignoreErrors: [
+            /* clangd language server */
+            "Aborted(). Build with -sASSERTIONS for more info.",
+        ],
     });
 } else {
     console.log("Sentry is disabled on the client.");


### PR DESCRIPTION
This should help...