### PR TITLE
try to debug why dosemu is failing in CI

### DIFF
--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -433,8 +433,8 @@ PSYQ_MSDOS_CC = (
     "echo \"\\$_hdimage = '+0 $(pwd) +1'\" > .dosemurc && "
     f'echo "{PSYQ_COMPILE_BAT}" >> COMPILE.BAT && '
     '/usr/bin/cpp -E "${INPUT}" | unix2dos > dos_src.c && '
-    '(HOME="$(pwd)" LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/i386-pc-dj64/lib64 /usr/bin/dosemu -quiet -dumb -f .dosemurc -p -K "${COMPILER_DIR}" -E "D:\\COMPILE.BAT") && '
-    '(HOME="$(pwd)" LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/i386-pc-dj64/lib64 /usr/bin/dosemu -quiet -dumb -f .dosemurc -p -K "${COMPILER_DIR}" -E "ASPSX.EXE -quiet D:\\output.s -o D:\\output.obj") && '
+    '(HOME="$(pwd)" LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/i386-pc-dj64/lib64 /usr/bin/dosemu -dumb -f .dosemurc -p -K "${COMPILER_DIR}" -E "D:\\COMPILE.BAT") && '
+    '(HOME="$(pwd)" LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/i386-pc-dj64/lib64 /usr/bin/dosemu -dumb -f .dosemurc -p -K "${COMPILER_DIR}" -E "ASPSX.EXE -quiet D:\\output.s -o D:\\output.obj") && '
     '${COMPILER_DIR}/psyq-obj-parser output.obj -o "${OUTPUT}"'
 )
 
