### PR TITLE
Disable prefetch for all Links

### DIFF
--- a/frontend/src/app/(navfooter)/SiteStats.tsx
+++ b/frontend/src/app/(navfooter)/SiteStats.tsx
@@ -2,7 +2,7 @@
 
 import type { ReactNode } from "react";
 
-import Link from "next/link";
+import Link from "@/components/Link";
 
 import { useStats } from "@/lib/api";
 

--- a/frontend/src/app/(navfooter)/WelcomeInfo.tsx
+++ b/frontend/src/app/(navfooter)/WelcomeInfo.tsx
@@ -1,4 +1,4 @@
-import Link from "next/link";
+import Link from "@/components/Link";
 
 import { ArrowRightIcon } from "@primer/octicons-react";
 
@@ -40,7 +40,7 @@ export default function WelcomeInfo() {
                     {SITE_DESCRIPTION}
                 </p>
                 <div className="flex flex-col items-center justify-center gap-2 md:flex-row">
-                    <Link href="/new" prefetch={false}>
+                    <Link href="/new">
                         <Button primary>
                             Start decomping
                             <ArrowRightIcon />
@@ -50,15 +50,11 @@ export default function WelcomeInfo() {
                 </div>
                 <p className="mx-auto my-6 w-full max-w-screen-sm text-gray-11 text-sm leading-tight">
                     Alternatively, check out existing scratches filtered by{" "}
-                    <Link
-                        className="font-bold"
-                        href="/platform"
-                        prefetch={false}
-                    >
+                    <Link className="font-bold" href="/platform">
                         platform
                     </Link>{" "}
                     or{" "}
-                    <Link className="font-bold" href="/preset" prefetch={false}>
+                    <Link className="font-bold" href="/preset">
                         preset
                     </Link>
                     .

--- a/frontend/src/app/(navfooter)/faq/page.tsx
+++ b/frontend/src/app/(navfooter)/faq/page.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 
-import Link from "next/link";
+import Link from "@/components/Link";
 
 import Frog from "@/components/Frog/Frog";
 

--- a/frontend/src/app/(navfooter)/new/NewScratchForm.tsx
+++ b/frontend/src/app/(navfooter)/new/NewScratchForm.tsx
@@ -9,7 +9,7 @@ import {
     useState,
 } from "react";
 
-import Link from "next/link";
+import Link from "@/components/Link";
 import { useRouter } from "next/navigation";
 
 import clsx from "clsx";

--- a/frontend/src/app/(navfooter)/privacy/page.tsx
+++ b/frontend/src/app/(navfooter)/privacy/page.tsx
@@ -1,4 +1,4 @@
-import Link from "next/link";
+import Link from "@/components/Link";
 
 const subtitle = "mt-8 text-xl font-semibold tracking-tight text-gray-11";
 const link = "text-blue-11 hover:underline active:translate-y-px";

--- a/frontend/src/components/Breadcrumbs.tsx
+++ b/frontend/src/components/Breadcrumbs.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 
-import Link from "next/link";
+import Link from "@/components/Link";
 
 import clsx from "clsx";
 

--- a/frontend/src/components/Button.tsx
+++ b/frontend/src/components/Button.tsx
@@ -2,7 +2,7 @@
 
 import { type ForwardedRef, forwardRef } from "react";
 
-import Link from "next/link";
+import Link from "@/components/Link";
 
 import clsx from "clsx";
 

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -1,4 +1,4 @@
-import Link from "next/link";
+import Link from "@/components/Link";
 
 import { MarkGithubIcon } from "@primer/octicons-react";
 

--- a/frontend/src/components/GhostButton.tsx
+++ b/frontend/src/components/GhostButton.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 
-import Link from "next/link";
+import Link from "@/components/Link";
 
 import clsx from "clsx";
 
@@ -29,7 +29,7 @@ export default function GhostButton({
 
     if (href) {
         return (
-            <Link href={href} prefetch={false} className={cn} onClick={onClick}>
+            <Link href={href} className={cn} onClick={onClick}>
                 {children}
             </Link>
         );

--- a/frontend/src/components/Link.tsx
+++ b/frontend/src/components/Link.tsx
@@ -1,0 +1,17 @@
+import NextLink from "next/link";
+import {
+    forwardRef,
+    type ComponentPropsWithoutRef,
+    type ElementRef,
+} from "react";
+
+export type Props = ComponentPropsWithoutRef<typeof NextLink>;
+
+const Link = forwardRef<ElementRef<typeof NextLink>, Props>(function Link(
+    { prefetch = false, ...props },
+    ref,
+) {
+    return <NextLink ref={ref} prefetch={prefetch} {...props} />;
+});
+
+export default Link;

--- a/frontend/src/components/Nav/Nav.tsx
+++ b/frontend/src/components/Nav/Nav.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useReducer, type ReactNode } from "react";
 
-import Link from "next/link";
+import Link from "@/components/Link";
 import { useRouter } from "next/navigation";
 
 import { ThreeBarsIcon, XIcon } from "@primer/octicons-react";

--- a/frontend/src/components/PlatformLink.tsx
+++ b/frontend/src/components/PlatformLink.tsx
@@ -1,4 +1,4 @@
-import Link from "next/link";
+import Link from "@/components/Link";
 
 import { platformUrl } from "@/lib/api/urls";
 
@@ -14,7 +14,7 @@ export default function PlatformLink(props: Props) {
     const Icon = platformIcon(props.platform);
 
     return (
-        <Link href={platformUrl(props.platform)} prefetch={false}>
+        <Link href={platformUrl(props.platform)}>
             <Icon
                 width={props.size}
                 height={props.size}

--- a/frontend/src/components/PlatformSelect/PlatformIcon.tsx
+++ b/frontend/src/components/PlatformSelect/PlatformIcon.tsx
@@ -1,4 +1,4 @@
-import Link from "next/link";
+import Link from "@/components/Link";
 
 import { platformUrl } from "@/lib/api/urls";
 
@@ -63,7 +63,7 @@ export function PlatformIcon({ platform, className, clickable, size }: Props) {
 
     if (clickable) {
         return (
-            <Link href={url} prefetch={false}>
+            <Link href={url}>
                 <Icon width={size} height={size} className={className} />
             </Link>
         );

--- a/frontend/src/components/PlatformSelect/PlatformName.tsx
+++ b/frontend/src/components/PlatformSelect/PlatformName.tsx
@@ -1,4 +1,4 @@
-import Link from "next/link";
+import Link from "@/components/Link";
 
 import useSWRImmutable from "swr/immutable";
 
@@ -16,9 +16,7 @@ export default function PlatformName({ platform }: Props) {
 
     return (
         <>
-            <Link href={`/platform/${platform}`} prefetch={false}>
-                {data?.name ?? platform}
-            </Link>
+            <Link href={`/platform/${platform}`}>{data?.name ?? platform}</Link>
         </>
     );
 }

--- a/frontend/src/components/PresetList.tsx
+++ b/frontend/src/components/PresetList.tsx
@@ -2,7 +2,7 @@
 
 import { type ReactNode, type JSX, useState } from "react";
 
-import Link from "next/link";
+import Link from "@/components/Link";
 
 import clsx from "clsx";
 

--- a/frontend/src/components/Scratch/ScratchMatchBanner.tsx
+++ b/frontend/src/components/Scratch/ScratchMatchBanner.tsx
@@ -1,4 +1,4 @@
-import Link from "next/link";
+import Link from "@/components/Link";
 
 import useSWR from "swr";
 

--- a/frontend/src/components/Scratch/ScratchToolbar.tsx
+++ b/frontend/src/components/Scratch/ScratchToolbar.tsx
@@ -19,7 +19,7 @@ import {
 } from "@primer/octicons-react";
 import clsx from "clsx";
 import ContentEditable from "react-contenteditable";
-import Link from "next/link";
+import Link from "@/components/Link";
 import { useRouter } from "next/navigation";
 
 import TimeAgo from "@/components/TimeAgo";

--- a/frontend/src/components/Scratch/SortableFamilyList.tsx
+++ b/frontend/src/components/Scratch/SortableFamilyList.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react";
 
-import Link from "next/link";
+import Link from "@/components/Link";
 
 import clsx from "clsx";
 import useSWR from "swr";
@@ -51,11 +51,7 @@ function FamilyMember({
             {isCurrent ? (
                 <span className="font-medium text-gray-11">This scratch</span>
             ) : (
-                <Link
-                    href={scratchUrl(scratch)}
-                    className="font-medium"
-                    prefetch={false}
-                >
+                <Link href={scratchUrl(scratch)} className="font-medium">
                     {scratch.name}
                 </Link>
             )}

--- a/frontend/src/components/Scratch/panels/AboutPanel.tsx
+++ b/frontend/src/components/Scratch/panels/AboutPanel.tsx
@@ -1,4 +1,4 @@
-import Link from "next/link";
+import Link from "@/components/Link";
 
 import useSWR from "swr";
 
@@ -31,11 +31,7 @@ function ScratchLink({ url }: { url: string }) {
 
     return (
         <span className={styles.scratchLinkContainer}>
-            <Link
-                href={scratchUrl(scratch)}
-                className={styles.scratchLink}
-                prefetch={false}
-            >
+            <Link href={scratchUrl(scratch)} className={styles.scratchLink}>
                 {scratch.name || "Untitled scratch"}
             </Link>
             {scratch.owner && (
@@ -103,9 +99,7 @@ export default function AboutPanel({ scratch, setScratch }: Props) {
                 {preset && (
                     <div className={styles.horizontalField}>
                         <p className={styles.label}>Preset</p>
-                        <Link href={presetUrl(preset)} prefetch={false}>
-                            {preset.name}
-                        </Link>
+                        <Link href={presetUrl(preset)}>{preset.name}</Link>
                     </div>
                 )}
                 <div className={styles.horizontalField}>

--- a/frontend/src/components/ScratchItem.tsx
+++ b/frontend/src/components/ScratchItem.tsx
@@ -3,7 +3,7 @@
 import type { ReactNode } from "react";
 
 import Image from "next/image";
-import Link from "next/link";
+import Link from "@/components/Link";
 
 import { RepoForkedIcon } from "@primer/octicons-react";
 import clsx from "clsx";
@@ -54,7 +54,6 @@ export function Improvement({
     return (
         <Link
             href={`/scratch/${improvement.slug}`}
-            prefetch={false}
             className={clsx(styles.improvement, {
                 [styles.match]: improvement.is_match,
             })}
@@ -82,7 +81,6 @@ function ScratchItemTitle({
             )}
             <Link
                 href={scratchUrl(scratch)}
-                prefetch={false}
                 className={clsx(styles.link, styles.name)}
             >
                 {scratch.name}
@@ -110,7 +108,7 @@ function ScratchPresetOrCompiler({ scratch }: { scratch: api.TerseScratch }) {
     const presetName = preset?.name;
 
     return presetName ? (
-        <Link href={presetUrl(preset)} prefetch={false} className={styles.link}>
+        <Link href={presetUrl(preset)} className={styles.link}>
             {presetName}
         </Link>
     ) : (
@@ -250,7 +248,6 @@ export function SingleLineScratchItem({
             />
             <Link
                 href={scratchUrl(scratch)}
-                prefetch={false}
                 className={clsx(styles.link, styles.name)}
             >
                 {scratch.name}

--- a/frontend/src/components/ScratchList.tsx
+++ b/frontend/src/components/ScratchList.tsx
@@ -2,7 +2,7 @@
 
 import { type JSX, type ReactNode, useState } from "react";
 
-import Link from "next/link";
+import Link from "@/components/Link";
 
 import clsx from "clsx";
 

--- a/frontend/src/components/VerticalMenu.tsx
+++ b/frontend/src/components/VerticalMenu.tsx
@@ -6,7 +6,7 @@ import {
     useState,
 } from "react";
 
-import Link from "next/link";
+import Link from "@/components/Link";
 import { useRouter } from "next/navigation";
 
 import clsx from "clsx";

--- a/frontend/src/components/YourScratchList.tsx
+++ b/frontend/src/components/YourScratchList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import Link from "next/link";
+import Link from "@/components/Link";
 
 import { useThisUser, isAnonUser } from "@/lib/api";
 

--- a/frontend/src/components/user/UserLink.tsx
+++ b/frontend/src/components/user/UserLink.tsx
@@ -1,4 +1,4 @@
-import Link from "next/link";
+import Link from "@/components/Link";
 
 import { isAnonUser, type User, type AnonymousUser } from "@/lib/api/types";
 
@@ -42,11 +42,7 @@ export default function UserLink({
     }
 
     return (
-        <Link
-            href={url}
-            prefetch={false}
-            className="hover:underline active:translate-y-px"
-        >
+        <Link href={url} className="hover:underline active:translate-y-px">
             {inner}
         </Link>
     );

--- a/frontend/src/components/user/UserMention.tsx
+++ b/frontend/src/components/user/UserMention.tsx
@@ -1,4 +1,4 @@
-import Link from "next/link";
+import Link from "@/components/Link";
 
 import { type User, type AnonymousUser, isAnonUser } from "@/lib/api/types";
 


### PR DESCRIPTION
We disabled it in most places before, but still missed a few, so pull out `next/link` and wrap it into our own version that sets prefetch={false} by default.