### PR TITLE
vertically align avatar/name in UserLink

### DIFF
--- a/frontend/src/components/user/UserLink.tsx
+++ b/frontend/src/components/user/UserLink.tsx
@@ -17,10 +17,10 @@ export default function UserLink({ user, showUsername }: Props) {
     const url: string | null = isAnonUser(user) ? null : `/u/${user.username}`;
 
     const inner = (
-        <>
-            <UserAvatar user={user} className="mr-1 size-4 align-middle" />
+        <div className="flex flex-row items-center">
+            <UserAvatar user={user} className="mr-1 size-5" />
             {showUsername !== false && <span>{user.username}</span>}
-        </>
+        </div>
     );
 
     if (!url) {


### PR DESCRIPTION
I was triggered by this screenshot so have tweaked the alignment so the avatar and name should be aligned vertically now...

<img width="489" height="532" alt="image" src="https://github.com/user-attachments/assets/816a7aea-5a4b-4ba5-b01c-f9334e5bf21a" />
