### PR TITLE
Fix Watcom 16-bit codegen compiler selection

### DIFF
--- a/backend/coreapp/compiler_wrapper.py
+++ b/backend/coreapp/compiler_wrapper.py
@@ -43,6 +43,23 @@ def _check_assembly_cache(*args: str) -> tuple[Assembly | None, str]:
 
 class CompilerWrapper:
     @staticmethod
+    def get_compiler_command(compiler: Compiler, compiler_flags: str) -> str:
+        cc_cmd = compiler.cc
+
+        if (
+            isinstance(compiler, compilers.WatcomCompiler)
+            and compiler.language == Language.C
+            and any(flag in {"-0", "-1", "-2"} for flag in compiler_flags.split())
+        ):
+            cc_cmd = cc_cmd.replace("/wcc386.exe", "/wcc.exe")
+
+        # IDO hack to support -KPIC
+        if compiler.type == CompilerType.IDO and "-KPIC" in compiler_flags:
+            cc_cmd = cc_cmd.replace("-non_shared", "")
+
+        return cc_cmd
+
+    @staticmethod
     def filter_compiler_flags(compiler_flags: str) -> str:
         # Remove irrelevant flags that are part of the base compiler configs or
         # don't affect matching, but clutter the compiler settings field.
@@ -128,7 +145,7 @@ class CompilerWrapper:
                 f.write(code)
                 f.write("\n")
 
-            cc_cmd = compiler.cc
+            cc_cmd = CompilerWrapper.get_compiler_command(compiler, compiler_flags)
 
             # MWCC requires the file to exist for DWARF line numbers,
             # and requires the file contents for error messages
@@ -144,10 +161,6 @@ class CompilerWrapper:
                 with src_path.open("w") as f:
                     f.write(code)
                     f.write("\n")
-
-            # IDO hack to support -KPIC
-            if compiler.type == CompilerType.IDO and "-KPIC" in compiler_flags:
-                cc_cmd = cc_cmd.replace("-non_shared", "")
 
             if compiler.platform != platforms.DUMMY and not compiler.path.exists():
                 raise CompilationError(f"Compiler {compiler.id} is not installed")

--- a/backend/coreapp/tests/test_compilation.py
+++ b/backend/coreapp/tests/test_compilation.py
@@ -17,6 +17,7 @@ from coreapp.compilers import (
     MWCC_247_92,
     PBX_GCC3,
     WATCOM_105_C,
+    WATCOM_105_CPP,
     Compiler,
     DummyCompiler,
 )
@@ -220,6 +221,21 @@ nop
         self.assertGreater(
             len(result.elf_object), 0, "The compilation result should be non-null"
         )
+
+    def test_watcom_16_bit_codegen_uses_16_bit_compiler(self) -> None:
+        for flag in ("-0", "-1", "-2"):
+            with self.subTest(flag=flag):
+                cc_cmd = CompilerWrapper.get_compiler_command(WATCOM_105_C, flag)
+                self.assertIn("/wcc.exe", cc_cmd)
+                self.assertNotIn("/wcc386.exe", cc_cmd)
+
+    def test_watcom_32_bit_codegen_uses_386_compiler(self) -> None:
+        cc_cmd = CompilerWrapper.get_compiler_command(WATCOM_105_C, "-3r")
+        self.assertIn("/wcc386.exe", cc_cmd)
+
+    def test_watcom_cpp_keeps_386_compiler(self) -> None:
+        cc_cmd = CompilerWrapper.get_compiler_command(WATCOM_105_CPP, "-2")
+        self.assertIn("/wpp386.exe", cc_cmd)
 
     def test_dummy_compiler(self) -> None:
         """


### PR DESCRIPTION
Watcom C compiler presets using 16-bit code-generation flags now invoke `wcc.exe` instead of `wcc386.exe`, while 386 C and C++ presets keep their existing compiler binaries.

Fixes #1645

Validation:

```bash
uv run python manage.py test coreapp.tests.test_compilation.CompilationTests.test_watcom_16_bit_codegen_uses_16_bit_compiler coreapp.tests.test_compilation.CompilationTests.test_watcom_32_bit_codegen_uses_386_compiler coreapp.tests.test_compilation.CompilationTests.test_watcom_cpp_keeps_386_compiler -v 2
uv run ruff check coreapp/compiler_wrapper.py coreapp/tests/test_compilation.py
uv run ruff format --check coreapp/compiler_wrapper.py coreapp/tests/test_compilation.py
```

All commands passed.
