### PR TITLE
Use alternate method to inject COMPILER_ARGS for N64 EGCS compilers

### DIFF
--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -938,7 +938,7 @@ EGCS1124 = GCCCompiler(
     platform=N64,
     cc=(
         PYTHON_SHLEX
-        + 'COMPILER_PATH="${COMPILER_DIR}" "${COMPILER_DIR}/mips-linux-gcc" "${FLAGS[@]}" -c -G 0 -fno-PIC -mgp32 -mfp32 -mcpu=4300 -nostdinc "${INPUT}" -o "${OUTPUT}"'
+        + 'COMPILER_PATH="${COMPILER_DIR}" "${COMPILER_DIR}/mips-linux-gcc" -c -G 0 -fno-PIC -mgp32 -mfp32 -mcpu=4300 -nostdinc "${FLAGS[@]}" "${INPUT}" -o "${OUTPUT}"'
     ),
 )
 
@@ -947,7 +947,7 @@ EGCS1124C = GCCCompiler(
     platform=N64,
     cc=(
         PYTHON_SHLEX
-        + 'COMPILER_PATH="${COMPILER_DIR}" "${COMPILER_DIR}/gcc" "${FLAGS[@]}" -c -G 0 -fno-PIC -mgp32 -mfp32 -mcpu=4300 -nostdinc "${INPUT}" -o "${OUTPUT}"'
+        + 'COMPILER_PATH="${COMPILER_DIR}" "${COMPILER_DIR}/gcc" -c -G 0 -fno-PIC -mgp32 -mfp32 -mcpu=4300 -nostdinc "${FLAGS[@]}" "${INPUT}" -o "${OUTPUT}"'
     ),
 )
 


### PR DESCRIPTION
The advantage of this over the `printf` + `xargs` approach is that this allows us to control the *placement* of the COMPILER_FLAGS (rather than being placed at the end of the command)

Fixes #1699.