### PR TITLE
Slightly darker red/blue/green for diff in light mode

### DIFF
--- a/frontend/src/components/Diff/Diff.module.scss
+++ b/frontend/src/components/Diff/Diff.module.scss
@@ -138,11 +138,19 @@
     color: #969896;
 }
 
+.source_filename { font-weight: bold; }
+
 .diff_any { background-color: rgba(255, 255, 255, 0.02); }
+
 .diff_change { color: #6d6dff; }
 .diff_add { color: #45bd00; }
 .diff_remove { color: #c82829; }
-.source_filename { font-weight: bold; }
+
+:global(html:not(.dark)) {
+    .diff_change { color: #3a3aff; }
+    .diff_add    { color: #2a8000; }
+    .diff_remove { color: #a31212; }
+}
 
 .source_function {
     font-weight: bold;


### PR DESCRIPTION
Pulling this change out of #1656. Slightly better contrast.

Before
<img width="904" height="298" alt="image" src="https://github.com/user-attachments/assets/e6c0d658-a824-4048-bf36-37c9a04a6f07" />

After
<img width="904" height="298" alt="image" src="https://github.com/user-attachments/assets/7a0f5bb6-c8d4-49d6-b6a5-8ad555c47b57" />
