### PR TITLE
Silence '--platform flag should not use constant value' linter warning

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,3 +1,4 @@
+# hadolint ignore=DL3029
 FROM --platform=linux/amd64 ubuntu:24.04 AS base
 
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
so chatgpt has lied to me. still produces the warning

> #1 WARN: FromPlatformFlagConstDisallowed: FROM --platform flag should not use constant value "linux/amd64" (line 2)
