### PR TITLE
Correct 'uv' command in daily chores

### DIFF
--- a/.github/workflows/chores.yaml
+++ b/.github/workflows/chores.yaml
@@ -25,7 +25,7 @@ jobs:
         run: pip install uv
 
       - name: Update m2c & asm-differ
-        run: cd backend && uv pip install --upgrade m2c asm-differ
+        run: cd backend && uv lock --upgrade-package m2c --upgrade-package asm-differ
 
       - name: Check for changes
         run: |


### PR DESCRIPTION
Fixup the broken daily chores (e.g. https://github.com/decompme/decomp.me/actions/runs/17965375327/job/51096924413)

> error: No virtual environment found; run `uv venv` to create an environment, or pass `--system` to install into a non-virtual environment
> Error: Process completed with exit code 2.