@@ -584,9 +584,9 @@ GCC2723_MIPSEL = GCCPS1Compiler(
 SATURN_CC = (
     "echo \"\\$_hdimage = '+0 $(pwd) +1'\" > .dosemurc && "
     'cat "${INPUT}" | unix2dos > dos_src.c && '
-    '(HOME="$(pwd)" LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/i386-pc-dj64/lib64 /usr/bin/dosemu -quiet -dumb -f .dosemurc -p -K "${COMPILER_DIR}" -E "CPP.EXE D:\\dos_src.c -o D:\\src_proc.c") && '
-    '(HOME="$(pwd)" LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/i386-pc-dj64/lib64 /usr/bin/dosemu -quiet -dumb -f .dosemurc -p -K "${COMPILER_DIR}" -E "CC1.EXE -quiet ${COMPILER_FLAGS} D:\\src_proc.c -o D:\\output.s") && '
-    '(HOME="$(pwd)" LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/i386-pc-dj64/lib64 /usr/bin/dosemu -quiet -dumb -f .dosemurc -p -K "${COMPILER_DIR}" -E "AS.EXE D:\\output.s -o D:\\output.o") && '
+    '(HOME="$(pwd)" LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/i386-pc-dj64/lib64 /usr/bin/dosemu -dumb -f .dosemurc -p -K "${COMPILER_DIR}" -E "CPP.EXE D:\\dos_src.c -o D:\\src_proc.c") && '
+    '(HOME="$(pwd)" LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/i386-pc-dj64/lib64 /usr/bin/dosemu -dumb -f .dosemurc -p -K "${COMPILER_DIR}" -E "CC1.EXE -quiet ${COMPILER_FLAGS} D:\\src_proc.c -o D:\\output.s") && '
+    '(HOME="$(pwd)" LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/i386-pc-dj64/lib64 /usr/bin/dosemu -dumb -f .dosemurc -p -K "${COMPILER_DIR}" -E "AS.EXE D:\\output.s -o D:\\output.o") && '
     'sh-elf-objcopy -Icoff-sh -Oelf32-sh output.o "${OUTPUT}"'
 )
 
@@ -1631,7 +1631,7 @@ WATCOM_110_CPP = WatcomCompiler(
 BORLAND_MSDOS_CC = (
     "echo \"\\$_hdimage = '+0 ${COMPILER_DIR} +1'\" > .dosemurc && "
     'cat "${INPUT}" | unix2dos > dos_src.c && '
-    '(HOME="$(pwd)" LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/i386-pc-dj64/lib64 /usr/bin/dosemu -quiet -dumb -f .dosemurc -p -K . -E "D:\\bin\\bcc.exe -ID:\\include ${COMPILER_FLAGS} -c -oout.o dos_src.c") && '
+    '(HOME="$(pwd)" LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/i386-pc-dj64/lib64 /usr/bin/dosemu -dumb -f .dosemurc -p -K . -E "D:\\bin\\bcc.exe -ID:\\include ${COMPILER_FLAGS} -c -oout.o dos_src.c") && '
     'cp out.o "${OUTPUT}"'
 )
 
@@ -1653,7 +1653,7 @@ MSC_51 = MicrosoftCCompiler(
     cc=(
         "echo \"\\$_hdimage = '+0 ${COMPILER_DIR} +1'\" > .dosemurc && "
         'cat "${INPUT}" | unix2dos > dos_src.c && '
-        '(HOME="$(pwd)" LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/i386-pc-dj64/lib64 /usr/bin/dosemu -quiet -dumb -f .dosemurc -p -K . -E "D:\\BIN\\CL.EXE /c ${COMPILER_FLAGS} /Foout.o dos_src.c") && '
+        '(HOME="$(pwd)" LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/i386-pc-dj64/lib64 /usr/bin/dosemu -dumb -f .dosemurc -p -K . -E "D:\\BIN\\CL.EXE /c ${COMPILER_FLAGS} /Foout.o dos_src.c") && '
         'cp out.o "${OUTPUT}"'
     ),
 )


### PR DESCRIPTION
not obvious as to why its failing... unless those ERRORs are actually fatal. I've not managed to reproduce this locally.

```
dosemu2 2.0pre9
Get the latest code at http://dosemu2.github.io/dosemu2
Submit Bugs via https://github.com/dosemu2/dosemu2/issues
Ask for help in: https://github.com/dosemu2/dosemu2/discussions
This program comes with ABSOLUTELY NO WARRANTY.
This is free software, GPL v2 (or any later version) distribution conditions.

FDPP kernel 1.7 [GIT: ]
Kernel compatibility 7.10 - clang - FAT32 support

Written by @stsp, FDPP project.
Based on FreeDOS sources (C) Pasquale J. Villani and The FreeDOS Project.

This program is free software: you can redistribute it and/or modify
it under the terms of the GNU General Public License as published by
the Free Software Foundation, either version 3 of the License, or
(at your option) any later version.

C: HD1, Pri[ 1], CHS=    0-1-1, start=     0 MB, size=  2000 MB
D: HD2, Pri[ 1], CHS=    0-1-1, start=     0 MB, size=  2000 MB
E: HD3, Pri[ 1], CHS=    0-1-1, start=     0 MB, size=  2000 MB
F: HD4, Pri[ 1], CHS=    0-1-1, start=     0 MB, size=  2000 MB

                                                                               
EMUFS host file and print access, non-resident driver mode
dosemu XMS 3.0 & UMB support enabled
dosemu EMS driver rev 0.9 installed.
dosemu CDROM driver installed (V0.2)
Process 0 starting: F:\command.com /e:512 /k %FDPP_AUTOEXEC% /M2
BLASTER=A220 I5 D1 H5 P300 T6
MIDI=SYNTH:2 MAP:E MODE:0
Welcome to dosemu2!
    Build 2.0pre9
Error: unable to execute G:\CPP.EXE

ERROR: KVM: error opening /dev/kvm: No such file or directory
ERROR: Unable to open console or check with X to evaluate the keyboard map.
Please specify your keyboard map explicitly via the $_layout option. Defaulting to US.
ERROR: ladspa: failed to load filter.so
ERROR: Failed to load plugin /usr/lib/x86_64-linux-gnu/ao/plugins-4/libsndio.so => dlopen() failed
ERROR: Failed to load plugin /usr/lib/x86_64-linux-gnu/ao/plugins-4/libnas.so => dlopen() failed
ERROR: Failed to load plugin /usr/lib/x86_64-linux-gnu/ao/plugins-4/libalsa.so => dlopen() failed
ERROR: libao: default driver not specified, trying alsa
ERROR: libao: unable to get driver id
ERROR: kbd: EOF from stdin
```