### PR TITLE
Add 24 hour caching of public images

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -64,6 +64,16 @@ let app = removeImports({
                     },
                 ],
             },
+            {
+                // cache images for 24 hours
+                source: "/:all*(png|jpg|jpeg|gif|svg|ico|webp)",
+                headers: [
+                    {
+                        key: "Cache-Control",
+                        value: "public, max-age=86400, stale-while-revalidate=86400",
+                    },
+                ],
+            },
         ];
     },
     webpack(config) {


### PR DESCRIPTION
We don't currently have any caching configured for these images (purple frog etc) which means they are served from the frontend every fetch... Adding 24 hour cache means they'll be cached at CloudFlare - i could have made them immutable, but 24 hour cache means we wont run into caching issues if we tweak them (without renaming).