### PR TITLE
Add FE8J agbcc compiler

### DIFF
--- a/backend/compilers/compilers.linux.yaml
+++ b/backend/compilers/compilers.linux.yaml
@@ -3,6 +3,7 @@ common:
 
 gba:
   - agbcc
+  - agbcc-fe8j
   - agbccpp
   - gcc2.96
 

--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -288,6 +288,12 @@ AGBCC = GCCCompiler(
     cc='/usr/bin/cpp -E -I "${COMPILER_DIR}"/include -iquote include -nostdinc -undef "$INPUT" | "${COMPILER_DIR}"/bin/agbcc $COMPILER_FLAGS -o - | arm-none-eabi-as -mcpu=arm7tdmi -o "$OUTPUT"',
 )
 
+AGBCC_FE8J = GCCCompiler(
+    id="agbcc-fe8j",
+    platform=GBA,
+    cc='/usr/bin/cpp -E -I "${COMPILER_DIR}"/include -iquote include -nostdinc -undef "$INPUT" | "${COMPILER_DIR}"/bin/agbcc $COMPILER_FLAGS -o - | arm-none-eabi-as -mcpu=arm7tdmi -o "$OUTPUT"',
+)
+
 OLD_AGBCC = GCCCompiler(
     id="old_agbcc",
     platform=GBA,
@@ -1704,6 +1710,7 @@ _all_compilers: list[Compiler] = [
     DUMMY_LONGRUNNING,
     # GBA
     AGBCC,
+    AGBCC_FE8J,
     OLD_AGBCC,
     AGBCC_ARM,
     AGBCCPP,

--- a/backend/coreapp/tests/test_compilation.py
+++ b/backend/coreapp/tests/test_compilation.py
@@ -9,6 +9,7 @@ from rest_framework import status
 from coreapp import compilers
 from coreapp.compiler_wrapper import CompilerWrapper
 from coreapp.compilers import (
+    AGBCC_FE8J,
     GCC281PM,
     GHS5322,
     IDO53,
@@ -35,6 +36,18 @@ def all_compilers_name_func(
 
 
 class CompilationTests(BaseTestCase):
+    @requiresCompiler(AGBCC_FE8J)
+    def test_agbcc_fe8j_promotion_flag(self) -> None:
+        result = CompilerWrapper.compile_code(
+            AGBCC_FE8J,
+            "-O2 -mthumb-interwork -mjp-promote",
+            "int func(void) { return 5; }",
+            "",
+            "func",
+        )
+
+        self.assertGreater(len(result.elf_object), 0)
+
     def test_compile_drops_blank_diff_flags(self) -> None:
         scratch = self.create_nop_scratch()
 

--- a/frontend/src/lib/i18n/locales/en/compilers.json
+++ b/frontend/src/lib/i18n/locales/en/compilers.json
@@ -1,6 +1,8 @@
 {
     "agbcc": "agbcc",
 
+    "agbcc-fe8j": "agbcc (Fire Emblem 8 JP)",
+
     "agbccpp": "agbccpp",
 
     "gcc2.96": "gcc2.96",


### PR DESCRIPTION
Adds the `agbcc-fe8j` compiler integration for [fireemblem8j issue #168](https://github.com/laqieer/fireemblem8j/issues/168).

- registers the compiler package on GBA
- uses the existing agbcc `cpp -> cc1 -> arm-none-eabi-as` pipeline
- adds the user-facing name `agbcc (Fire Emblem 8 JP)`
- adds a focused backend test proving `-mjp-promote` compiles

The source/release is https://github.com/laqieer/agbcc/releases/tag/fe8j-v1. Compiler package PR https://github.com/decompme/compilers/pull/75 is merged, and `ghcr.io/decompme/compilers/gba/agbcc-fe8j:latest` is published at digest `sha256:8c32b82006d422315f9bc92ce2555ee3ceed4f3d357e4224315f9fc1f8fab231`.

Production-path verification used this repository's own `compilers/download.py` to extract the official image, confirmed `/compilers/gba/agbcc-fe8j/bin/agbcc`, and compiled a probe with `-mjp-promote`. The extracted compiler SHA-256 is `348b0e28ea21a691cc8e88a882883b5bba6d7c6eedda16331b584b1db3c28b1c`, matching the validated release build. The focused Django test, MyPy, Ruff, formatting, and Vercel checks pass.

This PR is ready for Actions approval and review.