### PR TITLE
Fix 500 when creating scratches with a preset that have libraries

### DIFF
--- a/backend/coreapp/serializers.py
+++ b/backend/coreapp/serializers.py
@@ -155,7 +155,7 @@ class ScratchCreateSerializer(serializers.Serializer[None]):
     target_obj = serializers.FileField(allow_null=True, required=False)
     context = serializers.CharField(allow_blank=True)  # type: ignore
     diff_label = serializers.CharField(allow_blank=True, required=False)
-    libraries = serializers.ListField(child=LibrarySerializer(), default=list)
+    libraries = serializers.JSONField(default=list)
 
     project = serializers.CharField(allow_blank=False, required=False)
     rom_address = serializers.IntegerField(required=False)

--- a/backend/coreapp/serializers.py
+++ b/backend/coreapp/serializers.py
@@ -174,7 +174,9 @@ class ScratchCreateSerializer(serializers.Serializer[None]):
             raise serializers.ValidationError(f"Unknown compiler: {compiler}")
         return compiler
 
-    def validate_libraries(self, libraries: list[dict[str, str]]) -> list[dict[str, str]]:
+    def validate_libraries(
+        self, libraries: list[dict[str, str]]
+    ) -> list[dict[str, str]]:
         for library in libraries:
             for key in ["name", "version"]:
                 if key not in library:

--- a/backend/coreapp/serializers.py
+++ b/backend/coreapp/serializers.py
@@ -155,7 +155,7 @@ class ScratchCreateSerializer(serializers.Serializer[None]):
     target_obj = serializers.FileField(allow_null=True, required=False)
     context = serializers.CharField(allow_blank=True)  # type: ignore
     diff_label = serializers.CharField(allow_blank=True, required=False)
-    libraries = serializers.JSONField(default=list)
+    libraries = serializers.JSONField(default=list)  # type: ignore
 
     project = serializers.CharField(allow_blank=False, required=False)
     rom_address = serializers.IntegerField(required=False)
@@ -174,7 +174,7 @@ class ScratchCreateSerializer(serializers.Serializer[None]):
             raise serializers.ValidationError(f"Unknown compiler: {compiler}")
         return compiler
 
-    def validate_libraries(self, libraries: list[dict[str, str]]):
+    def validate_libraries(self, libraries: list[dict[str, str]]) -> list[dict[str, str]]:
         for library in libraries:
             for key in ["name", "version"]:
                 if key not in library:

--- a/backend/coreapp/serializers.py
+++ b/backend/coreapp/serializers.py
@@ -174,6 +174,13 @@ class ScratchCreateSerializer(serializers.Serializer[None]):
             raise serializers.ValidationError(f"Unknown compiler: {compiler}")
         return compiler
 
+    def validate_libraries(self, libraries: list[dict[str, str]]):
+        for library in libraries:
+            for key in ["name", "version"]:
+                if key not in library:
+                    raise serializers.ValidationError(f"Library {library} is missing '{key}' key")
+        return libraries
+
     def validate(self, data: Dict[str, Any]) -> Dict[str, Any]:
         if "preset" in data:
             preset: Preset = data["preset"]

--- a/backend/coreapp/serializers.py
+++ b/backend/coreapp/serializers.py
@@ -178,7 +178,9 @@ class ScratchCreateSerializer(serializers.Serializer[None]):
         for library in libraries:
             for key in ["name", "version"]:
                 if key not in library:
-                    raise serializers.ValidationError(f"Library {library} is missing '{key}' key")
+                    raise serializers.ValidationError(
+                        f"Library {library} is missing '{key}' key"
+                    )
         return libraries
 
     def validate(self, data: Dict[str, Any]) -> Dict[str, Any]:

--- a/backend/coreapp/views/scratch.py
+++ b/backend/coreapp/views/scratch.py
@@ -229,7 +229,9 @@ def create_scratch(data: Dict[str, Any], allow_project: bool = False) -> Scratch
 
     name = data.get("name", diff_label) or "Untitled"
 
-    libraries = [Library(**lib) if isinstance(lib, dict) else lib for lib in data["libraries"]]
+    libraries = [
+        Library(**lib) if isinstance(lib, dict) else lib for lib in data["libraries"]
+    ]
 
     ser = ScratchSerializer(
         data={

--- a/backend/coreapp/views/scratch.py
+++ b/backend/coreapp/views/scratch.py
@@ -229,7 +229,7 @@ def create_scratch(data: Dict[str, Any], allow_project: bool = False) -> Scratch
 
     name = data.get("name", diff_label) or "Untitled"
 
-    libraries = [Library(**lib) for lib in data["libraries"]]
+    libraries = [Library(**lib) if isinstance(lib, dict) else lib for lib in data["libraries"]]
 
     ser = ScratchSerializer(
         data={


### PR DESCRIPTION
This PR fixes iFarbod's issue and closes out #1684.

...by the time we get to this line, `data["libraries"]` will already be a list of Library objects.

Once merged users can specify a preset that has libraries or alternatively manually select the libraries... something like:

```py
with open(target_o, "rb") as f:
    data = {
        "platform": "win32",
        "compiler": "msvc6.0",
        "context": "",
        "source_code": "",
        # "preset": 175,
        "libraries": json.dumps([{"name": "directx", "version": "9.0"}]),
    }

    files = {
        "target_obj": ("target.o", f),
    }

    res = requests.post(
        f"{DECOMPME_URL}/api/scratch",
        files=files,
        data=data,
    )
    ```
