### PR TITLE
Avoid POST-ing to /compile on initial scratch load

### DIFF
--- a/backend/coreapp/views/scratch.py
+++ b/backend/coreapp/views/scratch.py
@@ -396,7 +396,7 @@ class ScratchViewSet(
             and len(compilation.elf_object) > 0,
         }
 
-        if include_objects:
+        if include_objects or request.method == "GET":
 
             def to_base64(obj: bytes) -> str:
                 return base64.b64encode(obj).decode("utf-8")

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 
 import { useRouter } from "next/navigation";
 
@@ -242,6 +242,7 @@ export function useCompilation(
     const [isCompilationOld, setIsCompilationOld] = useState(false);
     const [objdiffClientEnabled] = useObjdiffClientEnabled();
     const sUrl = scratchUrl(scratch);
+    const hasInitialized = useRef(false);
 
     const compile = useCallback(() => {
         if (compileRequestPromise) return compileRequestPromise;
@@ -313,8 +314,11 @@ export function useCompilation(
     });
 
     useEffect(() => {
-        if (!compilation) {
-            compile();
+        if (!hasInitialized.current) {
+            hasInitialized.current = true;
+            if (!compilation) {
+                compile();
+            }
         } else {
             setIsCompilationOld(true);
 


### PR DESCRIPTION
The `useDebouncedCallback` would always trigger a call to `/compile` on initial load.. Now we only call `/compile` if required during the initial load of the Scratch (i.e. no initial compilation).

This means we need to send back the left/right objects as part of a GET (for the scenario where the user is using objdiff - which is becoming more and more likely) - I think this is still much better than triggering a compilation request every time a Scratch is loaded. 