### PR TITLE
Use era appropriate cpp for ps1 gcc

### DIFF
--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -505,7 +505,7 @@ PSYQ46 = GCCPS1Compiler(
 )
 
 PS1_GCC = (
-    '/usr/bin/cpp -E -lang-c -nostdinc "${INPUT}" -o "${INPUT}".i && '
+    '${COMPILER_DIR}/cpp -E -lang-c -nostdinc "${INPUT}" -o "${INPUT}".i && '
     'eval "${COMPILER_DIR}/gcc ${COMPILER_FLAGS} -c -pipe -B${COMPILER_DIR}/ -o "${OUTPUT}" "${INPUT}".i"'
 )
 


### PR DESCRIPTION
Modern `cpp` emits `# 0` line directives which old GCC chokes on.

Closes #2007.