### PR TITLE
Use x86_64 binutils package for android objdump/nm

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -55,6 +55,7 @@ RUN dpkg --add-architecture i386 \
     binutils-mipsel-linux-gnu \
     binutils-powerpc-linux-gnu \
     binutils-sh-elf \
+    binutils-x86-64-linux-gnu \
     bzip2 \
     cpp \
     dj64 \

--- a/backend/coreapp/platforms.py
+++ b/backend/coreapp/platforms.py
@@ -268,10 +268,8 @@ ANDROID_X86 = Platform(
     description="i686",
     arch="i686",
     assemble_cmd='i686-linux-android-as -o "$OUTPUT" "$PRELUDE" "$INPUT"',
-    objdump_cmd="i686-linux-android-objdump",
-    nm_cmd="i686-linux-android-nm",
-    # While it supports disassembly, it doesn't allow specifying a symbol.
-    supports_objdump_disassemble=False,
+    objdump_cmd="x86_64-linux-gnu-objdump",
+    nm_cmd="x86_64-linux-gnu-nm",
 )
 
 _platforms: OrderedDict[str, Platform] = OrderedDict(


### PR DESCRIPTION
the era-correct android binutils does not support `--disassemble=SYMBOL` so use modern binutils instead.