### PR TITLE
Fix settings page icon alignment

### DIFF
--- a/frontend/src/components/GhostButton.tsx
+++ b/frontend/src/components/GhostButton.tsx
@@ -18,11 +18,14 @@ export default function GhostButton({
     className,
 }: Props) {
     const isClickable = !!(href || onClick);
-    const cn = clsx(className, {
-        "rounded bg-transparent px-2 py-1 text-sm whitespace-nowrap inline-block": true,
-        "transition-colors hover:bg-gray-3 cursor-pointer active:translate-y-px hover:text-gray-12":
-            isClickable,
-    });
+    const cn = clsx(
+        className,
+        "flex items-center gap-2 rounded bg-transparent px-2 py-1 text-sm whitespace-nowrap",
+        {
+            "transition-colors hover:bg-gray-3 cursor-pointer active:translate-y-px hover:text-gray-12":
+                isClickable,
+        },
+    );
 
     if (href) {
         return (


### PR DESCRIPTION
Before

<img width="792" height="186" alt="image" src="https://github.com/user-attachments/assets/be7d75c4-450c-4023-96b1-c90c843920ac" />


After
<img width="792" height="186" alt="image" src="https://github.com/user-attachments/assets/f23bc673-ab4b-4df3-a0ad-9bfafa171b60" />


Closes #1630.