### PR TITLE
Cache /new, /platform + /preset

### DIFF
--- a/frontend/src/app/(navfooter)/new/page.tsx
+++ b/frontend/src/app/(navfooter)/new/page.tsx
@@ -1,4 +1,4 @@
-import { get } from "@/lib/api/request";
+import { getPublic } from "@/lib/api/request";
 
 import DESCRIPTION from "./description";
 import NewScratchForm from "./NewScratchForm";
@@ -7,8 +7,10 @@ export const metadata = {
     title: "New scratch",
 };
 
+export const revalidate = 300;
+
 export default async function NewScratchPage() {
-    const availablePlatforms = await get("/platform");
+    const availablePlatforms = await getPublic("/platform");
 
     return (
         <main>

--- a/frontend/src/app/(navfooter)/platform/page.tsx
+++ b/frontend/src/app/(navfooter)/platform/page.tsx
@@ -1,8 +1,10 @@
 import { Platforms } from "@/app/(navfooter)/platform/platforms";
-import { get } from "@/lib/api/request";
+import { getPublic } from "@/lib/api/request";
+
+export const revalidate = 300;
 
 export default async function Page() {
-    const availablePlatforms = await get("/platform");
+    const availablePlatforms = await getPublic("/platform");
 
     return (
         <main className="mx-auto w-full max-w-3xl p-4">

--- a/frontend/src/app/(navfooter)/preset/page.tsx
+++ b/frontend/src/app/(navfooter)/preset/page.tsx
@@ -1,8 +1,10 @@
 import { Presets } from "@/app/(navfooter)/preset/presets";
-import { get } from "@/lib/api/request";
+import { getPublic } from "@/lib/api/request";
+
+export const revalidate = 300;
 
 export default async function Page() {
-    const availablePlatforms = await get("/platform");
+    const availablePlatforms = await getPublic("/platform");
 
     return (
         <main className="mx-auto w-full max-w-3xl p-4">


### PR DESCRIPTION
Per the title. Despite the backend endpoints being cached, they are still treated as dynamic by next.js, this PR addresses that.