### PR TITLE
Github link in FAQ page is invalid

### DIFF
--- a/frontend/src/app/(navfooter)/faq/page.tsx
+++ b/frontend/src/app/(navfooter)/faq/page.tsx
@@ -79,7 +79,7 @@ export default function Page() {
             </p>
             <p className="my-4">
                 It is an{" "}
-                <FaqLink href="https://www.github.com/decomp.me">
+                <FaqLink href="https://www.github.com/decompme/decomp.me">
                     open-source project
                 </FaqLink>{" "}
                 run by volunteers in their free time.


### PR DESCRIPTION
The link to this repo from the FAQ page points to
`https://github.com/decomp.me`
which is invalid and doesn't redirect to this repository

The correct URL should therefore either be
`https://github.com/decompme` (organization page)
or
`https://github.com/decompme/decomp.me` (repository page)

I'm assuming in that context it was meant to redirect to the repository,
so the proposed changes will reflect that