### PR TITLE
Fix indentation markers theme awareness

### DIFF
--- a/frontend/src/lib/codemirror/color-scheme.ts
+++ b/frontend/src/lib/codemirror/color-scheme.ts
@@ -134,9 +134,15 @@ export function applyColorScheme(scheme: ColorScheme) {
     if (isDark) {
         document.body.style.setProperty("--code-selection", "#ffffff22");
         document.body.style.setProperty("--code-highlight", "#ffffff05");
+        // Indentation marker colors for dark theme
+        document.body.style.setProperty("--indent-marker-bg-color", `color-mix(in srgb, ${colors.foreground}, transparent 60%)`);
+        document.body.style.setProperty("--indent-marker-active-bg-color", `color-mix(in srgb, ${colors.foreground}, transparent 40%)`);
     } else {
         document.body.style.setProperty("--code-selection", "#00000022");
         document.body.style.setProperty("--code-highlight", "#00000005");
+        // Indentation marker colors for light theme
+        document.body.style.setProperty("--indent-marker-bg-color", `color-mix(in srgb, ${colors.foreground}, transparent 60%)`);
+        document.body.style.setProperty("--indent-marker-active-bg-color", `color-mix(in srgb, ${colors.foreground}, transparent 40%)`);
     }
 }
 


### PR DESCRIPTION
## Summary
Fix indentation markers to use theme-aware colors instead of hardcoded values that were causing poor contrast in light themes.

## Changes
- Updated `applyColorScheme()` to set `--indent-marker-bg-color` and `--indent-marker-active-bg-color` CSS variables
- Uses `color-mix()` with theme foreground color at 60% opacity for normal markers and 40% for active markers
- Ensures proper contrast in both light and dark themes

## Test plan
- [ ] Test with light theme (Frog Light) - markers should be visible but not overly contrasting
- [ ] Test with dark themes (Frog Dark, Material, Dracula) - markers should maintain good visibility
- [ ] Verify markers still highlight correctly when hovering/active

🤖 Generated with [Claude Code](https://claude.ai/code)