### PR TITLE
Ensure .sh files are checked out with LF (not CRLF)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
Avoids the shell scripts being checked out on Windows as 
```
#!/usr/bin/bash\r\n
```

which obviously breaks :(

closes #1800.