### PR TITLE
Add cache-control headers

### DIFF
--- a/backend/coreapp/decorators/cache.py
+++ b/backend/coreapp/decorators/cache.py
@@ -1,0 +1,40 @@
+from functools import wraps
+import logging
+
+from typing import Callable, Any, Optional, TypeVar, ParamSpec
+from rest_framework.response import Response
+
+logger = logging.getLogger(__file__)
+
+# Generic types for a view function
+P = ParamSpec("P")
+R = TypeVar("R", bound=Response)
+
+
+def globally_cacheable(
+    max_age: int = 60, stale_while_revalidate: Optional[int] = None
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
+    """
+    Decorator to add Cache-Control headers for globally cacheable API responses.
+    """
+
+    def decorator(view_func: Callable[P, R]) -> Callable[P, R]:
+        @wraps(view_func)
+        def _wrapped_view(*args: P.args, **kwargs: P.kwargs) -> R:
+            # First argument is typically request
+            request: Any = args[0] if args else None
+            response: R = view_func(*args, **kwargs)
+
+            # Build Cache-Control header
+            directives = [f"public", f"max-age={max_age}"]
+            if stale_while_revalidate is not None:
+                directives.append(f"stale-while-revalidate={stale_while_revalidate}")
+
+            response["Cache-Control"] = ", ".join(directives)
+            response["X-Globally-Cacheable"] = True
+
+            return response
+
+        return _wrapped_view
+
+    return decorator

--- a/backend/coreapp/middleware.py
+++ b/backend/coreapp/middleware.py
@@ -110,3 +110,22 @@ def set_user_profile(
         return get_response(request)
 
     return middleware
+
+
+def strip_cookie_vary(
+    get_response: Callable[[HttpRequest], Response],
+) -> Callable[[Request], Response]:
+    def middleware(request: Request) -> Response:
+        response = get_response(request)
+        if getattr(response, "X-Globally-Cacheable", False):
+            if "Vary" in response:
+                vary_headers = [h.strip() for h in response["Vary"].split(",")]
+                vary_headers = [h for h in vary_headers if h.lower() != "cookie"]
+                if vary_headers:
+                    response["Vary"] = ", ".join(vary_headers)
+                else:
+                    del response["Vary"]
+            del response["X-Globally-Cacheable"]
+        return response
+
+    return middleware

--- a/backend/coreapp/views/compiler.py
+++ b/backend/coreapp/views/compiler.py
@@ -3,6 +3,7 @@ import typing
 from typing import Dict, Optional
 
 from coreapp import compilers
+from django.utils.decorators import method_decorator
 from django.utils.timezone import now
 from rest_framework.exceptions import NotFound
 from rest_framework.request import Request
@@ -12,6 +13,8 @@ from rest_framework.views import APIView
 from coreapp.models.preset import Preset
 
 from ..decorators.django import condition
+from ..decorators.cache import globally_cacheable
+
 
 boot_time = now()
 
@@ -20,6 +23,9 @@ def endpoint_updated(request: Request, **_: typing.Any) -> datetime:
     return max(Preset.most_recent_updated(request), boot_time)
 
 
+@method_decorator(
+    globally_cacheable(max_age=60, stale_while_revalidate=30), name="dispatch"
+)
 class SingleCompilerDetail(APIView):
     @condition(last_modified_func=lambda r, **_: boot_time)
     def get(
@@ -52,6 +58,9 @@ class SingleCompilerDetail(APIView):
         )
 
 
+@method_decorator(
+    globally_cacheable(max_age=60, stale_while_revalidate=30), name="dispatch"
+)
 class CompilerDetail(APIView):
     @staticmethod
     def compilers_json() -> Dict[str, Dict[str, object]]:

--- a/backend/coreapp/views/library.py
+++ b/backend/coreapp/views/library.py
@@ -1,5 +1,4 @@
-from typing import Dict
-
+from django.utils.decorators import method_decorator
 from django.utils.timezone import now
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -8,10 +7,15 @@ from rest_framework.views import APIView
 from coreapp import libraries
 
 from ..decorators.django import condition
+from ..decorators.cache import globally_cacheable
+
 
 boot_time = now()
 
 
+@method_decorator(
+    globally_cacheable(max_age=60, stale_while_revalidate=30), name="dispatch"
+)
 class LibraryDetail(APIView):
     @staticmethod
     def libraries_json(platform: str = "") -> list[dict[str, object]]:

--- a/backend/coreapp/views/platform.py
+++ b/backend/coreapp/views/platform.py
@@ -3,6 +3,8 @@ from datetime import datetime
 from coreapp import compilers
 from coreapp.models.preset import Preset
 from coreapp.views.compiler import CompilerDetail
+
+from django.utils.decorators import method_decorator
 from django.utils.timezone import now
 from rest_framework.decorators import api_view
 from rest_framework.request import Request
@@ -10,6 +12,8 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from ..decorators.django import condition
+from ..decorators.cache import globally_cacheable
+
 
 boot_time = now()
 
@@ -18,6 +22,9 @@ def endpoint_updated(request: Request) -> datetime:
     return max(Preset.most_recent_updated(request), boot_time)
 
 
+@method_decorator(
+    globally_cacheable(max_age=60, stale_while_revalidate=30), name="dispatch"
+)
 class PlatformDetail(APIView):
     @condition(last_modified_func=endpoint_updated)
     def head(self, request: Request) -> Response:
@@ -33,6 +40,7 @@ class PlatformDetail(APIView):
 
 
 @api_view(["GET"])
+@globally_cacheable(max_age=60, stale_while_revalidate=30)
 def single_platform(request: Request, id: str) -> Response:
     """
     Gets a platform's basic details including available compilers

--- a/backend/coreapp/views/preset.py
+++ b/backend/coreapp/views/preset.py
@@ -5,8 +5,12 @@ import django_filters
 from django import forms
 from django.db.models import Count
 
+from django.utils.decorators import method_decorator
+
 from rest_framework.exceptions import APIException
 from rest_framework.serializers import BaseSerializer
+
+from ..decorators.cache import globally_cacheable
 
 from ..filters.search import NonEmptySearchFilter
 
@@ -52,6 +56,9 @@ class PresetFilterSet(django_filters.FilterSet):
         fields = ["platform", "compiler", "owner"]
 
 
+@method_decorator(
+    globally_cacheable(max_age=60, stale_while_revalidate=30), name="dispatch"
+)
 class PresetViewSet(ModelViewSet):  # type: ignore
 
     permission_classes = [IsAdminUser | IsOwnerOrReadOnly]

--- a/backend/coreapp/views/scratch.py
+++ b/backend/coreapp/views/scratch.py
@@ -16,6 +16,7 @@ from django.db.models.functions import Cast
 from django.db.models.query import QuerySet
 
 from django.http import HttpResponse, QueryDict
+from coreapp.decorators.cache import globally_cacheable
 from rest_framework import filters, mixins, serializers, status
 from rest_framework.decorators import action
 from rest_framework.exceptions import APIException
@@ -520,6 +521,7 @@ class ScratchViewSet(
         )
 
     @action(detail=True)
+    @globally_cacheable(max_age=60, stale_while_revalidate=30)
     def family(self, request: Request, pk: str) -> Response:
         scratch: Scratch = self.get_object()
 

--- a/backend/coreapp/views/search.py
+++ b/backend/coreapp/views/search.py
@@ -1,6 +1,7 @@
 from rest_framework.views import APIView
 from rest_framework.response import Response
 
+from ..decorators.cache import globally_cacheable
 from ..middleware import Request
 from ..models.preset import Preset
 from ..models.scratch import Scratch
@@ -9,6 +10,7 @@ from ..serializers import PresetSerializer, TerseScratchSerializer, serialize_pr
 
 
 class SearchViewSet(APIView):
+    @globally_cacheable(max_age=60, stale_while_revalidate=30)
     def get(self, request: Request) -> Response:
         query = request.query_params.get("search", "")
         page_size = int(request.query_params.get("page_size", "5"))

--- a/backend/coreapp/views/stats.py
+++ b/backend/coreapp/views/stats.py
@@ -1,11 +1,18 @@
+from django.utils.decorators import method_decorator
+
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
+
+from ..decorators.cache import globally_cacheable
 
 from ..models.scratch import Asm, Scratch
 from ..models.github import GitHubUser
 
 
+@method_decorator(
+    globally_cacheable(max_age=60, stale_while_revalidate=30), name="dispatch"
+)
 class StatsDetail(APIView):
     def get(self, request: Request) -> Response:
         return Response(

--- a/backend/coreapp/views/user.py
+++ b/backend/coreapp/views/user.py
@@ -1,12 +1,16 @@
 import django_filters
+
 from django.contrib.auth import logout
 from django.db.models.query import QuerySet
 from django.shortcuts import get_object_or_404
+from django.utils.decorators import method_decorator
+
 from rest_framework import generics, filters
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from ..decorators.cache import globally_cacheable
 from ..middleware import Request
 from ..models.github import GitHubUser
 from ..models.profile import Profile
@@ -60,6 +64,9 @@ class CurrentUserScratchList(generics.ListAPIView):  # type: ignore
         return ScratchViewSet.queryset.filter(owner__id=self.request.profile.id)
 
 
+@method_decorator(
+    globally_cacheable(max_age=60, stale_while_revalidate=30), name="dispatch"
+)
 class UserScratchList(generics.ListAPIView):  # type: ignore
     """
     Gets a user's scratches
@@ -81,6 +88,7 @@ class UserScratchList(generics.ListAPIView):  # type: ignore
 
 
 @api_view(["GET"])  # type: ignore
+@globally_cacheable(max_age=60, stale_while_revalidate=30)
 def user(request: Request, username: str) -> Response:
     """
     Gets a user's basic data

--- a/backend/decompme/settings.py
+++ b/backend/decompme/settings.py
@@ -80,6 +80,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    "coreapp.middleware.strip_cookie_vary",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "corsheaders.middleware.CorsMiddleware",


### PR DESCRIPTION
The general idea is to add a 60 second cache to all GET endpoints. We can see how this goes and potentially increase/decrease based on feedback.