### PR TITLE
Fix bug in scratch language detection

### DIFF
--- a/backend/coreapp/serializers.py
+++ b/backend/coreapp/serializers.py
@@ -271,25 +271,17 @@ class ScratchSerializer(serializers.ModelSerializer[Scratch]):
             None,
         )
 
-        # We sort by match length to avoid having a partial match
         if language_flag_set:
-            language = next(
-                iter(
-                    sorted(
-                        (
-                            (flag, language)
-                            for flag, language in language_flag_set.flags.items()
-                            if flag in scratch.compiler_flags
-                        ),
-                        key=lambda lang: len(lang[0]),
-                        reverse=True,
-                    )
-                ),
-                None,
-            )
+            matches = [
+                (flag, language)
+                for flag, language in language_flag_set.flags.items()
+                if flag in scratch.compiler_flags
+            ]
 
-            if language:
-                return language[1].value
+            if matches:
+                # taking the longest avoids detecting C++ as C
+                longest_match = max(matches, key=lambda m: len(m[0]))
+                return longest_match[1].value
 
         # If we're here, either the compiler doesn't have a LanguageFlagSet, or the scratch doesn't
         # have a flag within it.


### PR DESCRIPTION
This fixes how we detect the scratch language based on the language flag that is serialized. It used to detect C++ as C, because the string starts with C.

Thanks to this, the language server can properly work with C++ code. The file extension of `src`, `ctx` and `code` is still using the compiler's default language though, as scratches don't have a language field in the backend yet. We would ideally add such a field and parse the flag at POST requests.

I took this from my stalled m2c PR.