### PR TITLE
Turn on m2c for saturn

### DIFF
--- a/backend/coreapp/m2c_wrapper.py
+++ b/backend/coreapp/m2c_wrapper.py
@@ -29,6 +29,8 @@ PLATFORM_ID_TO_M2C_ARCH = {
     "gba": "gba",
     "n3ds": "arm",
     "nds_arm9": "arm",
+    # superh
+    "saturn": "sh2",
 }
 
 

--- a/backend/coreapp/platforms.py
+++ b/backend/coreapp/platforms.py
@@ -172,6 +172,7 @@ SATURN = Platform(
     objdump_cmd="sh-elf-objdump",
     nm_cmd="sh-elf-nm",
     diff_flags=COMMON_DIFF_FLAGS,
+    has_decompiler=True,
 )
 
 DREAMCAST = Platform(

--- a/backend/coreapp/tests/test_decompilation.py
+++ b/backend/coreapp/tests/test_decompilation.py
@@ -2,7 +2,7 @@ from django.test.testcases import TestCase
 from django.urls import reverse
 from rest_framework import status
 
-from coreapp.compilers import GCC281PM, IDO53, MWCC_247_92
+from coreapp.compilers import CYGNUS_2_7_96Q3, GCC281PM, IDO53, MWCC_247_92
 from coreapp.decompiler_wrapper import DECOMP_WITH_CONTEXT_FAILED_PREAMBLE
 from coreapp.m2c_wrapper import M2CWrapper
 from coreapp.platforms import N64
@@ -143,3 +143,21 @@ class M2CTests(TestCase):
             "s32 func_800B43A8(s32 arg0, s32 arg1) {\n    return (arg0 ^ arg0) - arg1;\n}\n",
             c_code,
         )
+
+    def test_superh(self) -> None:
+        c_code = M2CWrapper.decompile(
+            """
+        .global test
+        test:
+        mov.l r14,@-r15
+        mov r15,r14
+        mov.l @r15+,r14
+        rts
+        mov #1,r0
+        """,
+            "",
+            "saturn",
+            CYGNUS_2_7_96Q3,
+        )
+
+        self.assertEqual("s32 test(void) {\n    return 1;\n}\n", c_code)


### PR DESCRIPTION
This enables m2c for saturn and adds a unit test. I tested locally and it seemed to work fine.