### PR TITLE
Remove exposed ports from dev docker compose config

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,11 +1,9 @@
 services:
   postgres:
-    image: postgres:17
+    image: docker.io/library/postgres:17
     environment:
       POSTGRES_USER: decompme
       POSTGRES_PASSWORD: decompme
-    ports:
-      - "5432:5432"
     volumes:
       - ./postgres:/var/lib/postgresql/data
   backend:
@@ -23,7 +21,6 @@ services:
     env_file:
       - backend/docker.dev.env
     ports:
-      - "8000:8000"
       - "5678:5678"  # vscode debugger
     security_opt:
       - apparmor=unconfined
@@ -41,15 +38,13 @@ services:
     environment:
       API_BASE: /api
       INTERNAL_API_BASE: http://backend:8000/api
-    ports:
-      - "8080:8080"
     volumes:
       - ./frontend:/frontend
       - .env:/.env
   nginx:
-    image: nginx:1.28-alpine
+    image: docker.io/library/nginx:1.28-alpine
     ports:
-      - "80:80"
+      - "8080:80"
     volumes:
       - ./nginx/development.conf:/etc/nginx/conf.d/default.conf:ro
       - ./nginx/geo.conf:/etc/nginx/conf.d/geo.conf:ro


### PR DESCRIPTION
This removes unnecessarily exposed ports from the dev docker-compose.yml. Since the application communicates with these services using the internal docker network, they aren't necessary to be exposed on the host. This avoids port conflicts with frequently-used ports. Additionally, this makes the nginx service bind to port `8080`, which matches the port you'd use to access the site if using regular `yarn dev`.

For compatibility with non-Docker container engines, explicitly specifies `docker.io/library/` prefix for container image refs.