### PR TITLE
Add gcc2.96

### DIFF
--- a/backend/compilers/compilers.linux.yaml
+++ b/backend/compilers/compilers.linux.yaml
@@ -4,6 +4,7 @@ common:
 gba:
   - agbcc
   - agbccpp
+  - gcc2.96
 
 gc_wii:
   - mwcc_233_144

--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -296,9 +296,9 @@ OLD_AGBCC = GCCCompiler(
 )
 
 GCC_296 = GCCCompiler(
-    id = "gcc2.96",
+    id="gcc2.96",
     platform=GBA,
-    cc='"${COMPILER_DIR}"/usr/local/bin/arm-elf-gcc $COMPILER_FLAGS -S -o - "$INPUT" | arm-none-eabi-as -mcpu=arm7tdmi -o "$OUTPUT"'
+    cc='"${COMPILER_DIR}"/usr/local/bin/arm-elf-gcc $COMPILER_FLAGS -S -o - "$INPUT" | arm-none-eabi-as -mcpu=arm7tdmi -o "$OUTPUT"',
 )
 
 AGBCC_ARM = GCCCompiler(

--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -295,6 +295,12 @@ OLD_AGBCC = GCCCompiler(
     base_compiler=AGBCC,
 )
 
+GCC_296 = GCCCompiler(
+    id = "gcc2.96",
+    platform=GBA,
+    cc='"${COMPILER_DIR}"/usr/local/bin/arm-elf-gcc $COMPILER_FLAGS -S -o - "$INPUT" | arm-none-eabi-as -mcpu=arm7tdmi -o "$OUTPUT"'
+)
+
 AGBCC_ARM = GCCCompiler(
     id="agbcc_arm",
     platform=GBA,
@@ -1686,6 +1692,7 @@ _all_compilers: list[Compiler] = [
     OLD_AGBCC,
     AGBCC_ARM,
     AGBCCPP,
+    GCC_296,
     # N3DS
     ARMCC_40_771,
     ARMCC_40_821,

--- a/frontend/src/lib/i18n/locales/en/compilers.json
+++ b/frontend/src/lib/i18n/locales/en/compilers.json
@@ -3,6 +3,8 @@
 
     "agbccpp": "agbccpp",
 
+    "gcc2.96": "gcc2.96",
+
     "armcc_40_771": "4.0 build 771",
     "armcc_40_821": "4.0 build 821",
     "armcc_40_865": "4.0 build 865",


### PR DESCRIPTION
Adds backend boilerplate for GCC 2.96, depends on https://github.com/decompme/compilers/pull/73 .

GCC 2.96 is a development snapshot between GCC 2.95 "agbcc" and GCC 3 which already has a unified thumb/arm compiler in one binary (`-mthumb`, `-marm`).

It was used in the game Golden Sun for the GBA.

If possible it would be nice to have a compiler flag preset for Golden Sun 1, it uses caller-save r4 to perform some arcane magic:
```
-O2 -mthumb -mthumb-interwork -mcpu=arm7tdmi -fcall-used-r4
```