### PR TITLE
update m2c

### DIFF
--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -884,7 +884,7 @@ pycparser = "^2.21"
 type = "git"
 url = "https://github.com/matt-kempster/m2c.git"
 reference = "HEAD"
-resolved_reference = "15e27ac7952eac9ea6d1faec8dd18dce078c5358"
+resolved_reference = "6983af41fd78e3e025a07ab0c2bb069be57e6ccc"
 
 [[package]]
 name = "moreorless"


### PR DESCRIPTION
Mainly for this commit, which adds a relevant feature for decompiling on decomp.me:
 https://github.com/matt-kempster/m2c/pull/296

No dependencies have been changed in m2c from the commit currently used.