### PR TITLE
debug ci...

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,7 @@ jobs:
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
           export USER_1000=$(getent passwd 1000 | cut -d: -f1)
           mkdir -p local_files && sudo chown ${USER_1000}:${USER_1000} local_files
+          ls -al $(pwd)/backend/compilers
           docker run \
             -v $(pwd)/local_files:/local_files \
             -v $(pwd)/backend/compilers:/compilers \
@@ -99,6 +100,7 @@ jobs:
             decompme_backend \
               -c '\
               for r in wine/*.reg; do regedit $r; done && \
+              ls -al /compilers && \
               uv run python manage.py test'
 
   docker_compose_test:


### PR DESCRIPTION
creating a PR to trigger CI.. because

```
Ran 248 tests in 29.105s
OK (skipped=14)
Destroying test database for alias 'default'...
Compiler psyq4.3 not found at /compilers/ps1/psyq4.3
Compiler psyq4.4 not found at /compilers/ps1/psyq4.4
Compiler gcc2.8.1-psx not found at /compilers/ps1/gcc2.8.1-psx
Compiler gcc2.7.0-mipsel not found at /compilers/ps1/gcc2.7.0-mipsel
Compiler gcc2.7.2.2-mipsel not found at /compilers/ps1/gcc2.7.2.2-mipsel
Compiler mwccpsp_3.0.1_134 not found at /compilers/psp/mwccpsp_3.0.1_134
Compiler mwccpsp_3.0.1_180 not found at /compilers/psp/mwccpsp_3.0.1_180
Compiler mwccpsp_3.0.1_201 not found at /compilers/psp/mwccpsp_3.0.1_201
Compiler mwccpsp_3.0.1_205 not found at /compilers/psp/mwccpsp_3.0.1_205
Compiler mwccpsp_3.0.1_210 not found at /compilers/psp/mwccpsp_3.0.1_210
Compiler shc-v5.0r10 not found at /compilers/dreamcast/shc-v5.0r10
Compiler shc-v5.0r26 not found at /compilers/dreamcast/shc-v5.0r26
Compiler shc-v5.0r28 not found at /compilers/dreamcast/shc-v5.0r28
Compiler shc-v5.1r08 not found at /compilers/dreamcast/shc-v5.1r08
Compiler shc-v5.1r13 not found at /compilers/dreamcast/shc-v5.1r13
Compiler ee-gcc2.9-990721 not found at /compilers/ps2/ee-gcc2.9-990721
Compiler ee-gcc2.9-991111-01 not found at /compilers/ps2/ee-gcc2.9-991111-01
Compiler mwcps2-3.0.1b51-030512 not found at /compilers/ps2/mwcps2-3.0.1b51-030512
Compiler mwcps2-3.0.1b75-030916 not found at /compilers/ps2/mwcps2-3.0.1b75-030916
Compiler mwcps2-3.0.1b87-031208 not found at /compilers/ps2/mwcps2-3.0.1b87-031208
Compiler mwcps2-3.0.1b119-040914 not found at /compilers/ps2/mwcps2-3.0.1b119-040914
Compiler mwcps2-3.0.1b145-050209 not found at /compilers/ps2/mwcps2-3.0.1b145-050209
Compiler mwcps2-3.0.1b210-060308 not found at /compilers/ps2/mwcps2-3.0.1b210-060308
Compiler ido5.3 not found at /compilers/n64/ido5.3
Compiler ido6.0 not found at /compilers/n64/ido6.0
Compiler ido7.1 not found at /compilers/n64/ido7.1
Compiler gcc2.7.2kmc not found at /compilers/n64/gcc2.7.2kmc
Compiler gcc2.7.2sn0006 not found at /compilers/n64/gcc2.7.2sn0006
Compiler gcc2.7.2sn0006-cxx not found at /compilers/n64/gcc2.7.2sn0006
Compiler egcs_1.1.2-4 not found at /compilers/n64/egcs_1.1.2-4
Compiler ido5.3_irix not found at /compilers/n64/ido5.3
Compiler ido5.3_asm_irix not found at /compilers/n64/ido5.3
Compiler ido5.3Pascal not found at /compilers/n64/ido5.3
Compiler ido6.0_irix not found at /compilers/n64/ido6.0
Compiler ido7.1_irix not found at /compilers/n64/ido7.1
Compiler ido7.1Pascal not found at /compilers/n64/ido7.1
Compiler prodg_393 not found at /compilers/gc_wii/prodg_393
Compiler gcc-5363 not found at /compilers/macosx/gcc-5363
Compiler gcc-5363-cpp not found at /compilers/macosx/gcc-5363
Compiler gcc-5026 not found at /compilers/macosx/gcc-5026
Compiler gcc-5026-cpp not found at /compilers/macosx/gcc-5026
Compiler wcc10.5 not found at /compilers/msdos/wcc10.5
Compiler wpp10.5 not found at /compilers/msdos/wcc10.5
Compiler wcc11.0 not found at /compilers/msdos/wcc11.0
Compiler wpp11.0 not found at /compilers/msdos/wcc11.0
Compiler bcc3.1 not found at /compilers/msdos/bcc3.1
Compiler ido5.3 not found at /compilers/n64/ido5.3
Compiler ido5.3 not found at /compilers/n64/ido5.3
Compiler ido7.1 not found at /compilers/n64/ido7.1
Compiler wcc10.5 not found at /compilers/msdos/wcc10.5
Compiler ido7.1 not found at /compilers/n64/ido7.1
Compiler ido5.3 not found at /compilers/n64/ido5.3
Compiler ido7.1 not found at /compilers/n64/ido7.1
Compiler ido7.1 not found at /compilers/n64/ido7.1
Compiler ido7.1 not found at /compilers/n64/ido7.1
Compiler ido5.3 not found at /compilers/n64/ido5.3
Compiler ido7.1 not found at /compilers/n64/ido7.1
Compiler ido7.1 not found at /compilers/n64/ido7.1
Compiler ido7.1 not found at /compilers/n64/ido7.1
Compiler ido7.1 not found at /compilers/n64/ido7.1
Found 248 test(s).
```