### PR TITLE
Update Dreamcast arch

### DIFF
--- a/backend/coreapp/platforms.py
+++ b/backend/coreapp/platforms.py
@@ -179,7 +179,7 @@ DREAMCAST = Platform(
     id="dreamcast",
     name="Dreamcast",
     description="SH4 (little-endian)",
-    arch="sh4",
+    arch="sh4el",
     assemble_cmd='sh-elf-as --isa=sh4 --little --relax -o "$OUTPUT" "$PRELUDE" "$INPUT"',
     objdump_cmd="sh-elf-objdump",
     nm_cmd="sh-elf-nm",


### PR DESCRIPTION
Previously SH asm-differ would guess the endian of the input but I recently changed that to use the arch's endian instead, which means some bytes in Dreamcast would be interpreted as Big Endian without this change.