### PR TITLE
Don't break on objdump for Android x86

### DIFF
--- a/backend/coreapp/platforms.py
+++ b/backend/coreapp/platforms.py
@@ -270,6 +270,8 @@ ANDROID_X86 = Platform(
     assemble_cmd='i686-linux-android-as -o "$OUTPUT" "$PRELUDE" "$INPUT"',
     objdump_cmd="i686-linux-android-objdump",
     nm_cmd="i686-linux-android-nm",
+    # While it supports disassembly, it doesn't allow specifying a symbol.
+    supports_objdump_disassemble=False,
 )
 
 _platforms: OrderedDict[str, Platform] = OrderedDict(


### PR DESCRIPTION
Currently, the site attempts to pass a specific symbol to objdump --disassemble, which is unsupported in this version.