### PR TITLE
Update to wibo 1.0.0-alpha.4

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -80,7 +80,7 @@ RUN wget http://security.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3
 
 COPY --from=nsjail /nsjail/nsjail /bin/nsjail
 
-COPY --from=ghcr.io/decompals/wibo:0.6.16 /usr/local/sbin/wibo /usr/bin/
+COPY --from=ghcr.io/decompals/wibo:1.0.0-alpha.4 /usr/local/sbin/wibo /usr/bin/
 
 # Patched mips binutils
 RUN wget "https://github.com/decompals/binutils-mips-ps2-decompals/releases/download/v0.4/binutils-mips-ps2-decompals-linux-x86-64.tar.gz" \

--- a/backend/compilers/compilers.linux.yaml
+++ b/backend/compilers/compilers.linux.yaml
@@ -1,3 +1,6 @@
+common:
+  - wibo_dlls
+
 gba:
   - agbcc
   - agbccpp

--- a/backend/coreapp/compiler_wrapper.py
+++ b/backend/coreapp/compiler_wrapper.py
@@ -195,6 +195,7 @@ class CompilerWrapper:
                         for lib in libraries
                     )
                 )
+                wibo_path = settings.COMPILER_BASE_PATH / "common" / "wibo_dlls"
                 compile_proc = sandbox.run_subprocess(
                     cc_cmd,
                     mounts=(
@@ -205,6 +206,7 @@ class CompilerWrapper:
                         "PATH": PATH,
                         "WINE": WINE,
                         "WIBO": WIBO,
+                        "WIBO_PATH": sandbox.rewrite_path(wibo_path),
                         "INPUT": sandbox.rewrite_path(code_path),
                         "OUTPUT": sandbox.rewrite_path(object_path),
                         "COMPILER_DIR": sandbox.rewrite_path(compiler.path),


### PR DESCRIPTION
Relies on https://github.com/decompme/compilers/pull/48. The `WIBO_PATH` variable is set to `/compilers/common/wibo_dlls` which contains various msvcrt versions.

wibo 1.0.0-alpha.4 passes the cromper test suite with only a single exception: `ee_gcc3_2_030210_beta2`, blocked on some cygwin strangeness.