### PR TITLE
Add GHS dotciscxx flag to compile as C++

### DIFF
--- a/backend/coreapp/flags.py
+++ b/backend/coreapp/flags.py
@@ -310,6 +310,7 @@ COMMON_GHS_FLAGS: Flags = [
     Checkbox("ghs_enable_noinline", "--enable_noinline"),
     Checkbox("ghs_link_once_templates", "--link_once_templates"),
     Checkbox("ghs_only_explicit_reg_use", "-only_explicit_reg_use"),
+    Checkbox("ghs_dotciscxx", "-dotciscxx"),
 ]
 
 COMMON_MSVC_FLAGS: Flags = [

--- a/frontend/src/lib/i18n/locales/en/compilers.json
+++ b/frontend/src/lib/i18n/locales/en/compilers.json
@@ -383,6 +383,8 @@
     "mwcc_line_numbers_on": "Enable debug info (C line numbers)",
     "mwcc_align_powerpc": "PowerPC alignment; default",
 
+    "ghs_dotciscxx": "Treat all files as C++ files",
+
     "msvc_opt_level": "Optimization level",
     "msvc_opt_level./O1": "minimize space",
     "msvc_opt_level./O2": "maximize speed",


### PR DESCRIPTION
With GHS, `ccppc` and `cxppc` both determine the file type by its extension. Since the files the scratch uses are called `ctx.c` and `code.c`, they're treated as C files. The flag `dotciscxx` is needed to treat them as C++ files instead.