### PR TITLE
Add sha256sum checks to archives downloaded in Dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -49,12 +49,25 @@ FROM base AS binutils
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
+    binutils-aarch64-linux-gnu \
+    binutils-arm-none-eabi \
+    binutils-djgpp \
+    binutils-mingw-w64-i686 \
+    binutils-mips-linux-gnu \
+    binutils-mipsel-linux-gnu \
+    binutils-powerpc-linux-gnu \
+    binutils-sh-elf \
+    binutils-x86-64-linux-gnu \
     bzip2 \
     libarchive-tools \
     wget \
     && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /binutils
+
+RUN cp /usr/bin/*-as /binutils/ \
+    && cp /usr/bin/*-objdump /binutils/ \
+    && cp /usr/bin/*-nm /binutils/
 
 WORKDIR /binutils
 
@@ -121,23 +134,12 @@ RUN dpkg --add-architecture i386 \
     && add-apt-repository -y ppa:stsp-0/dj64 \
     && apt-get update \
     && apt-get install -y -o APT::Immediate-Configure=false --no-install-recommends \
-    binutils-aarch64-linux-gnu \
-    binutils-arm-none-eabi \
-    binutils-djgpp \
-    binutils-mingw-w64-i686 \
-    binutils-mips-linux-gnu \
-    binutils-mipsel-linux-gnu \
-    binutils-powerpc-linux-gnu \
-    binutils-sh-elf \
-    binutils-x86-64-linux-gnu \
     cpp \
     dj64 \
     dos2unix \
     dosemu2 \
     iptables \
     libc6-dev-i386 \
-    libdevmapper1.02.1 \
-    libgpgme11 \
     libnl-route-3-200 \
     libprotobuf-dev \
     libtinfo6 \
@@ -147,6 +149,7 @@ RUN dpkg --add-architecture i386 \
     wine32:i386 \
     && rm -rf /var/lib/apt/lists/*
 
+# NOTE: libtinfo5 is required for clang
 RUN ARCHIVE=libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
     URL=http://security.ubuntu.com/ubuntu/pool/universe/n/ncurses/$ARCHIVE; \
     SHA256=ab89265d8dd18bda6a29d7c796367d6d9f22a39a8fa83589577321e7caf3857b; \

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update \
     software-properties-common \
     && rm -rf /var/lib/apt/lists/*
 
-FROM base as python312
+FROM base AS python312
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -63,11 +63,17 @@ RUN apt-get update \
     wget \
     && rm -rf /var/lib/apt/lists/*
 
-RUN mkdir /binutils
+RUN mkdir /binutils /binutils-libs
 
 RUN cp /usr/bin/*-as /binutils/ \
+    && cp /usr/bin/*-objcopy /binutils/ \
     && cp /usr/bin/*-objdump /binutils/ \
     && cp /usr/bin/*-nm /binutils/
+
+RUN cp /lib/x86_64-linux-gnu/libbfd*.so* /binutils-libs/ \
+    && cp /lib/x86_64-linux-gnu/libctf*.so* /binutils-libs/ \
+    && cp /lib/x86_64-linux-gnu/libopcodes*.so* /binutils-libs/ \
+    && cp /lib/x86_64-linux-gnu/libsframe*.so* /binutils-libs/
 
 WORKDIR /binutils
 
@@ -141,7 +147,7 @@ RUN dpkg --add-architecture i386 \
     iptables \
     libc6-dev-i386 \
     libnl-route-3-200 \
-    libprotobuf-dev \
+    libprotobuf32t64 \
     libtinfo6 \
     netcat-traditional \
     wget \
@@ -151,7 +157,7 @@ RUN dpkg --add-architecture i386 \
 
 # NOTE: libtinfo5 is required for clang
 RUN ARCHIVE=libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
-    URL=http://security.ubuntu.com/ubuntu/pool/universe/n/ncurses/$ARCHIVE; \
+    URL=https://security.ubuntu.com/ubuntu/pool/universe/n/ncurses/$ARCHIVE; \
     SHA256=ab89265d8dd18bda6a29d7c796367d6d9f22a39a8fa83589577321e7caf3857b; \
     wget -O "$ARCHIVE" "$URL" \
     && echo "$SHA256  $ARCHIVE" | sha256sum -c - \
@@ -177,6 +183,7 @@ RUN wineboot --init
 COPY --from=nsjail /nsjail/nsjail /bin/nsjail
 
 COPY --from=binutils /binutils/ /usr/bin/
+COPY --from=binutils /binutils-libs/ /usr/lib/x86_64-linux-gnu/
 
 COPY --from=ghcr.io/decompals/wibo:1.0.1 /usr/local/bin/wibo /usr/bin/
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,3 +1,5 @@
+# This image intentionally targets amd64 because Wine/wine32 and the bundled
+# compiler/binutils artifacts are x86 Linux binaries.
 FROM --platform=linux/amd64 ubuntu:24.04 AS base
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -14,7 +16,6 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
     python-is-python3 \
     python3 \
-    python3-pip \
     python3.12-dev \
     python3.12-venv \
     && rm -rf /var/lib/apt/lists/*
@@ -49,7 +50,6 @@ FROM base AS binutils
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
     bzip2 \
-    curl \
     libarchive-tools \
     wget \
     && rm -rf /var/lib/apt/lists/*
@@ -59,33 +59,59 @@ RUN mkdir /binutils
 WORKDIR /binutils
 
 # Patched mips binutils
-RUN wget "https://github.com/decompals/binutils-mips-ps2-decompals/releases/download/v0.8/binutils-mips-ps2-decompals-linux-x86-64.tar.gz" \
-    && tar xvzf binutils-mips-ps2-decompals-linux-x86-64.tar.gz mips-ps2-decompals-as mips-ps2-decompals-nm mips-ps2-decompals-objdump \
-    && rm binutils-mips-ps2-decompals-linux-x86-64.tar.gz \
+RUN ARCHIVE=binutils-mips-ps2-decompals-linux-x86-64.tar.gz; \
+    URL=https://github.com/decompals/binutils-mips-ps2-decompals/releases/download/v0.8/$ARCHIVE; \
+    SHA256=40f8dda9caae9ec2cd88811d7c4a322d5dd0fa9fe3b65ef6c9280c96b58415ea; \
+    wget -O "$ARCHIVE" "$URL" \
+    && echo "$SHA256  $ARCHIVE" | sha256sum -c - \
+    && tar xvzf "$ARCHIVE" mips-ps2-decompals-as mips-ps2-decompals-nm mips-ps2-decompals-objdump \
+    && rm "$ARCHIVE" \
     && chmod +x mips-ps2-decompals-*
 
 # Patched PowerPC binutils
-RUN curl -sSL "https://github.com/encounter/gc-wii-binutils/releases/download/2.42-2/linux-x86_64.zip" | \
-    bsdtar -xvf- powerpc-eabi-as powerpc-eabi-nm powerpc-eabi-objdump \
+RUN ARCHIVE=linux-x86_64.zip; \
+    URL=https://github.com/encounter/gc-wii-binutils/releases/download/2.42-2/$ARCHIVE; \
+    SHA256=64e4bf7aee5c06075d8fa818ebd2a0a3a72e0eeef3896bdec2f198b0e950fe63; \
+    wget -O "$ARCHIVE" "$URL" \
+    && echo "$SHA256  $ARCHIVE" | sha256sum -c - \
+    && bsdtar -xvf "$ARCHIVE" powerpc-eabi-as powerpc-eabi-nm powerpc-eabi-objdump \
+    && rm "$ARCHIVE" \
     && chmod +x powerpc-eabi-*
 
 # Xbox 360 (Xenon) PowerPC binutils
-RUN curl -sSL "https://github.com/encounter/xbox360-binutils/releases/download/2.45.1-1/linux-x86_64.zip" | \
-    bsdtar -xvf- powerpc-xenon-pe-as powerpc-xenon-pe-nm powerpc-xenon-pe-objdump \
+RUN ARCHIVE=linux-x86_64.zip; \
+    URL=https://github.com/encounter/xbox360-binutils/releases/download/2.45.1-1/$ARCHIVE; \
+    SHA256=33e01b228787ed507ebd08755370d5dac2053c2a37b0647a48c6c19cc528218c; \
+    wget -O "$ARCHIVE" "$URL" \
+    && echo "$SHA256  $ARCHIVE" | sha256sum -c - \
+    && bsdtar -xvf "$ARCHIVE" powerpc-xenon-pe-as powerpc-xenon-pe-nm powerpc-xenon-pe-objdump \
+    && rm "$ARCHIVE" \
     && chmod +x powerpc-xenon-pe-*
 
 # MSDOS specific
-RUN wget "https://github.com/OmniBlade/binutils-gdb/releases/download/omf-build/omftools.tar.gz" \
-    && tar xvzf omftools.tar.gz jwasm \
-    && rm omftools.tar.gz
-RUN wget "https://github.com/decompals/binutils-omf/releases/download/v0.4/omftools-linux-x86_64.tar.gz" \
-    && tar xvzf omftools-linux-x86_64.tar.gz omf-nm omf-objdump \
-    && rm omftools-linux-x86_64.tar.gz
+RUN ARCHIVE=omftools.tar.gz; \
+    URL=https://github.com/OmniBlade/binutils-gdb/releases/download/omf-build/$ARCHIVE; \
+    SHA256=b17dbbd3ee257bb870731df141ca44dde7eedee44d79294ab2acd1bccfed7834; \
+    wget -O "$ARCHIVE" "$URL" \
+    && echo "$SHA256  $ARCHIVE" | sha256sum -c - \
+    && tar xvzf "$ARCHIVE" jwasm \
+    && rm "$ARCHIVE"
+RUN ARCHIVE=omftools-linux-x86_64.tar.gz; \
+    URL=https://github.com/decompals/binutils-omf/releases/download/v0.4/$ARCHIVE; \
+    SHA256=d3a2e95e2b6079bb444f4f8f4d2d798954c58b2e7e59fb10523538696133b0c7; \
+    wget -O "$ARCHIVE" "$URL" \
+    && echo "$SHA256  $ARCHIVE" | sha256sum -c - \
+    && tar xvzf "$ARCHIVE" omf-nm omf-objdump \
+    && rm "$ARCHIVE"
 
 # Android binutils
-RUN wget "https://github.com/decompme/compilers/releases/download/compilers/android-ndk-r8e-linux-x86_64.tar.bz2" \
-    && bash -c 'tar xjvf android-ndk-r8e-linux-x86_64.tar.bz2 --strip-components=5 toolchains/x86-4.7/prebuilt/linux-x86_64/bin/i686-linux-android-{as,nm,objdump}' \
-    && rm android-ndk-r8e-linux-x86_64.tar.bz2
+RUN ARCHIVE=android-ndk-r8e-linux-x86_64.tar.bz2; \
+    URL=https://github.com/decompme/compilers/releases/download/compilers/$ARCHIVE; \
+    SHA256=126dce67022049dca1be063ea0f8a6c07070f9f0b139339fc9e6a8ff617ed7fc; \
+    wget -O "$ARCHIVE" "$URL" \
+    && echo "$SHA256  $ARCHIVE" | sha256sum -c - \
+    && bash -c 'tar xjvf "$0" --strip-components=5 toolchains/x86-4.7/prebuilt/linux-x86_64/bin/i686-linux-android-{as,nm,objdump}' "$ARCHIVE" \
+    && rm "$ARCHIVE"
 
 
 FROM python312 AS dependencies
@@ -108,7 +134,6 @@ RUN dpkg --add-architecture i386 \
     dj64 \
     dos2unix \
     dosemu2 \
-    gcc-mips-linux-gnu \
     iptables \
     libc6-dev-i386 \
     libdevmapper1.02.1 \
@@ -122,9 +147,13 @@ RUN dpkg --add-architecture i386 \
     wine32:i386 \
     && rm -rf /var/lib/apt/lists/*
 
-RUN wget http://security.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb \
-    && apt install ./libtinfo5_6.3-2ubuntu0.1_amd64.deb \
-    && rm libtinfo5_6.3-2ubuntu0.1_amd64.deb
+RUN ARCHIVE=libtinfo5_6.3-2ubuntu0.1_amd64.deb; \
+    URL=http://security.ubuntu.com/ubuntu/pool/universe/n/ncurses/$ARCHIVE; \
+    SHA256=ab89265d8dd18bda6a29d7c796367d6d9f22a39a8fa83589577321e7caf3857b; \
+    wget -O "$ARCHIVE" "$URL" \
+    && echo "$SHA256  $ARCHIVE" | sha256sum -c - \
+    && apt install "./$ARCHIVE" \
+    && rm "$ARCHIVE"
 
 RUN mkdir -p /etc/fonts
 


### PR DESCRIPTION
also remove:
- python3-pip (we use uv) 
- mips gcc which i don't believe we need (also is no longer packaged with ubuntu 26.04 so would be handy if we dont need it)
- libdevmapper/libgpgme (used in a previous generation of the compilers download.py)

~200mb savig on the Docker image:

**Before**
```
decompme-backend                             latest    e702fcc2f9b5   2 minutes ago    2.46GB
```
**After**
```
decompme-backend                             latest    2d41f02dc8d9   2 minutes ago    2.24GB
```