### PR TITLE
Add ido4.1

### DIFF
--- a/backend/compilers/compilers.linux.yaml
+++ b/backend/compilers/compilers.linux.yaml
@@ -49,6 +49,7 @@ n64:
   - gcc2.7.2snew
   - gcc2.8.1pm
   - gcc2.8.1sn
+  - ido4.1
   - ido5.3
   - ido5.3_c++
   - ido6.0

--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -855,7 +855,17 @@ MWCCPSP_3_0_1_219 = MWCCPSPCompiler(
     cc=MWCCPSP_CC,
 )
 
+MWCCEPPC_CC = 'printf "%s" "${COMPILER_FLAGS}" | xargs -x -- ${WIBO} "${COMPILER_DIR}/mwcceppc.exe" -pragma "msg_show_realref off" -c -proc gekko -nostdinc -stderr -o "${OUTPUT}" "${INPUT}"'
+
+IDO_41_CC = '"${COMPILER_DIR}"/usr/bin/qemu-irix-4.0 -silent -L "${COMPILER_DIR}" "${COMPILER_DIR}/usr/bin/cc" -I "{COMPILER_DIR}"/usr/include -EL -c -Xcpluscomm -G0 -non_shared ${COMPILER_FLAGS} -o "${OUTPUT}" "${INPUT}"'
 # N64
+IDO41 = IDOCompiler(
+    id="ido4.1",
+    platform=N64,
+    cc=IDO_41_CC
+    + '&& python3  "${COMPILER_DIR}"/usr/bin/ecoff_tool.py --convert-elf "$OUTPUT" -o "$OUTPUT"',
+)
+
 IDO53 = IDOCompiler(
     id="ido5.3",
     platform=N64,
@@ -1736,6 +1746,7 @@ _all_compilers: List[Compiler] = [
     MWCPS2_301B205_051227,
     MWCPS2_301B210_060308,
     # N64
+    IDO41,
     IDO53,
     IDO53_CXX,
     IDO60,

--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -855,8 +855,6 @@ MWCCPSP_3_0_1_219 = MWCCPSPCompiler(
     cc=MWCCPSP_CC,
 )
 
-MWCCEPPC_CC = 'printf "%s" "${COMPILER_FLAGS}" | xargs -x -- ${WIBO} "${COMPILER_DIR}/mwcceppc.exe" -pragma "msg_show_realref off" -c -proc gekko -nostdinc -stderr -o "${OUTPUT}" "${INPUT}"'
-
 IDO_41_CC = '"${COMPILER_DIR}"/usr/bin/qemu-irix-4.0 -silent -L "${COMPILER_DIR}" "${COMPILER_DIR}/usr/bin/cc" -I "{COMPILER_DIR}"/usr/include -EL -c -Xcpluscomm -G0 -non_shared ${COMPILER_FLAGS} -o "${OUTPUT}" "${INPUT}"'
 # N64
 IDO41 = IDOCompiler(

--- a/frontend/src/lib/i18n/locales/en/compilers.json
+++ b/frontend/src/lib/i18n/locales/en/compilers.json
@@ -95,6 +95,7 @@
 
     "ido6.0": "IDO 6.0",
     "ido7.1_irix": "IDO 7.1",
+    "ido4.1": "IDO 4.1",
     "ido5.3": "IDO 5.3",
     "ido5.3_c++": "IDO 5.3 C++",
     "ido5.3Pascal": "IDO 5.3 Pascal",


### PR DESCRIPTION
## Important info

- Debug flags are not supported yet
- The compile command uses a tool named [`ecoff_tool`](https://gist.github.com/Mc-muffin/74bc79cb84988cf4ad3b4bc64c58d3be) (made by @Mc-muffin) to convert the output ECOFF object in to an ELF file
