### PR TITLE
Display banner when another scratch improves upon current scratch

### DIFF
--- a/frontend/src/components/DismissableBanner.module.scss
+++ b/frontend/src/components/DismissableBanner.module.scss
@@ -9,7 +9,6 @@
     grid-template-columns: 1fr 2em;
 
     color: rgba(255, 255, 255, 0.75);
-    background: #4273e1;
 }
 
 .content {

--- a/frontend/src/components/DismissableBanner.tsx
+++ b/frontend/src/components/DismissableBanner.tsx
@@ -8,13 +8,17 @@ import styles from "./DismissableBanner.module.scss";
 export default function DismissableBanner({
     className,
     children,
-}: { className?: string; children?: ReactNode }) {
+    color = "#4273e1",
+}: { className?: string; children?: ReactNode; color: string }) {
     const [isOpen, setIsOpen] = useState(true);
 
     if (!isOpen) return null;
 
     return (
-        <div className={clsx(styles.container, className)}>
+        <div
+            className={clsx(styles.container, className)}
+            style={{ backgroundColor: color }}
+        >
             <div className={styles.content}>{children}</div>
             <button
                 title="Dismiss"

--- a/frontend/src/components/Scratch/ScratchMatchBanner.tsx
+++ b/frontend/src/components/Scratch/ScratchMatchBanner.tsx
@@ -6,6 +6,7 @@ import * as api from "@/lib/api";
 import { scratchUrl } from "@/lib/api/urls";
 
 import DismissableBanner from "../DismissableBanner";
+import { calculateScorePercent, percentToString } from "../ScoreBadge";
 
 export default function ScratchMatchBanner({
     scratch,
@@ -34,12 +35,20 @@ export default function ScratchMatchBanner({
 
     if (scratch.score === 0 || !match) return null;
 
-    let message = `This function has been ${match.score === 0 ? "matched" : `improved (score: ${match.score.toLocaleString("en-US")})`}`;
+    const isMatch = match.score === 0;
+
+    const percent = calculateScorePercent(match.score, match.max_score);
+    const percentString = percent !== 0 ? percentToString(percent) : "";
+
+    let message = `This function has ${isMatch ? "been matched" : "a lower-scoring scratch"}`;
     if (userIsYou(match.owner)) message += " by you, elsewhere";
     else if (match.owner) message += ` by ${match.owner.username}`;
 
+    if (!isMatch)
+        message += `. Improved score is ${match.score.toLocaleString("en-US")} ${percentString && `(${percentString})`}`;
+
     return (
-        <DismissableBanner>
+        <DismissableBanner color={isMatch ? "#951fd9" : "#4273e1"}>
             {message}.{" "}
             <Link href={scratchUrl(match)}>
                 View {match.score === 0 ? "match" : "improvement"}


### PR DESCRIPTION
Potentially controversial but I don't think so... Show the blue banner if any scratches in the family have a better score. 

I contemplated with having a different colour for the banner for match vs improved, but a) not sure what colour and b) this could be a separate PR based on user feedback.

Closes #https://github.com/decompme/decomp.me/issues/817 (somewhat indirectly?)