### PR TITLE
Reduce unnecessary calls to /compile

### DIFF
--- a/frontend/src/app/scratch/[slug]/ScratchEditor.tsx
+++ b/frontend/src/app/scratch/[slug]/ScratchEditor.tsx
@@ -35,13 +35,6 @@ function ScratchEditorInner({
 
     useWarnBeforeScratchUnload(scratch, !isDeleting);
 
-    // If the static props scratch changes (i.e. router push / page redirect), reset `scratch`.
-    useEffect(() => {
-        if (currentScratchUrl !== initialScratchUrl) {
-            setScratch(initialScratch);
-        }
-    }, [currentScratchUrl, initialScratch, initialScratchUrl]);
-
     // If the server scratch owner changes (i.e. scratch was claimed), update local scratch owner.
     // You can trigger this by:
     // 1. Logging out
@@ -170,6 +163,7 @@ export interface Props {
 
 export default function ScratchEditor(props: Props) {
     const [offline, setOffline] = useState(false);
+    const initialScratchUrl = scratchUrl(props.initialScratch);
 
     const offlineMiddleware = useMemo<Middleware>(() => {
         return (_useSWRNext) => {
@@ -198,7 +192,11 @@ export default function ScratchEditor(props: Props) {
     return (
         <>
             <SWRConfig value={{ use: [offlineMiddleware], onSuccess }}>
-                <ScratchEditorInner {...props} offline={offline} />
+                <ScratchEditorInner
+                    key={initialScratchUrl}
+                    {...props}
+                    offline={offline}
+                />
             </SWRConfig>
         </>
     );

--- a/frontend/src/app/scratch/[slug]/page.tsx
+++ b/frontend/src/app/scratch/[slug]/page.tsx
@@ -1,5 +1,8 @@
 import type { Metadata, ResolvingMetadata } from "next";
 
+import { bubbleNotFound, get } from "@/lib/api/request";
+import type { Scratch } from "@/lib/api/types";
+
 import getScratchDetails from "./getScratchDetails";
 import ScratchEditor from "./ScratchEditor";
 
@@ -8,7 +11,9 @@ export async function generateMetadata(
     parent: ResolvingMetadata,
 ): Promise<Metadata> {
     const params = await props.params;
-    const { scratch } = await getScratchDetails(params.slug);
+    const scratch: Scratch = await get(`/scratch/${params.slug}`).catch(
+        bubbleNotFound,
+    );
     const parentData = await parent;
 
     return {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -194,60 +194,63 @@ export function useCompilation(
     const compileRequestPromiseRef = useRef<Promise<void> | null>(null);
     const pendingCompileRef = useRef(false);
 
-    const compile = useCallback((queueIfRunning = false) => {
-        if (compileRequestPromiseRef.current) {
-            if (queueIfRunning) {
-                pendingCompileRef.current = true;
+    const compile = useCallback(
+        (queueIfRunning = false) => {
+            if (compileRequestPromiseRef.current) {
+                if (queueIfRunning) {
+                    pendingCompileRef.current = true;
+                }
+                return compileRequestPromiseRef.current;
             }
-            return compileRequestPromiseRef.current;
-        }
 
-        if (!scratch)
-            return Promise.reject(
-                new Error("Cannot compile without a scratch"),
-            );
+            if (!scratch)
+                return Promise.reject(
+                    new Error("Cannot compile without a scratch"),
+                );
 
-        if (!scratch.compiler)
-            return Promise.reject(
-                new Error("Cannot compile before a compiler is set"),
-            );
+            if (!scratch.compiler)
+                return Promise.reject(
+                    new Error("Cannot compile before a compiler is set"),
+                );
 
-        const promise = post(
-            `${scratchUrl(scratch)}/compile`,
-            buildScratchCompileRequest(savedScratch, scratch),
-        )
-            .then((compilation: Compilation) => {
-                return compilation;
-            })
-            .then((compilation: Compilation) => {
-                setCompilation(compilation);
-            })
-            .finally(() => {
-                compileRequestPromiseRef.current = null;
-                setCompileRequestPromise(null);
-                if (!pendingCompileRef.current) {
-                    setIsCompilationOld(false);
-                }
-            })
-            .catch((error) => {
-                if (error instanceof ResponseError) {
-                    setCompilation({
-                        compiler_output: error.json?.detail,
-                        diff_output: null,
-                        success: false,
-                        left_object: null,
-                        right_object: null,
-                    });
-                } else {
-                    return Promise.reject(error);
-                }
-            });
+            const promise = post(
+                `${scratchUrl(scratch)}/compile`,
+                buildScratchCompileRequest(savedScratch, scratch),
+            )
+                .then((compilation: Compilation) => {
+                    return compilation;
+                })
+                .then((compilation: Compilation) => {
+                    setCompilation(compilation);
+                })
+                .finally(() => {
+                    compileRequestPromiseRef.current = null;
+                    setCompileRequestPromise(null);
+                    if (!pendingCompileRef.current) {
+                        setIsCompilationOld(false);
+                    }
+                })
+                .catch((error) => {
+                    if (error instanceof ResponseError) {
+                        setCompilation({
+                            compiler_output: error.json?.detail,
+                            diff_output: null,
+                            success: false,
+                            left_object: null,
+                            right_object: null,
+                        });
+                    } else {
+                        return Promise.reject(error);
+                    }
+                });
 
-        compileRequestPromiseRef.current = promise;
-        setCompileRequestPromise(promise);
+            compileRequestPromiseRef.current = promise;
+            setCompileRequestPromise(promise);
 
-        return promise;
-    }, [savedScratch, scratch]);
+            return promise;
+        },
+        [savedScratch, scratch],
+    );
 
     // If the scratch we're looking at changes, we need to recompile
     const [url, setUrl] = useState(sUrl);

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -271,7 +271,6 @@ export function useCompilation(
         }
     }, [
         // eslint-disable-line react-hooks/exhaustive-deps
-        debouncedCompile,
         autoRecompile,
 
         // fields passed to compilations

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useRef } from "react";
+import { useState, useCallback, useEffect, useMemo, useRef } from "react";
 
 import { useRouter } from "@/lib/navigation";
 
@@ -193,6 +193,30 @@ export function useCompilation(
     const hasInitialized = useRef(false);
     const compileRequestPromiseRef = useRef<Promise<void> | null>(null);
     const pendingCompileRef = useRef(false);
+    const compileInputKey = useMemo(
+        () =>
+            JSON.stringify({
+                compiler: scratch?.compiler,
+                compiler_flags: scratch?.compiler_flags,
+                diff_flags: scratch?.diff_flags,
+                diff_label: scratch?.diff_label,
+                source_code: scratch?.source_code,
+                context: scratch?.context,
+                libraries: scratch?.libraries,
+            }),
+        [
+            scratch?.compiler,
+            scratch?.compiler_flags,
+            scratch?.diff_flags,
+            scratch?.diff_label,
+            scratch?.source_code,
+            scratch?.context,
+            scratch?.libraries,
+        ],
+    );
+    const compiledInputKeyRef = useRef<string | null>(
+        initial ? compileInputKey : null,
+    );
 
     const compile = useCallback(
         (queueIfRunning = false) => {
@@ -213,6 +237,7 @@ export function useCompilation(
                     new Error("Cannot compile before a compiler is set"),
                 );
 
+            const requestInputKey = compileInputKey;
             const promise = post(
                 `${scratchUrl(scratch)}/compile`,
                 buildScratchCompileRequest(savedScratch, scratch),
@@ -221,6 +246,7 @@ export function useCompilation(
                     return compilation;
                 })
                 .then((compilation: Compilation) => {
+                    compiledInputKeyRef.current = requestInputKey;
                     setCompilation(compilation);
                 })
                 .finally(() => {
@@ -232,6 +258,7 @@ export function useCompilation(
                 })
                 .catch((error) => {
                     if (error instanceof ResponseError) {
+                        compiledInputKeyRef.current = requestInputKey;
                         setCompilation({
                             compiler_output: error.json?.detail,
                             diff_output: null,
@@ -249,7 +276,7 @@ export function useCompilation(
 
             return promise;
         },
-        [savedScratch, scratch],
+        [compileInputKey, savedScratch, scratch],
     );
 
     // If the scratch we're looking at changes, we need to recompile
@@ -280,6 +307,10 @@ export function useCompilation(
                 compile();
             }
         } else {
+            if (compileInputKey === compiledInputKeyRef.current) {
+                return;
+            }
+
             setIsCompilationOld(true);
 
             if (autoRecompile) {
@@ -293,15 +324,7 @@ export function useCompilation(
     }, [
         // eslint-disable-line react-hooks/exhaustive-deps
         autoRecompile,
-
-        // fields passed to compilations
-        scratch.compiler,
-        scratch.compiler_flags,
-        scratch.diff_flags,
-        scratch.diff_label,
-        scratch.source_code,
-        scratch.context,
-        scratch.libraries,
+        compileInputKey,
     ]);
 
     return {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -172,6 +172,28 @@ export function useIsScratchSaved(scratch: Scratch, enabled = true): boolean {
     return isScratchSaved(scratch, saved);
 }
 
+function getScratchCompileInputKey(scratch: Scratch | null): string {
+    return JSON.stringify({
+        compiler: scratch?.compiler,
+        compiler_flags: scratch?.compiler_flags,
+        diff_flags: scratch?.diff_flags,
+        diff_label: scratch?.diff_label,
+        source_code: scratch?.source_code,
+        context: scratch?.context,
+        libraries: scratch?.libraries,
+    });
+}
+
+type CompilationState = {
+    compilation: Compilation | null;
+    inputKey: string | null;
+};
+
+type CompileRequest = {
+    promise: Promise<void>;
+    runAgain: boolean;
+};
+
 export function useCompilation(
     scratch: Scratch | null,
     autoRecompile: boolean,
@@ -185,46 +207,31 @@ export function useCompilation(
     isCompilationOld: boolean;
 } {
     const savedScratch = useSavedScratch(scratch);
-    const [compileRequestPromise, setCompileRequestPromise] =
-        useState<Promise<void>>(null);
-    const [compilation, setCompilation] = useState<Compilation>(initial);
+    const [isCompiling, setIsCompiling] = useState(false);
+    const compileInputKey = useMemo(
+        () => getScratchCompileInputKey(scratch),
+        [scratch],
+    );
+    const [compilationState, setCompilationState] = useState<CompilationState>(
+        () => ({
+            compilation: initial,
+            inputKey: initial ? compileInputKey : null,
+        }),
+    );
+    const compilation = compilationState.compilation;
     const [isCompilationOld, setIsCompilationOld] = useState(false);
+    const [queuedCompile, setQueuedCompile] = useState(false);
     const sUrl = scratchUrl(scratch);
     const hasInitialized = useRef(false);
-    const compileRequestPromiseRef = useRef<Promise<void> | null>(null);
-    const pendingCompileRef = useRef(false);
-    const compileInputKey = useMemo(
-        () =>
-            JSON.stringify({
-                compiler: scratch?.compiler,
-                compiler_flags: scratch?.compiler_flags,
-                diff_flags: scratch?.diff_flags,
-                diff_label: scratch?.diff_label,
-                source_code: scratch?.source_code,
-                context: scratch?.context,
-                libraries: scratch?.libraries,
-            }),
-        [
-            scratch?.compiler,
-            scratch?.compiler_flags,
-            scratch?.diff_flags,
-            scratch?.diff_label,
-            scratch?.source_code,
-            scratch?.context,
-            scratch?.libraries,
-        ],
-    );
-    const compiledInputKeyRef = useRef<string | null>(
-        initial ? compileInputKey : null,
-    );
+    const compileRequestRef = useRef<CompileRequest | null>(null);
 
     const compile = useCallback(
         (queueIfRunning = false) => {
-            if (compileRequestPromiseRef.current) {
+            if (compileRequestRef.current) {
                 if (queueIfRunning) {
-                    pendingCompileRef.current = true;
+                    compileRequestRef.current.runAgain = true;
                 }
-                return compileRequestPromiseRef.current;
+                return compileRequestRef.current.promise;
             }
 
             if (!scratch)
@@ -246,33 +253,40 @@ export function useCompilation(
                     return compilation;
                 })
                 .then((compilation: Compilation) => {
-                    compiledInputKeyRef.current = requestInputKey;
-                    setCompilation(compilation);
+                    setCompilationState({
+                        compilation,
+                        inputKey: requestInputKey,
+                    });
                 })
                 .finally(() => {
-                    compileRequestPromiseRef.current = null;
-                    setCompileRequestPromise(null);
-                    if (!pendingCompileRef.current) {
+                    const runAgain = compileRequestRef.current?.runAgain;
+                    compileRequestRef.current = null;
+                    setIsCompiling(false);
+                    if (runAgain) {
+                        setQueuedCompile(true);
+                    } else {
                         setIsCompilationOld(false);
                     }
                 })
                 .catch((error) => {
                     if (error instanceof ResponseError) {
-                        compiledInputKeyRef.current = requestInputKey;
-                        setCompilation({
-                            compiler_output: error.json?.detail,
-                            diff_output: null,
-                            success: false,
-                            left_object: null,
-                            right_object: null,
+                        setCompilationState({
+                            compilation: {
+                                compiler_output: error.json?.detail,
+                                diff_output: null,
+                                success: false,
+                                left_object: null,
+                                right_object: null,
+                            },
+                            inputKey: requestInputKey,
                         });
                     } else {
                         return Promise.reject(error);
                     }
                 });
 
-            compileRequestPromiseRef.current = promise;
-            setCompileRequestPromise(promise);
+            compileRequestRef.current = { promise, runAgain: false };
+            setIsCompiling(true);
 
             return promise;
         },
@@ -294,11 +308,11 @@ export function useCompilation(
     });
 
     useEffect(() => {
-        if (compileRequestPromise || !pendingCompileRef.current) return;
+        if (isCompiling || !queuedCompile) return;
 
-        pendingCompileRef.current = false;
+        setQueuedCompile(false);
         compile();
-    }, [compile, compileRequestPromise]);
+    }, [compile, isCompiling, queuedCompile]);
 
     useEffect(() => {
         if (!hasInitialized.current) {
@@ -307,7 +321,7 @@ export function useCompilation(
                 compile();
             }
         } else {
-            if (compileInputKey === compiledInputKeyRef.current) {
+            if (compileInputKey === compilationState.inputKey) {
                 return;
             }
 
@@ -317,7 +331,10 @@ export function useCompilation(
                 if (scratch && scratch.compiler !== "") {
                     debouncedCompile(true);
                 } else {
-                    setCompilation(null);
+                    setCompilationState({
+                        compilation: null,
+                        inputKey: compileInputKey,
+                    });
                 }
             }
         }
@@ -325,13 +342,14 @@ export function useCompilation(
         // eslint-disable-line react-hooks/exhaustive-deps
         autoRecompile,
         compileInputKey,
+        compilationState.inputKey,
     ]);
 
     return {
         compilation,
         compile,
         debouncedCompile,
-        isCompiling: !!compileRequestPromise,
+        isCompiling,
         isCompilationOld,
     };
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -191,9 +191,16 @@ export function useCompilation(
     const [isCompilationOld, setIsCompilationOld] = useState(false);
     const sUrl = scratchUrl(scratch);
     const hasInitialized = useRef(false);
+    const compileRequestPromiseRef = useRef<Promise<void> | null>(null);
+    const pendingCompileRef = useRef(false);
 
-    const compile = useCallback(() => {
-        if (compileRequestPromise) return compileRequestPromise;
+    const compile = useCallback((queueIfRunning = false) => {
+        if (compileRequestPromiseRef.current) {
+            if (queueIfRunning) {
+                pendingCompileRef.current = true;
+            }
+            return compileRequestPromiseRef.current;
+        }
 
         if (!scratch)
             return Promise.reject(
@@ -216,8 +223,11 @@ export function useCompilation(
                 setCompilation(compilation);
             })
             .finally(() => {
+                compileRequestPromiseRef.current = null;
                 setCompileRequestPromise(null);
-                setIsCompilationOld(false);
+                if (!pendingCompileRef.current) {
+                    setIsCompilationOld(false);
+                }
             })
             .catch((error) => {
                 if (error instanceof ResponseError) {
@@ -233,10 +243,11 @@ export function useCompilation(
                 }
             });
 
+        compileRequestPromiseRef.current = promise;
         setCompileRequestPromise(promise);
 
         return promise;
-    }, [compileRequestPromise, savedScratch, scratch]);
+    }, [savedScratch, scratch]);
 
     // If the scratch we're looking at changes, we need to recompile
     const [url, setUrl] = useState(sUrl);
@@ -253,6 +264,13 @@ export function useCompilation(
     });
 
     useEffect(() => {
+        if (compileRequestPromise || !pendingCompileRef.current) return;
+
+        pendingCompileRef.current = false;
+        compile();
+    }, [compile, compileRequestPromise]);
+
+    useEffect(() => {
         if (!hasInitialized.current) {
             hasInitialized.current = true;
             if (!compilation) {
@@ -263,7 +281,7 @@ export function useCompilation(
 
             if (autoRecompile) {
                 if (scratch && scratch.compiler !== "") {
-                    debouncedCompile();
+                    debouncedCompile(true);
                 } else {
                     setCompilation(null);
                 }


### PR DESCRIPTION
We get the `compilation` from the SSR, but because debouncedCompile function changes, we fire a fresh (but unnecessary) request to /compile.