### PR TITLE
Add Watcom C/C++ Compiler 10.0a

### DIFF
--- a/backend/compilers/compilers.linux.yaml
+++ b/backend/compilers/compilers.linux.yaml
@@ -211,6 +211,7 @@ macosx:
   - gcc3-1041
 
 msdos:
+  - wcc10.0a
   - wcc10.5
   - wcc10.5a
   - wcc10.6

--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -1572,6 +1572,20 @@ WATCOM_CXX = (
     + "\" | sed 's:/:\\\\:g')"
 )
 
+WATCOM_100A_C = WatcomCompiler(
+    id="wcc10.0a",
+    platform=MSDOS,
+    cc=WATCOM_CC,
+)
+
+WATCOM_100A_CPP = WatcomCompiler(
+    id="wpp10.0a",
+    base_compiler=WATCOM_100A_C,
+    platform=MSDOS,
+    language=Language.CXX,
+    cc=WATCOM_CXX,
+)
+
 WATCOM_105_C = WatcomCompiler(
     id="wcc10.5",
     platform=MSDOS,
@@ -1920,6 +1934,8 @@ _all_compilers: list[Compiler] = [
     MSVC80,
     MSVC80P,
     # Watcom, DOS and Win32
+    WATCOM_100A_C,
+    WATCOM_100A_CPP,
     WATCOM_105_C,
     WATCOM_105_CPP,
     WATCOM_105A_C,

--- a/frontend/src/lib/i18n/locales/en/compilers.json
+++ b/frontend/src/lib/i18n/locales/en/compilers.json
@@ -246,6 +246,8 @@
     "pspsnc_1.2.7503.0": "SN 1.2.7503.0",
     "psp-gcc-1.3.1": "GCC 3.3.3+allegrex-2.2.1-psp-1.3.1",
 
+    "wcc10.0a": "Watcom Optimizing C i386 Compiler 10.0a",
+    "wpp10.0a": "Watcom Optimizing C++ i386 Compiler 10.0a",
     "wcc10.5": "Watcom Optimizing C i386 Compiler 10.5",
     "wpp10.5": "Watcom Optimizing C++ i386 Compiler 10.5",
     "wcc10.5a": "Watcom Optimizing C i386 Compiler 10.5a",


### PR DESCRIPTION
Depends on https://github.com/decompme/compilers/pull/74

I'm working on a MechWarrior 2 decomp that needs this compiler. I tested it with a local instance and it built a scratch without problems.