### PR TITLE
Make compiler warnings scroll-to-line-number-able

### DIFF
--- a/frontend/src/components/Diff/CompilationPanel.tsx
+++ b/frontend/src/components/Diff/CompilationPanel.tsx
@@ -2,13 +2,13 @@ import { useMemo, useRef, useState } from "react";
 
 import { ChevronDownIcon, ChevronUpIcon } from "@primer/octicons-react";
 import { Allotment, type AllotmentHandle } from "allotment";
-import Ansi from "ansi-to-react";
 
 import type * as api from "@/lib/api";
 import { interdiff } from "@/lib/interdiff";
 import { ThreeWayDiffBase, useThreeWayDiffBase } from "@/lib/settings";
 
 import GhostButton from "../GhostButton";
+import CompilerMessageOutput from "../Scratch/CompilerMessageOutput";
 
 import Diff from "./Diff";
 
@@ -172,7 +172,9 @@ export default function CompilationPanel({
                             </h2>
 
                             <div className="h-full grow overflow-auto whitespace-pre px-3 py-2 font-mono text-xs leading-snug">
-                                <Ansi>{compilation.compiler_output}</Ansi>
+                                <CompilerMessageOutput
+                                    text={compilation.compiler_output}
+                                />
                             </div>
                         </div>
                     </Allotment.Pane>

--- a/frontend/src/components/Diff/Diff.tsx
+++ b/frontend/src/components/Diff/Diff.tsx
@@ -3,14 +3,12 @@ import {
     type CSSProperties,
     forwardRef,
     type HTMLAttributes,
-    type RefObject,
     useEffect,
     useMemo,
     useState,
 } from "react";
 
 import { FoldIcon } from "@primer/octicons-react";
-import type { EditorView } from "codemirror";
 import AutoSizer from "react-virtualized-auto-sizer";
 import { FixedSizeList } from "react-window";
 
@@ -168,23 +166,6 @@ function DiffBody({
             </AutoSizer>
         </div>
     );
-}
-
-export function scrollToLineNumber(
-    editorView: RefObject<EditorView>,
-    lineNumber: number,
-) {
-    const view = editorView.current;
-    if (!view) return;
-    if (lineNumber <= view.state.doc.lines) {
-        // check if the source line <= number of lines
-        // which can be false if pragmas are used to force line numbers
-        const line = view.state.doc.line(lineNumber);
-        if (line) {
-            const { top } = view.lineBlockAt(line.to);
-            view.scrollDOM.scrollTo({ top, behavior: "smooth" });
-        }
-    }
 }
 
 export const PADDING_TOP = 8;

--- a/frontend/src/components/Diff/DiffRowAsmDiffer.tsx
+++ b/frontend/src/components/Diff/DiffRowAsmDiffer.tsx
@@ -7,11 +7,12 @@ import type { EditorView } from "codemirror";
 import { areEqual } from "react-window";
 
 import type * as api from "@/lib/api";
+import { scrollToLineNumber } from "@/lib/codemirror/scrollToLineNumber";
 import * as settings from "@/lib/settings";
 
 import { ScrollContext } from "../ScrollContext";
 import { useSelectedSourceLine } from "../SelectedSourceLineContext";
-import { PADDING_TOP, scrollToLineNumber, type VisibleRow } from "./Diff";
+import { PADDING_TOP, type VisibleRow } from "./Diff";
 import styles from "./Diff.module.scss";
 import type { Highlighter } from "./Highlighter";
 

--- a/frontend/src/components/Scratch/CompilerMessageOutput.tsx
+++ b/frontend/src/components/Scratch/CompilerMessageOutput.tsx
@@ -1,0 +1,40 @@
+import { type RefObject, useContext } from "react";
+
+import type { EditorView } from "@codemirror/view";
+import Ansi from "ansi-to-react";
+
+import { scrollToLineNumber } from "@/lib/codemirror/scrollToLineNumber";
+
+import { ScrollContext } from "../ScrollContext";
+
+import { parseCompilerMessages } from "./compilerMessages";
+
+export default function CompilerMessageOutput({ text }: { text: string }) {
+    const sourceEditor = useContext<RefObject<EditorView>>(ScrollContext);
+    const parts = parseCompilerMessages(text);
+
+    return (
+        <>
+            {parts.map((part, index) => {
+                if (part.type === "sourceLine") {
+                    return (
+                        <button
+                            className="inline cursor-pointer border-0 bg-transparent p-0 align-baseline font-mono text-blue-11 text-xs underline decoration-dotted underline-offset-2 hover:text-blue-12"
+                            key={index}
+                            type="button"
+                            onClick={() =>
+                                scrollToLineNumber(sourceEditor, part.line, {
+                                    select: true,
+                                })
+                            }
+                        >
+                            <Ansi>{part.text}</Ansi>
+                        </button>
+                    );
+                }
+
+                return <Ansi key={index}>{part.text}</Ansi>;
+            })}
+        </>
+    );
+}

--- a/frontend/src/components/Scratch/compilerMessages.test.ts
+++ b/frontend/src/components/Scratch/compilerMessages.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import { parseCompilerMessages } from "./compilerMessages";
+
+describe("parseCompilerMessages", () => {
+    it("captures src file line references", () => {
+        expect(
+            parseCompilerMessages(
+                "src.c:49: warning: incompatible pointer type",
+            ),
+        ).toEqual([
+            { type: "sourceLine", text: "src.c:49", line: 49 },
+            { type: "text", text: ": warning: incompatible pointer type" },
+        ]);
+    });
+
+    it("captures cfe src file line references", () => {
+        expect(
+            parseCompilerMessages(
+                "cfe: Warning 745: src.c, line 1: storage size for 'some_array' isn't known",
+            ),
+        ).toEqual([
+            { type: "text", text: "cfe: Warning 745: " },
+            { type: "sourceLine", text: "src.c, line 1", line: 1 },
+            {
+                type: "text",
+                text: ": storage size for 'some_array' isn't known",
+            },
+        ]);
+    });
+
+    it("captures quoted src file line references", () => {
+        expect(
+            parseCompilerMessages(
+                '"src.c", line 3: Error:  #70: incomplete type is not allowed',
+            ),
+        ).toEqual([
+            { type: "sourceLine", text: '"src.c", line 3', line: 3 },
+            {
+                type: "text",
+                text: ": Error:  #70: incomplete type is not allowed",
+            },
+        ]);
+    });
+
+    it("captures parenthesized src file line references", () => {
+        expect(
+            parseCompilerMessages(
+                "src.c(16) : 1000 (W) Illegal pointer assignment",
+            ),
+        ).toEqual([
+            { type: "sourceLine", text: "src.c(16)", line: 16 },
+            { type: "text", text: " : 1000 (W) Illegal pointer assignment" },
+        ]);
+    });
+
+    it("preserves text around the source line reference", () => {
+        expect(parseCompilerMessages("note: src.cpp:7: error")).toEqual([
+            { type: "text", text: "note: " },
+            { type: "sourceLine", text: "src.cpp:7", line: 7 },
+            { type: "text", text: ": error" },
+        ]);
+    });
+
+    it("ignores context file line references", () => {
+        expect(parseCompilerMessages("ctx.c:12: error")).toEqual([
+            { type: "text", text: "ctx.c:12: error" },
+        ]);
+    });
+
+    it("does not capture embedded src-looking strings", () => {
+        expect(parseCompilerMessages("tmp/src.c:12: error")).toEqual([
+            { type: "text", text: "tmp/src.c:12: error" },
+        ]);
+    });
+});

--- a/frontend/src/components/Scratch/compilerMessages.ts
+++ b/frontend/src/components/Scratch/compilerMessages.ts
@@ -1,0 +1,74 @@
+export type CompilerMessagePart =
+    | { type: "text"; text: string }
+    | { type: "sourceLine"; text: string; line: number };
+
+const SOURCE_LINE_LOCATION_PATTERNS = [
+    /(^|[^\w./-])(src\.[A-Za-z0-9]+:(\d+))(?=[:\s]|$)/g,
+    /(^|[^\w./-])("?src\.[A-Za-z0-9]+"?,\s+line\s+(\d+))(?=[:\s]|$)/g,
+    /(^|[^\w./-])(src\.[A-Za-z0-9]+\((\d+)\))(?=\s*[:\s]|$)/g,
+];
+
+type SourceLineMatch = {
+    start: number;
+    end: number;
+    text: string;
+    line: number;
+};
+
+function findSourceLineMatches(text: string): SourceLineMatch[] {
+    const matches: SourceLineMatch[] = [];
+
+    for (const pattern of SOURCE_LINE_LOCATION_PATTERNS) {
+        for (const match of text.matchAll(pattern)) {
+            const matchText = match[0];
+            const prefix = match[1] ?? "";
+            const locationText = match[2];
+            const line = Number.parseInt(match[3], 10);
+
+            if (!Number.isSafeInteger(line) || line < 1) {
+                continue;
+            }
+
+            matches.push({
+                start: match.index + prefix.length,
+                end: match.index + matchText.length,
+                text: locationText,
+                line,
+            });
+        }
+    }
+
+    return matches.sort((a, b) => a.start - b.start);
+}
+
+export function parseCompilerMessages(text: string): CompilerMessagePart[] {
+    const locations: CompilerMessagePart[] = [];
+    let index = 0;
+
+    for (const match of findSourceLineMatches(text)) {
+        if (match.start < index) {
+            continue;
+        }
+
+        if (match.start > index) {
+            locations.push({
+                type: "text",
+                text: text.slice(index, match.start),
+            });
+        }
+
+        locations.push({
+            type: "sourceLine",
+            text: match.text,
+            line: match.line,
+        });
+
+        index = match.end;
+    }
+
+    if (index < text.length) {
+        locations.push({ type: "text", text: text.slice(index) });
+    }
+
+    return locations;
+}

--- a/frontend/src/components/Scratch/panels/ProblemPanel.tsx
+++ b/frontend/src/components/Scratch/panels/ProblemPanel.tsx
@@ -1,9 +1,9 @@
-import Ansi from "ansi-to-react";
+import CompilerMessageOutput from "../CompilerMessageOutput";
 
 export default function ProblemPanel({ text }: { text: string }) {
     return (
         <div className="h-full min-h-0 overflow-auto whitespace-pre p-1 font-mono text-xs">
-            <Ansi>{text}</Ansi>
+            <CompilerMessageOutput text={text} />
         </div>
     );
 }

--- a/frontend/src/lib/codemirror/scrollToLineNumber.ts
+++ b/frontend/src/lib/codemirror/scrollToLineNumber.ts
@@ -1,0 +1,30 @@
+import type { RefObject } from "react";
+
+import type { EditorView } from "@codemirror/view";
+
+type Options = {
+    select?: boolean;
+};
+
+export function scrollToLineNumber(
+    editorView: RefObject<EditorView>,
+    lineNumber: number,
+    options: Options = {},
+) {
+    const view = editorView.current;
+    if (!view) return;
+    if (lineNumber <= view.state.doc.lines) {
+        // Source line numbers can be out of range when pragmas force line info.
+        const line = view.state.doc.line(lineNumber);
+        const { top } = view.lineBlockAt(line.to);
+        view.scrollDOM.scrollTo({ top, behavior: "smooth" });
+
+        if (options.select) {
+            view.dispatch({
+                selection: { anchor: line.from },
+                scrollIntoView: true,
+            });
+            view.focus();
+        }
+    }
+}


### PR DESCRIPTION
small QOL when we are able to capture the warning output
<img width="871" height="97" alt="image" src="https://github.com/user-attachments/assets/e59da9de-5075-443e-9d51-8be235404482" />
