### PR TITLE
No need to bust frontend docker cache if no frontend changes

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -40,8 +40,6 @@ ENV GITHUB_CLIENT_ID=${GITHUB_CLIENT_ID}
 ARG OBJDIFF_BASE=https://diff.decomp.me/
 ENV OBJDIFF_BASE=${OBJDIFF_BASE}
 
-ARG GIT_HASH
-
 RUN yarn build && rm -rf .next/cache
 
 


### PR DESCRIPTION
We used to always bust the cache to ensure the frontend triggered a rebuild if the backend changed, but now that the frontend does not rely on backend being up to build, this is unnecessary and prevents efficient docker layer caching.