### PR TITLE
Fix these two tests that fail when the site is running

### DIFF
--- a/backend/coreapp/tests/test_preset.py
+++ b/backend/coreapp/tests/test_preset.py
@@ -75,7 +75,7 @@ class PresetTests(BaseTestCase):
         self.create_user()
         preset = self.create_preset(DUMMY_PRESET_DICT)
         assert preset.owner is not None
-        assert preset.owner.pk == self.user.pk
+        assert preset.owner.user_id == self.user.pk
 
     def test_owner_can_delete_preset(self) -> None:
         self.create_user()
@@ -106,10 +106,11 @@ class PresetTests(BaseTestCase):
     def test_list_preset_by_owner(self) -> None:
         # Create a new user and make it create a preset
         self.create_user()
-        self.create_preset(DUMMY_PRESET_DICT)
+        preset = self.create_preset(DUMMY_PRESET_DICT)
+        assert preset.owner_id is not None
 
         # Let's list all the user's presets
-        response = self.client.get(f"{reverse('preset-list')}?owner={self.user.pk}")
+        response = self.client.get(f"{reverse('preset-list')}?owner={preset.owner_id}")
         # Ensure the response is OK
         assert response.status_code == status.HTTP_200_OK
         # Check we only get one preset owned by the user
@@ -119,7 +120,8 @@ class PresetTests(BaseTestCase):
         # Ensure the user is the owner of the preset
         owner = results[0].get("owner")
         assert owner is not None
-        assert owner.get("id") == self.user.pk
+        assert owner.get("id") == preset.owner_id
+        assert owner.get("username") == self.user.username
 
     @requiresCompiler(GCC281PM)
     def test_create_preset_with_invalid_compiler(self) -> None:


### PR DESCRIPTION
The bug is that these tests confuse `User.id` with `Profile.id`.

Preset.owner is a Profile:
```python
owner = models.ForeignKey(Profile, ...)
```
But the tests use self.user.pk, which is a django.contrib.auth.models.User id:
```
assert preset.owner.pk == self.user.pk
response = self.client.get(f"{reverse('preset-list')}?owner={self.user.pk}")
```
**That only passes by coincidence when the created User and created Profile happen to receive the same primary key.** When the site is running, it can create anonymous/session profiles through set_user_profile middleware, which advances the Profile id sequence independently from the User sequence. Then the coincidence disappears:
```
User.id    = 1
Profile.id = 7
Preset.owner_id = 7
```
So:

test_user_create_preset fails because it compares preset.owner.pk to self.user.pk.
test_list_preset_by_owner fails because ?owner= filters Preset.owner, i.e. profile id, but the test passes a user id.
The tests should use the profile id / profile user relationship instead:
```py
assert preset.owner is not None
assert preset.owner.user_id == self.user.pk
```
and:
```py
preset = self.create_preset(DUMMY_PRESET_DICT)

response = self.client.get(f"{reverse('preset-list')}?owner={preset.owner_id}")
...
assert owner.get("id") == preset.owner_id
assert owner.get("username") == self.user.username
```
That explains why the site being up matters: normal site traffic can create Profile rows without matching User rows, so the two id sequences drift apart.