### PR TITLE
Add more dreamcast compilers

### DIFF
--- a/backend/compilers/compilers.linux.yaml
+++ b/backend/compilers/compilers.linux.yaml
@@ -189,8 +189,11 @@ dreamcast:
   - shc-v5.0r31
   - shc-v5.0r32
   - shc-v5.1r01
+  - shc-v5.1r03
+  - shc-v5.1r04
   - shc-v5.1r08
   - shc-v5.1r11
+  - shc-v5.1r13
 
 macosx:
   - gcc-5026

--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -531,8 +531,11 @@ SHC_V50R28 = SHCCompiler(id="shc-v5.0r28", platform=DREAMCAST, cc=DREAMCAST_CC)
 SHC_V50R31 = SHCCompiler(id="shc-v5.0r31", platform=DREAMCAST, cc=DREAMCAST_CC)
 SHC_V50R32 = SHCCompiler(id="shc-v5.0r32", platform=DREAMCAST, cc=DREAMCAST_CC)
 SHC_V51R01 = SHCCompiler(id="shc-v5.1r01", platform=DREAMCAST, cc=DREAMCAST_CC)
+SHC_V51R03 = SHCCompiler(id="shc-v5.1r03", platform=DREAMCAST, cc=DREAMCAST_CC)
+SHC_V51R04 = SHCCompiler(id="shc-v5.1r04", platform=DREAMCAST, cc=DREAMCAST_CC)
 SHC_V51R08 = SHCCompiler(id="shc-v5.1r08", platform=DREAMCAST, cc=DREAMCAST_CC)
 SHC_V51R11 = SHCCompiler(id="shc-v5.1r11", platform=DREAMCAST, cc=DREAMCAST_CC)
+SHC_V51R13 = SHCCompiler(id="shc-v5.1r13", platform=DREAMCAST, cc=DREAMCAST_CC)
 
 # PS2
 IOP_GCC281 = GCCPS2Compiler(
@@ -1583,8 +1586,11 @@ _all_compilers: List[Compiler] = [
     SHC_V50R31,
     SHC_V50R32,
     SHC_V51R01,
+    SHC_V51R03,
+    SHC_V51R04,
     SHC_V51R08,
     SHC_V51R11,
+    SHC_V51R13,
     # PS2
     IOP_GCC281,
     IOP_GCC2952_102,

--- a/frontend/src/lib/i18n/locales/en/compilers.json
+++ b/frontend/src/lib/i18n/locales/en/compilers.json
@@ -202,8 +202,11 @@
     "shc-v5.0r31": "SHC v5.0 (Release 31)",
     "shc-v5.0r32": "SHC v5.0 (Release 32)",
     "shc-v5.1r01": "SHC v5.1 (Release 1)",
+    "shc-v5.1r03": "SHC v5.1 (Release 3)",
+    "shc-v5.1r04": "SHC v5.1 (Release 4)",
     "shc-v5.1r08": "SHC v5.1 (Release 8)",
     "shc-v5.1r11": "SHC v5.1 (Release 11)",
+    "shc-v5.1r13": "SHC v5.1 (Release 13)",
 
     "psyq3.3": "PSYQ3.3 (gcc 2.6.0 + aspsx 2.21)",
     "psyq3.5": "PSYQ3.5 (gcc 2.6.0 + aspsx 2.34)",


### PR DESCRIPTION
Relies on https://github.com/decompme/compilers/issues/44
Seems to work fine locally by manually copying the compilers into backend/compilers/dreamcast