### PR TITLE
Add 'delete scratch' button to user profile page

### DIFF
--- a/frontend/src/app/globals.scss
+++ b/frontend/src/app/globals.scss
@@ -6,7 +6,7 @@
 
 :root {
     --link: #58a6ff;
-    --danger: #f00;
+    --danger: #c00000;
     --monospace: "JetBrains Mono", "Menlo", "Monaco", monospace;
     --font-ui: -apple-system, "BlinkMacSystemFont", "Segoe UI", "Helvetica", "Arial", sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
 

--- a/frontend/src/components/ScratchItem.module.scss
+++ b/frontend/src/components/ScratchItem.module.scss
@@ -147,3 +147,11 @@
         text-overflow: ellipsis;
     }
 }
+
+.red-on-shift {
+    color: rgb(206, 58, 58);
+}
+
+.red-on-shift:hover {
+    color: rgb(245, 141, 141) !important;
+}

--- a/frontend/src/components/ScratchItem.module.scss
+++ b/frontend/src/components/ScratchItem.module.scss
@@ -150,14 +150,18 @@
 
 .delete-button {
     --warning-color: #ce3a3a;
-    color: var(--warning-color)  !important;
+    background-color: var(--warning-color)  !important;
     border-color: var(--warning-color) !important;
+    color: white !important;
     font-size: 0.8em;
     padding: 0 0.4em;
+    min-width: 4.5rem;
+    justify-content: center;
 }
 
 .delete-button:hover {
     --warning-hover-color: #f58d8d;
-    color: var(--warning-hover-color)  !important;
+    background-color: var(--warning-hover-color)  !important;
     border-color: var(--warning-hover-color) !important;
+    color: white !important;
 }

--- a/frontend/src/components/ScratchItem.module.scss
+++ b/frontend/src/components/ScratchItem.module.scss
@@ -149,9 +149,13 @@
 }
 
 .red-on-shift {
-    color: rgb(206, 58, 58);
+    --warning-color: rgb(206, 58, 58);
+    color: var(--warning-color)  !important;
+    border-color: var(--warning-color) !important;
 }
 
 .red-on-shift:hover {
-    color: rgb(245, 141, 141) !important;
+    --warning-hover-color: rgb(245, 141, 141);
+    color: var(--warning-hover-color)  !important;
+    border-color: var(--warning-hover-color) !important;
 }

--- a/frontend/src/components/ScratchItem.module.scss
+++ b/frontend/src/components/ScratchItem.module.scss
@@ -148,13 +148,15 @@
     }
 }
 
-.red-on-shift {
+.delete-button {
     --warning-color: #ce3a3a;
     color: var(--warning-color)  !important;
     border-color: var(--warning-color) !important;
+    font-size: 0.8em;
+    padding: 0 0.4em;
 }
 
-.red-on-shift:hover {
+.delete-button:hover {
     --warning-hover-color: #f58d8d;
     color: var(--warning-hover-color)  !important;
     border-color: var(--warning-hover-color) !important;

--- a/frontend/src/components/ScratchItem.module.scss
+++ b/frontend/src/components/ScratchItem.module.scss
@@ -32,9 +32,9 @@
     flex-shrink: 0;
     gap: 0.35rem;
     justify-content: center;
-    min-width: 4.5rem;
+    min-width: 5rem;
     height: 1.4rem;
-    padding: 0 0.45rem;
+    padding: 0 0.5rem;
 
     border-radius: 0.5em;
 
@@ -145,22 +145,4 @@
         overflow: hidden;
         text-overflow: ellipsis;
     }
-}
-
-.delete-button {
-    --warning-color: #ce3a3a;
-    background-color: var(--warning-color)  !important;
-    border-color: var(--warning-color) !important;
-    color: white !important;
-    font-size: 0.8em;
-    max-width: 4.5rem;
-    max-height: 1.5rem;
-    justify-content: center;
-}
-
-.delete-button:hover {
-    --warning-hover-color: #f58d8d;
-    background-color: var(--warning-hover-color)  !important;
-    border-color: var(--warning-hover-color) !important;
-    color: white !important;
 }

--- a/frontend/src/components/ScratchItem.module.scss
+++ b/frontend/src/components/ScratchItem.module.scss
@@ -149,13 +149,13 @@
 }
 
 .red-on-shift {
-    --warning-color: rgb(206, 58, 58);
+    --warning-color: #ce3a3a;
     color: var(--warning-color)  !important;
     border-color: var(--warning-color) !important;
 }
 
 .red-on-shift:hover {
-    --warning-hover-color: rgb(245, 141, 141);
+    --warning-hover-color: #f58d8d;
     color: var(--warning-hover-color)  !important;
     border-color: var(--warning-hover-color) !important;
 }

