### PR TITLE
Reduce ulimit before running dosemu to fix performance regression

### DIFF
--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -387,6 +387,8 @@ CLANG_800 = ClangCompiler(
 )
 
 # PS1
+DOSEMU = 'ulimit -n 1024 && HOME="$(pwd)" /usr/bin/dosemu'
+
 PSYQ_COMPILE_BAT = "\r\n".join(
     [
         "@echo off",
@@ -399,8 +401,8 @@ PSYQ_MSDOS_CC = (
     "echo \"\\$_hdimage = '+0 $(pwd) +1'\" > .dosemurc && "
     f'echo "{PSYQ_COMPILE_BAT}" >> COMPILE.BAT && '
     '/usr/bin/cpp -E "${INPUT}" | unix2dos > dos_src.c && '
-    '(HOME="$(pwd)" /usr/bin/dosemu -quiet -dumb -f .dosemurc -p -K "${COMPILER_DIR}" -E "D:\\COMPILE.BAT") && '
-    '(HOME="$(pwd)" /usr/bin/dosemu -quiet -dumb -f .dosemurc -p -K "${COMPILER_DIR}" -E "ASPSX.EXE -quiet D:\\output.s -o D:\\output.obj") && '
+    f'({DOSEMU} -quiet -dumb -f .dosemurc -p -K "${{COMPILER_DIR}}" -E "D:\\COMPILE.BAT") && '
+    f'({DOSEMU} -quiet -dumb -f .dosemurc -p -K "${{COMPILER_DIR}}" -E "ASPSX.EXE -quiet D:\\output.s -o D:\\output.obj") && '
     '${COMPILER_DIR}/psyq-obj-parser output.obj -o "${OUTPUT}"'
 )
 
@@ -550,9 +552,9 @@ GCC2723_MIPSEL = GCCPS1Compiler(
 SATURN_CC = (
     "echo \"\\$_hdimage = '+0 $(pwd) +1'\" > .dosemurc && "
     'cat "${INPUT}" | unix2dos > dos_src.c && '
-    '(HOME="$(pwd)" /usr/bin/dosemu -quiet -dumb -f .dosemurc -p -K "${COMPILER_DIR}" -E "CPP.EXE D:\\dos_src.c -o D:\\src_proc.c") && '
-    '(HOME="$(pwd)" /usr/bin/dosemu -quiet -dumb -f .dosemurc -p -K "${COMPILER_DIR}" -E "CC1.EXE -quiet ${COMPILER_FLAGS} D:\\src_proc.c -o D:\\output.s") && '
-    '(HOME="$(pwd)" /usr/bin/dosemu -quiet -dumb -f .dosemurc -p -K "${COMPILER_DIR}" -E "AS.EXE D:\\output.s -o D:\\output.o") && '
+    f'({DOSEMU} -quiet -dumb -f .dosemurc -p -K "${{COMPILER_DIR}}" -E "CPP.EXE D:\\dos_src.c -o D:\\src_proc.c") && '
+    f'({DOSEMU} -quiet -dumb -f .dosemurc -p -K "${{COMPILER_DIR}}" -E "CC1.EXE -quiet ${{COMPILER_FLAGS}} D:\\src_proc.c -o D:\\output.s") && '
+    f'({DOSEMU} -quiet -dumb -f .dosemurc -p -K "${{COMPILER_DIR}}" -E "AS.EXE D:\\output.s -o D:\\output.o") && '
     'sh-elf-objcopy -Icoff-sh -Oelf32-sh output.o "${OUTPUT}"'
 )
 
@@ -1578,7 +1580,7 @@ WATCOM_110_CPP = WatcomCompiler(
 BORLAND_MSDOS_CC = (
     "echo \"\\$_hdimage = '+0 ${COMPILER_DIR} +1'\" > .dosemurc && "
     'cat "${INPUT}" | unix2dos > dos_src.c && '
-    '(HOME="$(pwd)" /usr/bin/dosemu -quiet -dumb -f .dosemurc -p -K . -E "D:\\bin\\bcc.exe -ID:\\include ${COMPILER_FLAGS} -c -oout.o dos_src.c") && '
+    f'({DOSEMU} -quiet -dumb -f .dosemurc -p -K . -E "D:\\bin\\bcc.exe -ID:\\include ${{COMPILER_FLAGS}} -c -oout.o dos_src.c") && '
     'cp out.o "${OUTPUT}"'
 )
 

--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -387,7 +387,7 @@ CLANG_800 = ClangCompiler(
 )
 
 # PS1
-DOSEMU = 'ulimit -n 1024 && HOME="$(pwd)" /usr/bin/dosemu'
+DOSEMU = 'ulimit -n 16384 && HOME="$(pwd)" /usr/bin/dosemu'
 
 PSYQ_COMPILE_BAT = "\r\n".join(
     [


### PR DESCRIPTION
See https://github.com/dosemu2/dosemu2/issues/2889 for some background. dosemu2 tries to close all file descriptors.. which is equal to the ulimit (1048576) which takes AGES. reducing this down to even 16k means invocation goes from 1.3 seconds to 80ms and should not affect compilation.