### PR TITLE
Ensure geo.conf is loaded before default.conf

### DIFF
--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -54,7 +54,7 @@ services:
     volumes:
       # repo files
       - ./nginx/production.conf:/etc/nginx/conf.d/default.conf:ro
-      - ./nginx/geo.conf:/etc/nginx/conf.d/geo.conf:ro
+      - ./nginx/geo.conf:/etc/nginx/conf.d/000_geo.conf:ro
       - ./frontend/down.html:/var/www/decomp.me/down.html:ro
       # certbot
       - ./certbot:/var/www/certbot

--- a/nginx/production.conf
+++ b/nginx/production.conf
@@ -1,5 +1,3 @@
-include /etc/nginx/conf.d/geo.conf;
-
 server {
     listen 80;
     server_name decomp.me www.decomp.me;


### PR DESCRIPTION
1. Removing the explicit include of `geo.conf` because the default nginx config (/etc/nginx) is explicitly including all .conf files:

```
include /etc/nginx/conf.d/*.conf;
```

2. mounting geo.conf as 000_geo.conf so it gets loaded first (before default.conf)

NOTE: already made this change manually on the box because I noticed we were not logging remote IPs (instead we logged cloudflare ip twice)