--- a/frontend/src/components/ScratchItem.module.scss
+++ b/frontend/src/components/ScratchItem.module.scss
@@ -49,8 +49,7 @@
     }
 
     span {
-        // transform: translateY(1px);
-        transform: translate(-2px, 1px);
+        transform: translateX(-2px);
     }
 }
 
@@ -154,8 +153,8 @@
     border-color: var(--warning-color) !important;
     color: white !important;
     font-size: 0.8em;
-    padding: 0 0.4em;
-    min-width: 4.5rem;
+    max-width: 4.5rem;
+    max-height: 1.5rem;
     justify-content: center;
 }
 

--- a/frontend/src/components/ScratchItem.tsx
+++ b/frontend/src/components/ScratchItem.tsx
@@ -85,7 +85,7 @@ function ScratchItemTitle({
                 href={scratchUrl(scratch)}
                 className={clsx(styles.link, styles.name)}
             >
-                {scratch.name + ` [${scratch.slug}]`}
+                {scratch.name}
             </Link>
         </div>
     );
@@ -163,8 +163,13 @@ function ScratchItemRow({
             return;
         }
 
-        await api.delete_(scratchUrl(scratch), {});
-        setShowElement(false);
+        try {
+            await api.delete_(scratchUrl(scratch), {});
+            setShowElement(false); // Hide deleted element to avoid performing a page refresh, and allow deleting more scratches
+        } catch (error) {
+            alert("An error occurred trying to deleting this scratch.");
+            throw error;
+        }
     };
 
     document.body.addEventListener("keydown", (evt: KeyboardEvent) => {

--- a/frontend/src/components/ScratchItem.tsx
+++ b/frontend/src/components/ScratchItem.tsx
@@ -155,16 +155,24 @@ function ScratchItemRow({
     showDeleteButton?: boolean;
 }) {
     const [showElement, setShowElement] = useState(true);
+    const [isDeleting, setIsDeleting] = useState(false);
+
     const deleteScratch = async (
         scratch: api.TerseScratch,
         isShiftPressed: boolean,
     ) => {
+        if (isDeleting) {
+            return;
+        }
+
+        setIsDeleting(true);
         if (
             !isShiftPressed &&
             !confirm(
                 "Are you sure you want to delete this scratch? This action cannot be undone.",
             )
         ) {
+            setIsDeleting(false);
             return;
         }
 
@@ -173,8 +181,11 @@ function ScratchItemRow({
             setShowElement(false); // Hide deleted element to avoid performing a page refresh, and allow deleting more scratches
         } catch (error) {
             alert("An error occurred trying to deleting this scratch.");
+            setIsDeleting(false);
             throw error;
         }
+
+        setIsDeleting(false);
     };
 
     return (

--- a/frontend/src/components/ScratchItem.tsx
+++ b/frontend/src/components/ScratchItem.tsx
@@ -154,11 +154,13 @@ function ScratchItemRow({
     showPresetOrCompiler?: boolean;
     showDeleteButton?: boolean;
 }) {
-    const [warnDelete, setWarnDelete] = useState(false);
     const [showElement, setShowElement] = useState(true);
-    const deleteScratch = async (scratch: api.TerseScratch) => {
+    const deleteScratch = async (
+        scratch: api.TerseScratch,
+        isShiftPressed: boolean,
+    ) => {
         if (
-            !warnDelete &&
+            !isShiftPressed &&
             !confirm(
                 "Are you sure you want to delete this scratch? This action cannot be undone.",
             )
@@ -175,17 +177,8 @@ function ScratchItemRow({
         }
     };
 
-    document.body.addEventListener("keydown", (evt: KeyboardEvent) => {
-        setWarnDelete(evt.shiftKey);
-    });
-
-    document.body.addEventListener("keyup", (evt: KeyboardEvent) => {
-        setWarnDelete(evt.shiftKey);
-    });
-
     return (
         <>
-            {" "}
             {showElement && (
                 <li className={styles.item}>
                     <div className={styles.scratch}>
@@ -215,16 +208,15 @@ function ScratchItemRow({
                                     )}
                                     {showDeleteButton && (
                                         <Button
-                                            onClick={() =>
-                                                deleteScratch(scratch)
+                                            onClick={(evt) =>
+                                                deleteScratch(
+                                                    scratch,
+                                                    evt.shiftKey,
+                                                )
                                             }
-                                            className={
-                                                warnDelete
-                                                    ? styles["red-on-shift"]
-                                                    : ""
-                                            }
+                                            className={styles["delete-button"]}
                                         >
-                                            <TrashIcon />
+                                            <TrashIcon size={14} /> Delete
                                         </Button>
                                     )}
                                 </div>
@@ -232,7 +224,7 @@ function ScratchItemRow({
                         </div>
                     </div>
                 </li>
-            )}{" "}
+            )}
         </>
     );
 }

--- a/frontend/src/components/ScratchItem.tsx
+++ b/frontend/src/components/ScratchItem.tsx
@@ -67,6 +67,58 @@ export function Improvement({
     );
 }
 
+function DeleteButton({
+    scratch,
+    onDeleteCallback,
+}: {
+    scratch: api.TerseScratch;
+    onDeleteCallback: () => void;
+}) {
+    const [isDeleting, setIsDeleting] = useState(false);
+
+    const deleteScratch = async (
+        scratch: api.TerseScratch,
+        isShiftPressed: boolean,
+    ) => {
+        if (isDeleting) {
+            return;
+        }
+
+        setIsDeleting(true);
+        if (
+            !isShiftPressed &&
+            !confirm(
+                "Are you sure you want to delete this scratch? This action cannot be undone.",
+            )
+        ) {
+            setIsDeleting(false);
+            return;
+        }
+
+        try {
+            await api.delete_(scratchUrl(scratch), {});
+            // Hide deleted element to avoid performing a page refresh, and allow deleting more scratches
+            onDeleteCallback();
+        } catch (error) {
+            alert("An error occurred trying to deleting this scratch.");
+            setIsDeleting(false);
+            throw error;
+        }
+        setIsDeleting(false);
+    };
+
+    return (
+        <Button
+            onClick={(evt) => deleteScratch(scratch, evt.shiftKey)}
+            className="!border-none !py-1 text-xs rounded-md md:min-w-20"
+            danger
+        >
+            <TrashIcon size={14} />
+            <span className="hidden md:inline">Delete</span>
+        </Button>
+    );
+}
+
 function ScratchItemTitle({
     scratch,
     showPlatform,
@@ -155,38 +207,7 @@ function ScratchItemRow({
     showDeleteButton?: boolean;
 }) {
     const [showElement, setShowElement] = useState(true);
-    const [isDeleting, setIsDeleting] = useState(false);
-
-    const deleteScratch = async (
-        scratch: api.TerseScratch,
-        isShiftPressed: boolean,
-    ) => {
-        if (isDeleting) {
-            return;
-        }
-
-        setIsDeleting(true);
-        if (
-            !isShiftPressed &&
-            !confirm(
-                "Are you sure you want to delete this scratch? This action cannot be undone.",
-            )
-        ) {
-            setIsDeleting(false);
-            return;
-        }
-
-        try {
-            await api.delete_(scratchUrl(scratch), {});
-            setShowElement(false); // Hide deleted element to avoid performing a page refresh, and allow deleting more scratches
-        } catch (error) {
-            alert("An error occurred trying to deleting this scratch.");
-            setIsDeleting(false);
-            throw error;
-        }
-
-        setIsDeleting(false);
-    };
+    const onDeleteCallback = () => setShowElement(false);
 
     return (
         <>
@@ -218,20 +239,10 @@ function ScratchItemRow({
                                         <ScratchOwner scratch={scratch} />
                                     )}
                                     {showDeleteButton && (
-                                        <Button
-                                            onClick={(evt) =>
-                                                deleteScratch(
-                                                    scratch,
-                                                    evt.shiftKey,
-                                                )
-                                            }
-                                            className={styles["delete-button"]}
-                                        >
-                                            <TrashIcon size={14} />
-                                            <span className="hidden md:inline">
-                                                Delete
-                                            </span>
-                                        </Button>
+                                        <DeleteButton
+                                            scratch={scratch}
+                                            onDeleteCallback={onDeleteCallback}
+                                        />
                                     )}
                                 </div>
                             )}

--- a/frontend/src/components/ScratchItem.tsx
+++ b/frontend/src/components/ScratchItem.tsx
@@ -154,11 +154,15 @@ function ScratchItemRow({
     showPresetOrCompiler?: boolean;
     showDeleteButton?: boolean;
 }) {
-
-    let [warnDelete, setWarnDelete] = useState(false);
-    let [showElement, setShowElement] = useState(true);
+    const [warnDelete, setWarnDelete] = useState(false);
+    const [showElement, setShowElement] = useState(true);
     const deleteScratch = async (scratch: api.TerseScratch) => {
-        if (!warnDelete && !confirm("Are you sure you want to delete this scratch? This action cannot be undone.")) {
+        if (
+            !warnDelete &&
+            !confirm(
+                "Are you sure you want to delete this scratch? This action cannot be undone.",
+            )
+        ) {
             return;
         }
 
@@ -179,47 +183,82 @@ function ScratchItemRow({
         setWarnDelete(evt.shiftKey);
     });
 
-    return <> { showElement &&
-        <li className={styles.item}>
-            <div className={styles.scratch}>
-                <div className={styles.header}>
-                    <ScratchItemTitle
-                        scratch={scratch}
-                        showPlatform={showPlatform}
-                    />
-                    <span className={styles.improvementSlot}>
-                        <Improvement improvement={scratch.best_fork} />
-                    </span>
-                </div>
-                <div className={styles.metadata}>
-                    <ScratchMetadata
-                        scratch={scratch}
-                        showPresetOrCompiler={showPresetOrCompiler}
-                    />
-                    {(children || showOwner || showDeleteButton) && (
-                        <div className={styles.metadataAside}>
-                            {children && (
-                                <div className={styles.actions}>{children}</div>
-                            )}
-                            {showOwner && <ScratchOwner scratch={scratch} />}
-                            {showDeleteButton && <Button onClick={() => deleteScratch(scratch)} className={warnDelete ? styles["red-on-shift"] : ""}><TrashIcon/></Button>}
+    return (
+        <>
+            {" "}
+            {showElement && (
+                <li className={styles.item}>
+                    <div className={styles.scratch}>
+                        <div className={styles.header}>
+                            <ScratchItemTitle
+                                scratch={scratch}
+                                showPlatform={showPlatform}
+                            />
+                            <span className={styles.improvementSlot}>
+                                <Improvement improvement={scratch.best_fork} />
+                            </span>
                         </div>
-                    )}
-                </div>
-            </div>
-        </li>
-    } </>;
+                        <div className={styles.metadata}>
+                            <ScratchMetadata
+                                scratch={scratch}
+                                showPresetOrCompiler={showPresetOrCompiler}
+                            />
+                            {(children || showOwner || showDeleteButton) && (
+                                <div className={styles.metadataAside}>
+                                    {children && (
+                                        <div className={styles.actions}>
+                                            {children}
+                                        </div>
+                                    )}
+                                    {showOwner && (
+                                        <ScratchOwner scratch={scratch} />
+                                    )}
+                                    {showDeleteButton && (
+                                        <Button
+                                            onClick={() =>
+                                                deleteScratch(scratch)
+                                            }
+                                            className={
+                                                warnDelete
+                                                    ? styles["red-on-shift"]
+                                                    : ""
+                                            }
+                                        >
+                                            <TrashIcon />
+                                        </Button>
+                                    )}
+                                </div>
+                            )}
+                        </div>
+                    </div>
+                </li>
+            )}{" "}
+        </>
+    );
 }
 
 export function ScratchItem({
     scratch,
     children,
-}: { scratch: api.TerseScratch; children?: ReactNode; showDeleteButton?: boolean }) {
+}: {
+    scratch: api.TerseScratch;
+    children?: ReactNode;
+    showDeleteButton?: boolean;
+}) {
     return <ScratchItemRow scratch={scratch}>{children}</ScratchItemRow>;
 }
 
-export function ScratchItemNoOwner({ scratch, showDeleteButton }: { scratch: api.TerseScratch; showDeleteButton?: boolean }) {
-    return <ScratchItemRow scratch={scratch} showOwner={false} showDeleteButton={showDeleteButton} />;
+export function ScratchItemNoOwner({
+    scratch,
+    showDeleteButton,
+}: { scratch: api.TerseScratch; showDeleteButton?: boolean }) {
+    return (
+        <ScratchItemRow
+            scratch={scratch}
+            showOwner={false}
+            showDeleteButton={showDeleteButton}
+        />
+    );
 }
 
 export function ScratchItemPlatformList({

--- a/frontend/src/components/ScratchItem.tsx
+++ b/frontend/src/components/ScratchItem.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { type ReactNode, JSX, useState } from "react";
+import { type ReactNode, useState } from "react";
 
 import Image from "next/image";
 import Link from "@/components/Link";
 
-import { RepoForkedIcon } from "@primer/octicons-react";
+import { RepoForkedIcon, TrashIcon } from "@primer/octicons-react";
 import clsx from "clsx";
 
 import TimeAgo from "@/components/TimeAgo";
@@ -15,12 +15,11 @@ import { presetUrl, scratchUrl, userAvatarUrl } from "@/lib/api/urls";
 import getTranslation from "@/lib/i18n/translate";
 
 import AnonymousFrogAvatar from "./Frog/AnonymousFrog";
+import Button from "./Button";
 import PlatformLink from "./PlatformLink";
 import { calculateScorePercent, percentToString } from "./ScoreBadge";
 import styles from "./ScratchItem.module.scss";
 import UserLink from "./user/UserLink";
-import Button from "./Button";
-import { TrashIcon } from "@primer/octicons-react";
 
 type MatchPercentSource = api.TerseScratch | api.BestFork;
 

--- a/frontend/src/components/ScratchItem.tsx
+++ b/frontend/src/components/ScratchItem.tsx
@@ -217,7 +217,9 @@ function ScratchItemRow({
                                             className={styles["delete-button"]}
                                         >
                                             <TrashIcon size={14} />
-                                            <span className="hidden md:inline">Delete</span>
+                                            <span className="hidden md:inline">
+                                                Delete
+                                            </span>
                                         </Button>
                                     )}
                                 </div>

--- a/frontend/src/components/ScratchItem.tsx
+++ b/frontend/src/components/ScratchItem.tsx
@@ -216,7 +216,8 @@ function ScratchItemRow({
                                             }
                                             className={styles["delete-button"]}
                                         >
-                                            <TrashIcon size={14} /> Delete
+                                            <TrashIcon size={14} />
+                                            <span className="hidden md:inline">Delete</span>
                                         </Button>
                                     )}
                                 </div>

--- a/frontend/src/components/ScratchItem.tsx
+++ b/frontend/src/components/ScratchItem.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { ReactNode } from "react";
+import { type ReactNode, JSX, useState } from "react";
 
 import Image from "next/image";
 import Link from "@/components/Link";
@@ -19,6 +19,8 @@ import PlatformLink from "./PlatformLink";
 import { calculateScorePercent, percentToString } from "./ScoreBadge";
 import styles from "./ScratchItem.module.scss";
 import UserLink from "./user/UserLink";
+import Button from "./Button";
+import { TrashIcon } from "@primer/octicons-react";
 
 type MatchPercentSource = api.TerseScratch | api.BestFork;
 
@@ -83,7 +85,7 @@ function ScratchItemTitle({
                 href={scratchUrl(scratch)}
                 className={clsx(styles.link, styles.name)}
             >
-                {scratch.name}
+                {scratch.name + ` [${scratch.slug}]`}
             </Link>
         </div>
     );
@@ -144,14 +146,36 @@ function ScratchItemRow({
     showOwner = true,
     showPlatform = true,
     showPresetOrCompiler = true,
+    showDeleteButton = false,
 }: {
     scratch: api.TerseScratch;
     children?: ReactNode;
     showOwner?: boolean;
     showPlatform?: boolean;
     showPresetOrCompiler?: boolean;
+    showDeleteButton?: boolean;
 }) {
-    return (
+
+    let [warnDelete, setWarnDelete] = useState(false);
+    let [showElement, setShowElement] = useState(true);
+    const deleteScratch = async (scratch: api.TerseScratch) => {
+        if (!warnDelete && !confirm("Are you sure you want to delete this scratch? This action cannot be undone.")) {
+            return;
+        }
+
+        await api.delete_(scratchUrl(scratch), {});
+        setShowElement(false);
+    };
+
+    document.body.addEventListener("keydown", (evt: KeyboardEvent) => {
+        setWarnDelete(evt.shiftKey);
+    });
+
+    document.body.addEventListener("keyup", (evt: KeyboardEvent) => {
+        setWarnDelete(evt.shiftKey);
+    });
+
+    return <> { showElement &&
         <li className={styles.item}>
             <div className={styles.scratch}>
                 <div className={styles.header}>
@@ -168,29 +192,30 @@ function ScratchItemRow({
                         scratch={scratch}
                         showPresetOrCompiler={showPresetOrCompiler}
                     />
-                    {(children || showOwner) && (
+                    {(children || showOwner || showDeleteButton) && (
                         <div className={styles.metadataAside}>
                             {children && (
                                 <div className={styles.actions}>{children}</div>
                             )}
                             {showOwner && <ScratchOwner scratch={scratch} />}
+                            {showDeleteButton && <Button onClick={() => deleteScratch(scratch)} className={warnDelete ? styles["red-on-shift"] : ""}><TrashIcon/></Button>}
                         </div>
                     )}
                 </div>
             </div>
         </li>
-    );
+    } </>;
 }
 
 export function ScratchItem({
     scratch,
     children,
-}: { scratch: api.TerseScratch; children?: ReactNode }) {
+}: { scratch: api.TerseScratch; children?: ReactNode; showDeleteButton?: boolean }) {
     return <ScratchItemRow scratch={scratch}>{children}</ScratchItemRow>;
 }
 
-export function ScratchItemNoOwner({ scratch }: { scratch: api.TerseScratch }) {
-    return <ScratchItemRow scratch={scratch} showOwner={false} />;
+export function ScratchItemNoOwner({ scratch, showDeleteButton }: { scratch: api.TerseScratch; showDeleteButton?: boolean }) {
+    return <ScratchItemRow scratch={scratch} showOwner={false} showDeleteButton={showDeleteButton} />;
 }
 
 export function ScratchItemPlatformList({

--- a/frontend/src/components/ScratchItem.tsx
+++ b/frontend/src/components/ScratchItem.tsx
@@ -110,7 +110,7 @@ function DeleteButton({
     return (
         <Button
             onClick={(evt) => deleteScratch(scratch, evt.shiftKey)}
-            className="!border-none !py-1 text-xs rounded-md md:min-w-20"
+            className="!border-none !py-1 rounded-md text-xs md:min-w-20"
             danger
         >
             <TrashIcon size={14} />

--- a/frontend/src/components/ScratchList.tsx
+++ b/frontend/src/components/ScratchList.tsx
@@ -34,7 +34,7 @@ export default function ScratchList({
     emptyButtonLabel,
     isSortable,
     isPublic,
-    showDeleteButtons
+    showDeleteButtons,
 }: Props) {
     const [sortMode, setSortMode] = useState(SortMode.NEWEST_FIRST);
     const { results, isLoading, hasNext, loadNext } =
@@ -64,7 +64,11 @@ export default function ScratchList({
                     )}
                 >
                     {results.map((scratch) => (
-                        <Item key={scratchUrl(scratch)} scratch={scratch} showDeleteButton={showDeleteButtons} />
+                        <Item
+                            key={scratchUrl(scratch)}
+                            scratch={scratch}
+                            showDeleteButton={showDeleteButtons}
+                        />
                     ))}
                     {results.length === 0 && emptyButtonLabel && (
                         <li className={styles.button}>

--- a/frontend/src/components/ScratchList.tsx
+++ b/frontend/src/components/ScratchList.tsx
@@ -23,6 +23,7 @@ export interface Props {
     emptyButtonLabel?: ReactNode;
     isSortable?: boolean;
     isPublic?: boolean;
+    showDeleteButtons?: boolean;
 }
 
 export default function ScratchList({
@@ -33,6 +34,7 @@ export default function ScratchList({
     emptyButtonLabel,
     isSortable,
     isPublic,
+    showDeleteButtons
 }: Props) {
     const [sortMode, setSortMode] = useState(SortMode.NEWEST_FIRST);
     const { results, isLoading, hasNext, loadNext } =
@@ -62,7 +64,7 @@ export default function ScratchList({
                     )}
                 >
                     {results.map((scratch) => (
-                        <Item key={scratchUrl(scratch)} scratch={scratch} />
+                        <Item key={scratchUrl(scratch)} scratch={scratch} showDeleteButton={showDeleteButtons} />
                     ))}
                     {results.length === 0 && emptyButtonLabel && (
                         <li className={styles.button}>

--- a/frontend/src/components/user/tabs/ScratchesTab.tsx
+++ b/frontend/src/components/user/tabs/ScratchesTab.tsx
@@ -1,16 +1,18 @@
 import ScratchList from "@/components/ScratchList";
 import { ScratchItemNoOwner } from "@/components/ScratchItem";
 
-import type { User } from "@/lib/api";
+import { type User, useUserIsYou } from "@/lib/api";
 import { userUrl } from "@/lib/api/urls";
 
 export default function ScratchesTab({ user }: { user: User }) {
+    const userIsYou = useUserIsYou();
     return (
         <section className="mt-4">
             <ScratchList
                 url={`${userUrl(user)}/scratches?page_size=20`}
                 item={ScratchItemNoOwner}
                 isSortable={true}
+                showDeleteButtons={userIsYou(user)}
             />
         </section>
     );

--- a/frontend/src/components/user/tabs/ScratchesTab.tsx
+++ b/frontend/src/components/user/tabs/ScratchesTab.tsx
@@ -1,18 +1,20 @@
 import ScratchList from "@/components/ScratchList";
 import { ScratchItemNoOwner } from "@/components/ScratchItem";
 
-import { type User, useUserIsYou } from "@/lib/api";
+import { type User, useUserIsYou, useThisUserIsAdmin } from "@/lib/api";
 import { userUrl } from "@/lib/api/urls";
 
 export default function ScratchesTab({ user }: { user: User }) {
     const userIsYou = useUserIsYou();
+    const isAdmin = useThisUserIsAdmin();
+
     return (
         <section className="mt-4">
             <ScratchList
                 url={`${userUrl(user)}/scratches?page_size=20`}
                 item={ScratchItemNoOwner}
                 isSortable={true}
-                showDeleteButtons={userIsYou(user)}
+                showDeleteButtons={userIsYou(user) || isAdmin}
             />
         </section>
     );

--- a/frontend/src/components/user/tabs/ScratchesTab.tsx
+++ b/frontend/src/components/user/tabs/ScratchesTab.tsx
@@ -1,7 +1,7 @@
 import ScratchList from "@/components/ScratchList";
 import { ScratchItemNoOwner } from "@/components/ScratchItem";
 
-import { type User, useUserIsYou, useThisUserIsAdmin } from "@/lib/api";
+import { type User, useThisUserIsAdmin, useUserIsYou } from "@/lib/api";
 import { userUrl } from "@/lib/api/urls";
 
 export default function ScratchesTab({ user }: { user: User }) {


### PR DESCRIPTION
These changes add a 'delete scratch' button to the user's profile, only viewable and usable by themselves and admins.
The button starts white and prompts for confirmation before deletion, but can be bypassed by holding shift (which also turns the button red).

<img height="200" alt="image" src="https://github.com/user-attachments/assets/e1fdc140-3857-4458-aec9-8cba34bc9877" />
<img height="200" alt="image" src="https://github.com/user-attachments/assets/6cd952dd-9396-4d6b-bf0f-a78d2f9d2472" />
