### PR TITLE
add best functions by name page

### DIFF
--- a/backend/coreapp/middleware.py
+++ b/backend/coreapp/middleware.py
@@ -50,6 +50,7 @@ def is_public_get_request(req: Request) -> bool:
         "/api/platform",
         "/api/preset",
         "/api/scratch-count$",
+        "/api/scratch/best-by-name$",
         "/api/scratch/[A-Za-z0-9]+/compile$",
         "/api/scratch/[A-Za-z0-9]+/export$",
         "/api/scratch/[A-Za-z0-9]+/family$",

--- a/backend/coreapp/pagination.py
+++ b/backend/coreapp/pagination.py
@@ -3,7 +3,7 @@ from typing import Any
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db.models import QuerySet
 from rest_framework.exceptions import ParseError
-from rest_framework.pagination import CursorPagination
+from rest_framework.pagination import CursorPagination, PageNumberPagination
 from rest_framework.request import Request
 from rest_framework.views import APIView
 
@@ -25,3 +25,9 @@ class SafeCursorPagination(CursorPagination):
     def _cursor_has_position(self) -> bool:
         cursor = getattr(self, "cursor", None)
         return getattr(cursor, "position", None) is not None
+
+
+class ScratchBestByNamePagination(PageNumberPagination):
+    page_size = 25
+    page_size_query_param = "page_size"
+    max_page_size = 100

--- a/backend/coreapp/serializers.py
+++ b/backend/coreapp/serializers.py
@@ -466,6 +466,26 @@ class TerseScratchSerializer(ScratchSerializer):
         }
 
 
+class ScratchBestByNameCandidateSerializer(serializers.Serializer[Scratch]):
+    rank = serializers.IntegerField(source="name_rank", read_only=True)
+    slug = serializers.SlugField(read_only=True)
+    match_percent = serializers.FloatField(read_only=True)
+    score = serializers.IntegerField(read_only=True)
+    max_score = serializers.IntegerField(read_only=True)
+    owner = ProfileField(read_only=True)
+    compiler = serializers.CharField(read_only=True)
+    preset = serializers.PrimaryKeyRelatedField(read_only=True)  # type: ignore
+    creation_time = serializers.DateTimeField(read_only=True)
+    last_updated = serializers.DateTimeField(read_only=True)
+
+
+class ScratchBestByNameGroupSerializer(serializers.Serializer[dict[str, Any]]):
+    name = serializers.CharField(read_only=True)
+    best_match_percent = serializers.FloatField(read_only=True)
+    latest_activity = serializers.DateTimeField(read_only=True)
+    scratches = ScratchBestByNameCandidateSerializer(many=True, read_only=True)
+
+
 # On initial creation, include the "claim_token" field.
 class ClaimableScratchSerializer(ScratchSerializer):
     claim_token = serializers.CharField(read_only=True)

--- a/backend/coreapp/tests/test_scratch.py
+++ b/backend/coreapp/tests/test_scratch.py
@@ -918,20 +918,20 @@ class ScratchBestByNameTests(BaseTestCase):
         return scratch
 
     def get_best_by_name(self, **params: Any) -> Any:
-        params.setdefault("platform", platforms.DUMMY.id)
         params.setdefault("preset", self.preset.id)
         response = self.client.get(reverse("scratch-best-by-name"), params)
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
         return response.json()
 
-    def test_requires_platform_and_preset(self) -> None:
+    def test_requires_preset(self) -> None:
         response = self.client.get(reverse("scratch-best-by-name"))
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
+    def test_does_not_require_platform(self) -> None:
         response = self.client.get(
-            reverse("scratch-best-by-name"), {"platform": platforms.DUMMY.id}
+            reverse("scratch-best-by-name"), {"preset": self.preset.id}
         )
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_ranks_by_match_percent_not_raw_score(self) -> None:
         worse_match = self.make_scratch(

--- a/backend/coreapp/tests/test_scratch.py
+++ b/backend/coreapp/tests/test_scratch.py
@@ -2,18 +2,22 @@ import base64
 import io
 import json
 import zipfile
+from datetime import timedelta
 from time import sleep
 from typing import Any
 from urllib.parse import urlencode
 
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.db.models import ProtectedError
+from django.db.models.signals import post_init
 from django.urls import reverse
+from django.utils import timezone
 from rest_framework import status
 
 from coreapp import compilers, platforms
 from coreapp.compilers import EE_GCC29_991111, GCC281PM, IDO53, IDO71, MWCC_242_81
 from coreapp.libraries import Library
+from coreapp.models.preset import Preset
 from coreapp.models.scratch import Assembly, Context, LibrariesField, Scratch
 from coreapp.platforms import GC_WII, N64
 from coreapp.tests.common import BaseTestCase, requiresCompiler
@@ -880,3 +884,258 @@ class ScratchExportTests(BaseTestCase):
         self.assertIn("code.c", file_names)
         self.assertIn("ctx.c", file_names)
         self.assertNotIn("current.o", file_names)
+
+
+class ScratchBestByNameTests(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.preset = Preset.objects.create(
+            name="Test Preset",
+            platform=platforms.DUMMY.id,
+            compiler=compilers.DUMMY.id,
+        )
+        self.other_preset = Preset.objects.create(
+            name="Other Preset",
+            platform=platforms.DUMMY.id,
+            compiler=compilers.DUMMY.id,
+        )
+
+    def make_scratch(
+        self,
+        name: str,
+        score: int,
+        max_score: int,
+        preset: Preset | None,
+        match_override: bool = False,
+    ) -> Scratch:
+        scratch = self.create_nop_scratch()
+        scratch.name = name
+        scratch.preset = preset
+        scratch.score = score
+        scratch.max_score = max_score
+        scratch.match_override = match_override
+        scratch.save()
+        return scratch
+
+    def get_best_by_name(self, **params: Any) -> Any:
+        params.setdefault("platform", platforms.DUMMY.id)
+        params.setdefault("preset", self.preset.id)
+        response = self.client.get(reverse("scratch-best-by-name"), params)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
+        return response.json()
+
+    def test_requires_platform_and_preset(self) -> None:
+        response = self.client.get(reverse("scratch-best-by-name"))
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        response = self.client.get(
+            reverse("scratch-best-by-name"), {"platform": platforms.DUMMY.id}
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_ranks_by_match_percent_not_raw_score(self) -> None:
+        worse_match = self.make_scratch(
+            "func_a", score=5, max_score=10, preset=self.preset
+        )
+        better_match = self.make_scratch(
+            "func_a", score=50, max_score=1000, preset=self.preset
+        )
+
+        data = self.get_best_by_name(depth=2)
+
+        self.assertEqual(data["count"], 1)
+        group = data["results"][0]
+        self.assertEqual(group["name"], "func_a")
+        self.assertEqual(len(group["scratches"]), 2)
+        self.assertEqual(group["scratches"][0]["slug"], better_match.slug)
+        self.assertEqual(group["scratches"][0]["rank"], 1)
+        self.assertEqual(group["scratches"][1]["slug"], worse_match.slug)
+        self.assertEqual(group["scratches"][1]["rank"], 2)
+
+    def test_includes_100_percent_matches(self) -> None:
+        perfect = self.make_scratch(
+            "func_b", score=0, max_score=1000, preset=self.preset
+        )
+
+        data = self.get_best_by_name()
+        group = data["results"][0]
+        self.assertEqual(group["scratches"][0]["slug"], perfect.slug)
+        self.assertEqual(group["scratches"][0]["match_percent"], 1.0)
+        self.assertEqual(group["best_match_percent"], 1.0)
+
+    def test_match_override_counts_as_full_match(self) -> None:
+        overridden = self.make_scratch(
+            "func_b2", score=42, max_score=1000, preset=self.preset, match_override=True
+        )
+
+        data = self.get_best_by_name()
+        group = data["results"][0]
+        self.assertEqual(group["scratches"][0]["slug"], overridden.slug)
+        self.assertEqual(group["scratches"][0]["match_percent"], 1.0)
+
+    def test_depth_limits_candidates_per_group(self) -> None:
+        for i in range(5):
+            self.make_scratch("func_c", score=i * 10, max_score=100, preset=self.preset)
+
+        data = self.get_best_by_name(depth=3)
+        group = data["results"][0]
+        self.assertEqual(len(group["scratches"]), 3)
+        self.assertEqual([c["rank"] for c in group["scratches"]], [1, 2, 3])
+        match_percents = [c["match_percent"] for c in group["scratches"]]
+        self.assertEqual(match_percents, sorted(match_percents, reverse=True))
+
+    def test_high_cardinality_function_does_not_load_losing_rows(self) -> None:
+        loser_count = 200
+        for i in range(loser_count):
+            self.make_scratch(
+                "func_popular", score=i + 1, max_score=1000, preset=self.preset
+            )
+        winner = self.make_scratch(
+            "func_popular", score=0, max_score=1000, preset=self.preset
+        )
+
+        instantiated_pks: list[str] = []
+
+        def on_init(sender: type[Scratch], instance: Scratch, **kwargs: Any) -> None:
+            instantiated_pks.append(instance.pk)
+
+        post_init.connect(on_init, sender=Scratch)
+        try:
+            data = self.get_best_by_name(depth=1)
+        finally:
+            post_init.disconnect(on_init, sender=Scratch)
+
+        group = data["results"][0]
+        self.assertEqual(len(group["scratches"]), 1)
+        self.assertEqual(group["scratches"][0]["slug"], winner.slug)
+
+        self.assertEqual(instantiated_pks, [winner.slug])
+
+    def test_filters_platform_and_preset_before_ranking(self) -> None:
+        excluded = self.make_scratch(
+            "func_d", score=0, max_score=100, preset=self.other_preset
+        )
+        included = self.make_scratch(
+            "func_d", score=50, max_score=100, preset=self.preset
+        )
+
+        data = self.get_best_by_name()
+        group = data["results"][0]
+        slugs = [c["slug"] for c in group["scratches"]]
+        self.assertNotIn(excluded.slug, slugs)
+        self.assertIn(included.slug, slugs)
+
+    def test_excludes_untitled_placeholder_scratches(self) -> None:
+        untitled = self.make_scratch(
+            "Untitled", score=0, max_score=100, preset=self.preset
+        )
+        named = self.make_scratch(
+            "func_named", score=0, max_score=100, preset=self.preset
+        )
+
+        data = self.get_best_by_name()
+
+        names = [group["name"] for group in data["results"]]
+        self.assertNotIn("Untitled", names)
+        self.assertIn("func_named", names)
+
+        all_slugs = [
+            candidate["slug"]
+            for group in data["results"]
+            for candidate in group["scratches"]
+        ]
+        self.assertNotIn(untitled.slug, all_slugs)
+        self.assertIn(named.slug, all_slugs)
+
+    def test_deterministic_tie_break_by_last_updated(self) -> None:
+        older = self.make_scratch("func_e", score=0, max_score=100, preset=self.preset)
+        newer = self.make_scratch("func_e", score=0, max_score=100, preset=self.preset)
+
+        Scratch.objects.filter(slug=older.slug).update(
+            last_updated=timezone.now() - timedelta(days=1)
+        )
+        Scratch.objects.filter(slug=newer.slug).update(last_updated=timezone.now())
+
+        data = self.get_best_by_name(depth=2)
+        group = data["results"][0]
+        self.assertEqual(group["scratches"][0]["slug"], newer.slug)
+        self.assertEqual(group["scratches"][1]["slug"], older.slug)
+
+    def test_pagination_covers_all_groups_without_duplicates(self) -> None:
+        names = ["func_f", "func_g", "func_h"]
+        for name in names:
+            self.make_scratch(name, score=0, max_score=100, preset=self.preset)
+
+        seen: list[str] = []
+        page = 1
+        while True:
+            data = self.get_best_by_name(page_size=2, page=page)
+            seen.extend(group["name"] for group in data["results"])
+            if data["next"] is None:
+                break
+            page += 1
+
+        self.assertCountEqual(seen, names)
+
+    def test_clamps_depth_to_maximum(self) -> None:
+        for i in range(12):
+            self.make_scratch("func_i", score=i, max_score=100, preset=self.preset)
+
+        data = self.get_best_by_name(depth=999)
+        group = data["results"][0]
+        self.assertEqual(len(group["scratches"]), 10)
+
+    def test_empty_result_for_unmatched_preset(self) -> None:
+        empty_preset = Preset.objects.create(
+            name="Empty Preset",
+            platform=platforms.DUMMY.id,
+            compiler=compilers.DUMMY.id,
+        )
+
+        data = self.get_best_by_name(preset=empty_preset.id)
+        self.assertEqual(data["count"], 0)
+        self.assertEqual(data["results"], [])
+
+    def test_rejects_invalid_ordering(self) -> None:
+        response = self.client.get(
+            reverse("scratch-best-by-name"),
+            {
+                "platform": platforms.DUMMY.id,
+                "preset": str(self.preset.id),
+                "ordering": "not-a-real-ordering",
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_rejects_invalid_min_match(self) -> None:
+        for invalid_value in ["nan", "inf", "-inf", "-0.1", "1.1", "100"]:
+            response = self.client.get(
+                reverse("scratch-best-by-name"),
+                {
+                    "platform": platforms.DUMMY.id,
+                    "preset": str(self.preset.id),
+                    "min_match": invalid_value,
+                },
+            )
+            self.assertEqual(
+                response.status_code,
+                status.HTTP_400_BAD_REQUEST,
+                f"min_match={invalid_value!r} should be rejected",
+            )
+
+    def test_accepts_boundary_min_match(self) -> None:
+        self.make_scratch("func_boundary", score=0, max_score=100, preset=self.preset)
+        for boundary_value in ["0", "0.0", "1", "1.0"]:
+            response = self.client.get(
+                reverse("scratch-best-by-name"),
+                {
+                    "platform": platforms.DUMMY.id,
+                    "preset": str(self.preset.id),
+                    "min_match": boundary_value,
+                },
+            )
+            self.assertEqual(
+                response.status_code,
+                status.HTTP_200_OK,
+                f"min_match={boundary_value!r} should be accepted",
+            )

--- a/backend/coreapp/views/scratch.py
+++ b/backend/coreapp/views/scratch.py
@@ -688,9 +688,7 @@ class ScratchViewSet(
     @action(detail=False, methods=["GET"], url_path="best-by-name")
     def best_by_name(self, request: Request) -> Response:
         if not request.query_params.get("preset"):
-            raise serializers.ValidationError(
-                {"detail": "'preset' is required."}
-            )
+            raise serializers.ValidationError({"detail": "'preset' is required."})
 
         try:
             depth = int(request.query_params.get("depth", DEFAULT_BEST_BY_NAME_DEPTH))

--- a/backend/coreapp/views/scratch.py
+++ b/backend/coreapp/views/scratch.py
@@ -687,11 +687,9 @@ class ScratchViewSet(
     @method_decorator(globally_cacheable(max_age=5, stale_while_revalidate=1))
     @action(detail=False, methods=["GET"], url_path="best-by-name")
     def best_by_name(self, request: Request) -> Response:
-        if not request.query_params.get("platform") or not request.query_params.get(
-            "preset"
-        ):
+        if not request.query_params.get("preset"):
             raise serializers.ValidationError(
-                {"detail": "Both 'platform' and 'preset' are required."}
+                {"detail": "'preset' is required."}
             )
 
         try:

--- a/backend/coreapp/views/scratch.py
+++ b/backend/coreapp/views/scratch.py
@@ -3,15 +3,17 @@ import hashlib
 import io
 import json
 import logging
+import math
 import re
 import zipfile
+from collections import defaultdict
 from datetime import datetime
-from typing import Any
+from typing import Any, cast
 
 import django_filters
 from django.core.files import File
-from django.db.models import Case, F, FloatField, Value, When
-from django.db.models.functions import Cast
+from django.db.models import Case, F, FloatField, Max, Value, When, Window
+from django.db.models.functions import Cast, RowNumber
 from django.db.models.query import QuerySet
 from django.http import HttpResponse, QueryDict
 from django.utils.decorators import method_decorator
@@ -30,16 +32,17 @@ from ..decorators.django import condition
 from ..diff_wrapper import DiffWrapper
 from ..error import CompilationError, DiffError
 from ..filters.scratch import ScratchFilter
-from ..filters.search import NonEmptySearchFilter
+from ..filters.search import NonEmptySearchFilter, validate_search_query
 from ..libraries import Library
 from ..middleware import Request
 from ..models.best_fork import update_best_forks_for_scratch
 from ..models.preset import Preset
 from ..models.scratch import Asm, Assembly, Scratch
-from ..pagination import SafeCursorPagination
+from ..pagination import SafeCursorPagination, ScratchBestByNamePagination
 from ..platforms import Platform
 from ..serializers import (
     ClaimableScratchSerializer,
+    ScratchBestByNameGroupSerializer,
     ScratchCompileSerializer,
     ScratchCreateSerializer,
     ScratchDecompileSerializer,
@@ -69,6 +72,19 @@ def get_db_asm(request_asm: str) -> Asm:
 
 # 1 MB
 MAX_FILE_SIZE = 1000 * 1024
+
+UNTITLED_SCRATCH_NAME = "Untitled"
+
+MAX_BEST_BY_NAME_DEPTH = 10
+DEFAULT_BEST_BY_NAME_DEPTH = 1
+
+BEST_BY_NAME_ORDERING = {
+    "best_match": "-best_match_percent",
+    "name": "name",
+    "latest": "-latest_activity",
+    "oldest": "latest_activity",
+}
+DEFAULT_BEST_BY_NAME_ORDERING = "best_match"
 
 
 def cache_object(platform: Platform, file: File[Any]) -> Assembly:
@@ -252,7 +268,7 @@ def create_scratch(
         preset: Preset = data["preset"]
         preset_id = str(preset.id)
 
-    name = data.get("name", diff_label) or "Untitled"
+    name = data.get("name", diff_label) or UNTITLED_SCRATCH_NAME
 
     libraries = [
         Library(**lib) if isinstance(lib, dict) else lib for lib in data["libraries"]
@@ -630,3 +646,128 @@ class ScratchViewSet(
         return Response(
             TerseScratchSerializer(family, many=True, context={"request": request}).data
         )
+
+    def _best_by_name_eligible_queryset(self, request: Request) -> QuerySet[Scratch]:
+        queryset = (
+            Scratch.objects.all()
+            .exclude(name=UNTITLED_SCRATCH_NAME)
+            .annotate(match_percent=self.match_percent)
+        )
+
+        filterset = ScratchFilter(
+            data=request.query_params, queryset=queryset, request=request
+        )
+        if not filterset.is_valid():
+            raise serializers.ValidationError(filterset.errors)
+        queryset = filterset.qs
+
+        search = request.query_params.get("search", "").strip()
+        if search:
+            validate_search_query(search)
+            queryset = queryset.filter(name__icontains=search)
+
+        min_match = request.query_params.get("min_match")
+        if min_match:
+            try:
+                min_match_value = float(min_match)
+            except ValueError:
+                raise serializers.ValidationError(
+                    {"min_match": "Must be a number."}
+                ) from None
+            if not math.isfinite(min_match_value) or not (
+                0.0 <= min_match_value <= 1.0
+            ):
+                raise serializers.ValidationError(
+                    {"min_match": "Must be a number between 0.0 and 1.0."}
+                )
+            queryset = queryset.filter(match_percent__gte=min_match_value)
+
+        return queryset
+
+    @method_decorator(globally_cacheable(max_age=5, stale_while_revalidate=1))
+    @action(detail=False, methods=["GET"], url_path="best-by-name")
+    def best_by_name(self, request: Request) -> Response:
+        if not request.query_params.get("platform") or not request.query_params.get(
+            "preset"
+        ):
+            raise serializers.ValidationError(
+                {"detail": "Both 'platform' and 'preset' are required."}
+            )
+
+        try:
+            depth = int(request.query_params.get("depth", DEFAULT_BEST_BY_NAME_DEPTH))
+        except ValueError:
+            raise serializers.ValidationError(
+                {"depth": "Must be an integer."}
+            ) from None
+        depth = max(1, min(depth, MAX_BEST_BY_NAME_DEPTH))
+
+        ordering_param = request.query_params.get(
+            "ordering", DEFAULT_BEST_BY_NAME_ORDERING
+        )
+        if ordering_param not in BEST_BY_NAME_ORDERING:
+            raise serializers.ValidationError(
+                {
+                    "ordering": "Must be one of: "
+                    + ", ".join(sorted(BEST_BY_NAME_ORDERING))
+                }
+            )
+        group_ordering = BEST_BY_NAME_ORDERING[ordering_param]
+
+        eligible = self._best_by_name_eligible_queryset(request)
+
+        name_groups = (
+            eligible.values("name")
+            .annotate(
+                best_match_percent=Max("match_percent"),
+                latest_activity=Max("last_updated"),
+            )
+            .order_by(group_ordering, "name")
+        )
+
+        paginator = ScratchBestByNamePagination()
+        page = cast(
+            "list[dict[str, Any]]",
+            paginator.paginate_queryset(name_groups, request, view=self) or [],
+        )
+        names_on_page = [group["name"] for group in page]
+
+        ranked = (
+            eligible.filter(name__in=names_on_page)
+            .select_related("owner__user__github")
+            .annotate(
+                name_rank=Window(
+                    expression=RowNumber(),
+                    partition_by=[F("name")],
+                    order_by=[
+                        F("match_percent").desc(),
+                        F("last_updated").desc(),
+                        F("creation_time").desc(),
+                        F("pk").desc(),
+                    ],
+                )
+            )
+            .filter(name_rank__lte=depth)
+            .order_by("name", "name_rank")
+        )
+
+        candidates_by_name: dict[str, list[Scratch]] = defaultdict(list)
+        for scratch in ranked:
+            candidates_by_name[scratch.name].append(scratch)
+
+        groups = [
+            {
+                "name": group["name"],
+                "best_match_percent": group["best_match_percent"],
+                "latest_activity": group["latest_activity"],
+                "scratches": candidates_by_name.get(group["name"], []),
+            }
+            for group in page
+        ]
+
+        serializer = ScratchBestByNameGroupSerializer(
+            groups,  # type: ignore[arg-type]
+            many=True,
+            context={"request": request},
+        )
+        return paginator.get_paginated_response(serializer.data)

--- a/frontend/src/app/(navfooter)/scratches/best/BestScratches.state.test.ts
+++ b/frontend/src/app/(navfooter)/scratches/best/BestScratches.state.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from "vitest";
+
+import type { PlatformBase, Preset } from "@/lib/api/types";
+
+import {
+    apiFractionToPercentString,
+    parseDepthParam,
+    parseOrderingParam,
+    parsePlatformParam,
+    parsePresetParam,
+    parseSearchParam,
+    percentStringToApiFraction,
+    resolveDefaultPlatform,
+    selectPresetId,
+} from "./BestScratches.state";
+
+function platforms(
+    ids: string[] = ["saturn", "n64"],
+): Record<string, PlatformBase> {
+    const result: Record<string, PlatformBase> = {};
+    for (const id of ids) {
+        result[id] = {
+            id,
+            name: id,
+            description: "",
+            arch: "",
+            has_decompiler: false,
+        };
+    }
+    return result;
+}
+
+function preset(overrides: Partial<Preset> = {}): Preset {
+    return {
+        id: 1,
+        name: "Preset",
+        platform: "saturn",
+        compiler: "cygnus-2.7-96Q3",
+        compiler_flags: "",
+        diff_flags: [],
+        libraries: [],
+        assembler_flags: "",
+        decompiler_flags: "",
+        num_scratches: 0,
+        owner: null,
+        ...overrides,
+    };
+}
+
+describe("parsePlatformParam", () => {
+    it("accepts a platform id present in the available platforms", () => {
+        expect(parsePlatformParam(platforms(), "saturn")).toBe("saturn");
+    });
+
+    it("rejects a platform id not present in the available platforms", () => {
+        expect(
+            parsePlatformParam(platforms(), "not-a-platform"),
+        ).toBeUndefined();
+    });
+
+    it("rejects a missing platform param", () => {
+        expect(parsePlatformParam(platforms(), undefined)).toBeUndefined();
+    });
+});
+
+describe("parsePresetParam", () => {
+    it("accepts a positive integer string", () => {
+        expect(parsePresetParam("1")).toBe(1);
+        expect(parsePresetParam("42")).toBe(42);
+    });
+
+    it("rejects non-numeric, zero, negative, and missing values", () => {
+        expect(parsePresetParam("not-a-number")).toBeUndefined();
+        expect(parsePresetParam("0")).toBeUndefined();
+        expect(parsePresetParam("-1")).toBeUndefined();
+        expect(parsePresetParam("1.5")).toBeUndefined();
+        expect(parsePresetParam(undefined)).toBeUndefined();
+    });
+});
+
+describe("resolveDefaultPlatform", () => {
+    it("uses a valid initial platform from the URL", () => {
+        expect(resolveDefaultPlatform(platforms(), "n64")).toBe("n64");
+    });
+
+    it("falls back to saturn when no valid initial platform is given", () => {
+        expect(resolveDefaultPlatform(platforms(), undefined)).toBe("saturn");
+    });
+
+    it("ignores an initial platform that isn't available", () => {
+        expect(resolveDefaultPlatform(platforms(), "not-a-platform")).toBe(
+            "saturn",
+        );
+    });
+
+    it("falls back to the first available platform when saturn is absent", () => {
+        expect(
+            resolveDefaultPlatform(platforms(["n64", "gc_wii"]), undefined),
+        ).toBe("n64");
+    });
+});
+
+describe("selectPresetId", () => {
+    it("keeps a preset id that is present in the loaded presets", () => {
+        const presets = [preset({ id: 5 }), preset({ id: 9 })];
+        expect(selectPresetId(presets, 9)).toBe(9);
+    });
+
+    it("keeps the id from a direct /scratches/best?platform=saturn&preset=<id> link", () => {
+        const sotnId = 9;
+        const presets = [
+            preset({ id: 5, name: "Other" }),
+            preset({ id: sotnId, name: "SOTN" }),
+        ];
+        expect(selectPresetId(presets, sotnId)).toBe(sotnId);
+    });
+
+    it("falls back to the first preset when the current id isn't in the list", () => {
+        const presets = [preset({ id: 5 }), preset({ id: 9 })];
+        expect(selectPresetId(presets, 123)).toBe(5);
+    });
+
+    it("falls back to the first preset when no id is selected yet", () => {
+        const presets = [preset({ id: 5 }), preset({ id: 9 })];
+        expect(selectPresetId(presets, null)).toBe(5);
+    });
+
+    it("returns null when there are no presets for the platform", () => {
+        expect(selectPresetId([], 5)).toBeNull();
+    });
+
+    it("leaves the current id untouched while presets are still loading", () => {
+        expect(selectPresetId(undefined, 5)).toBe(5);
+    });
+});
+
+describe("parseDepthParam", () => {
+    it("accepts a supported depth", () => {
+        expect(parseDepthParam("10")).toBe("10");
+    });
+
+    it("falls back to the default for missing or unsupported depths", () => {
+        expect(parseDepthParam(undefined)).toBe("1");
+        expect(parseDepthParam("7")).toBe("1");
+        expect(parseDepthParam("not-a-number")).toBe("1");
+    });
+});
+
+describe("parseOrderingParam", () => {
+    it("accepts a supported ordering", () => {
+        expect(parseOrderingParam("latest")).toBe("latest");
+    });
+
+    it("falls back to the default for missing or unsupported orderings", () => {
+        expect(parseOrderingParam(undefined)).toBe("best_match");
+        expect(parseOrderingParam("-best_match")).toBe("best_match");
+    });
+});
+
+describe("parseSearchParam", () => {
+    it("trims whitespace", () => {
+        expect(parseSearchParam("  func_a  ")).toBe("func_a");
+    });
+
+    it("returns an empty string for a missing param", () => {
+        expect(parseSearchParam(undefined)).toBe("");
+    });
+});
+
+describe("percentStringToApiFraction / apiFractionToPercentString", () => {
+    it("round-trips a normal percentage", () => {
+        expect(percentStringToApiFraction("50")).toBe("0.5");
+        expect(apiFractionToPercentString("0.5")).toBe("50");
+    });
+
+    it("clamps values above 100 or below 0 before they reach the API", () => {
+        expect(percentStringToApiFraction("101")).toBe("1");
+        expect(percentStringToApiFraction("-1")).toBe("0");
+    });
+
+    it("clamps a fraction outside 0.0-1.0 read back from the URL", () => {
+        expect(apiFractionToPercentString("1.5")).toBe("100");
+        expect(apiFractionToPercentString("-0.2")).toBe("0");
+    });
+
+    it("rejects non-finite values instead of sending them to the API", () => {
+        expect(percentStringToApiFraction("nan")).toBeUndefined();
+        expect(percentStringToApiFraction("Infinity")).toBeUndefined();
+        expect(apiFractionToPercentString("nan")).toBe("");
+    });
+
+    it("treats empty/missing values as no filter", () => {
+        expect(percentStringToApiFraction("")).toBeUndefined();
+        expect(percentStringToApiFraction("   ")).toBeUndefined();
+        expect(apiFractionToPercentString(undefined)).toBe("");
+    });
+});
+
+describe("direct navigation with a fully-specified query string", () => {
+    it("reproduces every filter from ?platform=saturn&preset=9&depth=10&ordering=name&min_match=0.5&search=func", () => {
+        const availablePlatforms = platforms();
+        const query = new URLSearchParams(
+            "platform=saturn&preset=9&depth=10&ordering=name&min_match=0.5&search=func",
+        );
+
+        expect(
+            parsePlatformParam(
+                availablePlatforms,
+                query.get("platform") ?? undefined,
+            ),
+        ).toBe("saturn");
+        expect(parsePresetParam(query.get("preset") ?? undefined)).toBe(9);
+        expect(parseDepthParam(query.get("depth") ?? undefined)).toBe("10");
+        expect(parseOrderingParam(query.get("ordering") ?? undefined)).toBe(
+            "name",
+        );
+        expect(
+            apiFractionToPercentString(query.get("min_match") ?? undefined),
+        ).toBe("50");
+        expect(parseSearchParam(query.get("search") ?? undefined)).toBe("func");
+    });
+});

--- a/frontend/src/app/(navfooter)/scratches/best/BestScratches.state.ts
+++ b/frontend/src/app/(navfooter)/scratches/best/BestScratches.state.ts
@@ -1,0 +1,113 @@
+import type { Preset, PlatformBase } from "@/lib/api/types";
+
+export const DEPTH_OPTIONS: Record<string, string> = {
+    "1": "Top 1",
+    "3": "Top 3",
+    "5": "Top 5",
+    "10": "Top 10",
+};
+export const DEFAULT_DEPTH = "1";
+
+export const ORDERING_OPTIONS: Record<string, string> = {
+    best_match: "Best match",
+    name: "Function name",
+    latest: "Recently active",
+    oldest: "Oldest activity",
+};
+export const DEFAULT_ORDERING = "best_match";
+
+export function parsePlatformParam(
+    availablePlatforms: Record<string, PlatformBase>,
+    platformParam: string | undefined,
+): string | undefined {
+    if (platformParam && platformParam in availablePlatforms) {
+        return platformParam;
+    }
+    return undefined;
+}
+
+export function parsePresetParam(
+    presetParam: string | undefined,
+): number | undefined {
+    if (!presetParam) {
+        return undefined;
+    }
+    const parsed = Number(presetParam);
+    if (Number.isInteger(parsed) && parsed > 0) {
+        return parsed;
+    }
+    return undefined;
+}
+
+export function parseDepthParam(depthParam: string | undefined): string {
+    if (depthParam && depthParam in DEPTH_OPTIONS) {
+        return depthParam;
+    }
+    return DEFAULT_DEPTH;
+}
+
+export function parseOrderingParam(orderingParam: string | undefined): string {
+    if (orderingParam && orderingParam in ORDERING_OPTIONS) {
+        return orderingParam;
+    }
+    return DEFAULT_ORDERING;
+}
+
+export function parseSearchParam(searchParam: string | undefined): string {
+    return searchParam?.trim() ?? "";
+}
+
+export function resolveDefaultPlatform(
+    availablePlatforms: Record<string, PlatformBase>,
+    initialPlatform: string | undefined,
+): string | undefined {
+    if (initialPlatform && initialPlatform in availablePlatforms) {
+        return initialPlatform;
+    }
+    if ("saturn" in availablePlatforms) {
+        return "saturn";
+    }
+    return Object.keys(availablePlatforms)[0];
+}
+
+export function selectPresetId(
+    presets: Preset[] | undefined,
+    currentPresetId: number | null,
+): number | null {
+    if (!presets) {
+        return currentPresetId;
+    }
+    if (presets.some((preset) => preset.id === currentPresetId)) {
+        return currentPresetId;
+    }
+    return presets[0]?.id ?? null;
+}
+
+export function percentStringToApiFraction(
+    percentStr: string,
+): string | undefined {
+    const trimmed = percentStr.trim();
+    if (!trimmed) {
+        return undefined;
+    }
+    const parsed = Number(trimmed);
+    if (!Number.isFinite(parsed)) {
+        return undefined;
+    }
+    const clampedPercent = Math.min(100, Math.max(0, parsed));
+    return String(clampedPercent / 100);
+}
+
+export function apiFractionToPercentString(
+    fractionParam: string | undefined,
+): string {
+    if (!fractionParam) {
+        return "";
+    }
+    const parsed = Number(fractionParam);
+    if (!Number.isFinite(parsed)) {
+        return "";
+    }
+    const clampedFraction = Math.min(1, Math.max(0, parsed));
+    return String(clampedFraction * 100);
+}

--- a/frontend/src/app/(navfooter)/scratches/best/BestScratches.tsx
+++ b/frontend/src/app/(navfooter)/scratches/best/BestScratches.tsx
@@ -1,0 +1,314 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import { usePathname, useRouter } from "next/navigation";
+
+import { useDebounce } from "use-debounce";
+
+import AsyncButton from "@/components/AsyncButton";
+import Link from "@/components/Link";
+import { percentToString } from "@/components/ScoreBadge";
+import Select from "@/components/Select2";
+import TimeAgo from "@/components/TimeAgo";
+import UserLink from "@/components/user/UserLink";
+import { usePaginated, usePresets } from "@/lib/api";
+import type {
+    BestByNameCandidate,
+    BestByNameGroup,
+    PlatformBase,
+} from "@/lib/api/types";
+
+import {
+    DEFAULT_DEPTH,
+    DEFAULT_ORDERING,
+    DEPTH_OPTIONS,
+    ORDERING_OPTIONS,
+    apiFractionToPercentString,
+    percentStringToApiFraction,
+    resolveDefaultPlatform,
+    selectPresetId,
+} from "./BestScratches.state";
+
+function platformsToOptions(platforms: Record<string, PlatformBase>) {
+    const options: Record<string, string> = {};
+    for (const [id, platform] of Object.entries(platforms)) {
+        options[id] = platform.name;
+    }
+    return options;
+}
+
+function CandidateRow({ candidate }: { candidate: BestByNameCandidate }) {
+    return (
+        <li className="flex flex-wrap items-center gap-x-2 gap-y-1 py-1 pl-6 text-sm">
+            <span className="w-6 shrink-0 text-gray-11 tabular-nums">
+                #{candidate.rank}
+            </span>
+            <Link
+                href={`/scratch/${candidate.slug}`}
+                className="font-medium hover:text-[var(--link)]"
+            >
+                {percentToString(candidate.match_percent * 100)} matched
+            </Link>
+            <span className="flex items-center gap-1 text-gray-11">
+                {candidate.owner ? (
+                    <UserLink user={candidate.owner} truncateUsername={false} />
+                ) : (
+                    <span>No owner</span>
+                )}
+                <span>•</span>
+                <TimeAgo date={candidate.last_updated} />
+            </span>
+        </li>
+    );
+}
+
+function GroupRow({ group }: { group: BestByNameGroup }) {
+    if (group.scratches.length === 0) {
+        return null;
+    }
+
+    return (
+        <li className="rounded-md border border-gray-6 py-2">
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1 px-3">
+                <span className="font-mono font-semibold">{group.name}</span>
+                <span className="text-gray-11 text-sm">
+                    {percentToString(group.best_match_percent * 100)} best
+                </span>
+                <span className="text-gray-11 text-sm">
+                    updated <TimeAgo date={group.latest_activity} />
+                </span>
+            </div>
+            <ul className="mt-1">
+                {group.scratches.map((candidate) => (
+                    <CandidateRow key={candidate.slug} candidate={candidate} />
+                ))}
+            </ul>
+        </li>
+    );
+}
+
+function GroupList({ url }: { url: string }) {
+    const { results, isLoading, hasNext, loadNext } =
+        usePaginated<BestByNameGroup>(url, { isPublic: true });
+
+    return (
+        <ul className="flex flex-col gap-2" aria-busy={isLoading}>
+            {results.map((group) => (
+                <GroupRow key={group.name} group={group} />
+            ))}
+            {results.length === 0 && !isLoading && (
+                <li className="py-4 text-center text-gray-11 text-sm">
+                    No scratches match these filters.
+                </li>
+            )}
+            {hasNext && (
+                <li className="flex justify-center pt-2">
+                    <AsyncButton onClick={loadNext}>
+                        Show more functions
+                    </AsyncButton>
+                </li>
+            )}
+        </ul>
+    );
+}
+
+export default function BestScratches({
+    availablePlatforms,
+    initialPlatform,
+    initialPreset,
+    initialDepth,
+    initialOrdering,
+    initialMinMatch,
+    initialSearch,
+}: {
+    availablePlatforms: Record<string, PlatformBase>;
+    initialPlatform?: string;
+    initialPreset?: number;
+    initialDepth?: string;
+    initialOrdering?: string;
+    initialMinMatch?: string;
+    initialSearch?: string;
+}) {
+    const router = useRouter();
+    const pathname = usePathname();
+
+    const platformOptions = useMemo(
+        () => platformsToOptions(availablePlatforms),
+        [availablePlatforms],
+    );
+
+    const [platform, setPlatform] = useState(
+        () => resolveDefaultPlatform(availablePlatforms, initialPlatform) ?? "",
+    );
+    const presets = usePresets(platform);
+    const [presetId, setPresetId] = useState<number | null>(
+        initialPreset ?? null,
+    );
+    const [depth, setDepth] = useState(initialDepth ?? DEFAULT_DEPTH);
+    const [ordering, setOrdering] = useState(
+        initialOrdering ?? DEFAULT_ORDERING,
+    );
+    const [minMatch, setMinMatch] = useState(initialMinMatch ?? "");
+    const [search, setSearch] = useState(initialSearch ?? "");
+    const [debouncedSearch] = useDebounce(search, 300);
+
+    useEffect(() => {
+        setPresetId((currentPresetId) =>
+            selectPresetId(presets, currentPresetId),
+        );
+    }, [presets]);
+
+    const minMatchFraction = percentStringToApiFraction(minMatch);
+
+    useEffect(() => {
+        if (!presetId) {
+            return;
+        }
+        const params = new URLSearchParams();
+        params.set("platform", platform);
+        params.set("preset", String(presetId));
+        if (depth !== DEFAULT_DEPTH) {
+            params.set("depth", depth);
+        }
+        if (ordering !== DEFAULT_ORDERING) {
+            params.set("ordering", ordering);
+        }
+        if (minMatchFraction !== undefined) {
+            params.set("min_match", minMatchFraction);
+        }
+        if (debouncedSearch.trim()) {
+            params.set("search", debouncedSearch.trim());
+        }
+        router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+    }, [
+        platform,
+        presetId,
+        depth,
+        ordering,
+        minMatchFraction,
+        debouncedSearch,
+        pathname,
+        router,
+    ]);
+
+    const presetOptions = useMemo(() => {
+        const options: Record<string, string> = {};
+        for (const preset of presets ?? []) {
+            options[String(preset.id)] = preset.name;
+        }
+        return options;
+    }, [presets]);
+
+    const url = useMemo(() => {
+        if (!presetId) {
+            return null;
+        }
+
+        const params = new URLSearchParams({
+            platform,
+            preset: String(presetId),
+            depth,
+            ordering,
+            page_size: "25",
+        });
+        const trimmedSearch = debouncedSearch.trim();
+        if (trimmedSearch) {
+            params.set("search", trimmedSearch);
+        }
+        if (minMatchFraction !== undefined) {
+            params.set("min_match", minMatchFraction);
+        }
+
+        return `/scratch/best-by-name?${params.toString()}`;
+    }, [
+        platform,
+        presetId,
+        depth,
+        ordering,
+        debouncedSearch,
+        minMatchFraction,
+    ]);
+
+    return (
+        <section>
+            <div className="flex flex-wrap items-end gap-3 pb-4">
+                <label className="flex flex-col gap-1 text-gray-11 text-xs">
+                    <span>Platform</span>
+                    <Select
+                        value={platform}
+                        onChange={(value) => {
+                            setPlatform(value);
+                            setPresetId(null);
+                        }}
+                        options={platformOptions}
+                    />
+                </label>
+                <label className="flex flex-col gap-1 text-gray-11 text-xs">
+                    <span>Preset</span>
+                    <Select
+                        value={presetId ? String(presetId) : ""}
+                        onChange={(value) => {
+                            if (value) {
+                                setPresetId(Number(value));
+                            }
+                        }}
+                        options={
+                            Object.keys(presetOptions).length > 0
+                                ? presetOptions
+                                : { "": "No presets for this platform" }
+                        }
+                    />
+                </label>
+                <label className="flex flex-col gap-1 text-gray-11 text-xs">
+                    <span>Depth</span>
+                    <Select
+                        value={depth}
+                        onChange={setDepth}
+                        options={DEPTH_OPTIONS}
+                    />
+                </label>
+                <label className="flex flex-col gap-1 text-gray-11 text-xs">
+                    <span>Sort</span>
+                    <Select
+                        value={ordering}
+                        onChange={setOrdering}
+                        options={ORDERING_OPTIONS}
+                    />
+                </label>
+                <label className="flex flex-col gap-1 text-gray-11 text-xs">
+                    <span>Min match %</span>
+                    <input
+                        type="number"
+                        min={0}
+                        max={100}
+                        placeholder="Any"
+                        className="w-20 rounded border border-[var(--g400)] bg-[var(--g200)] px-[10px] py-2 text-[0.8rem] text-[var(--g1600)]"
+                        value={minMatch}
+                        onChange={(event) => setMinMatch(event.target.value)}
+                    />
+                </label>
+                <label className="flex flex-1 flex-col gap-1 text-gray-11 text-xs">
+                    <span>Search function name</span>
+                    <input
+                        type="text"
+                        placeholder="func_..."
+                        className="w-full rounded border border-[var(--g400)] bg-[var(--g200)] px-[10px] py-2 text-[0.8rem] text-[var(--g1600)]"
+                        value={search}
+                        onChange={(event) => setSearch(event.target.value)}
+                    />
+                </label>
+            </div>
+
+            {url ? (
+                <GroupList url={url} />
+            ) : (
+                <p className="py-4 text-gray-11 text-sm">
+                    {presets
+                        ? "No presets available for this platform."
+                        : "Loading presets…"}
+                </p>
+            )}
+        </section>
+    );
+}

--- a/frontend/src/app/(navfooter)/scratches/best/BestScratches.tsx
+++ b/frontend/src/app/(navfooter)/scratches/best/BestScratches.tsx
@@ -206,7 +206,6 @@ export default function BestScratches({
         }
 
         const params = new URLSearchParams({
-            platform,
             preset: String(presetId),
             depth,
             ordering,
@@ -221,14 +220,7 @@ export default function BestScratches({
         }
 
         return `/scratch/best-by-name?${params.toString()}`;
-    }, [
-        platform,
-        presetId,
-        depth,
-        ordering,
-        debouncedSearch,
-        minMatchFraction,
-    ]);
+    }, [presetId, depth, ordering, debouncedSearch, minMatchFraction]);
 
     return (
         <section>

--- a/frontend/src/app/(navfooter)/scratches/best/page.tsx
+++ b/frontend/src/app/(navfooter)/scratches/best/page.tsx
@@ -1,0 +1,62 @@
+import type { Metadata } from "next";
+
+import { getPublic } from "@/lib/api/request";
+import type { PlatformBase } from "@/lib/api/types";
+
+import BestScratches from "./BestScratches";
+import {
+    apiFractionToPercentString,
+    parseDepthParam,
+    parseOrderingParam,
+    parsePlatformParam,
+    parsePresetParam,
+    parseSearchParam,
+} from "./BestScratches.state";
+
+export const metadata: Metadata = {
+    title: "Best scratches by function",
+};
+
+export const dynamic = "force-dynamic";
+
+export default async function Page(props: {
+    searchParams: Promise<{
+        platform?: string;
+        preset?: string;
+        depth?: string;
+        ordering?: string;
+        min_match?: string;
+        search?: string;
+    }>;
+}) {
+    const searchParams = await props.searchParams;
+    const availablePlatforms: Record<string, PlatformBase> =
+        await getPublic("/platform");
+
+    const initialPlatform = parsePlatformParam(
+        availablePlatforms,
+        searchParams.platform,
+    );
+    const initialPreset = parsePresetParam(searchParams.preset);
+    const initialDepth = parseDepthParam(searchParams.depth);
+    const initialOrdering = parseOrderingParam(searchParams.ordering);
+    const initialMinMatch = apiFractionToPercentString(searchParams.min_match);
+    const initialSearch = parseSearchParam(searchParams.search);
+
+    return (
+        <main className="mx-auto w-full max-w-3xl p-4">
+            <h1 className="font-semibold text-2xl text-gray-12 tracking-tight md:text-3xl">
+                Best scratches by function name
+            </h1>
+            <BestScratches
+                availablePlatforms={availablePlatforms}
+                initialPlatform={initialPlatform}
+                initialPreset={initialPreset}
+                initialDepth={initialDepth}
+                initialOrdering={initialOrdering}
+                initialMinMatch={initialMinMatch}
+                initialSearch={initialSearch}
+            />
+        </main>
+    );
+}

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -193,6 +193,26 @@ export interface Platform extends PlatformBase {
     compilers: string[];
 }
 
+export interface BestByNameCandidate {
+    rank: number;
+    slug: string;
+    match_percent: number;
+    score: number;
+    max_score: number;
+    owner: AnonymousUser | User | null;
+    compiler: string;
+    preset: number | null;
+    creation_time: string;
+    last_updated: string;
+}
+
+export interface BestByNameGroup {
+    name: string;
+    best_match_percent: number;
+    latest_activity: string;
+    scratches: BestByNameCandidate[];
+}
+
 export interface ScratchResult {
     type: "scratch";
     item: TerseScratch;


### PR DESCRIPTION
This puts together a "best scratches by function name page. The use case is:

On the projects I work on, people tend to get a function to 90%+ then get stuck, and people forget about the scratch. I want to be able to go back and see these scratches. My function_finder tool used to work for this case by using the API but now with CloudFlare it's non-functional. https://github.com/Xeeynamo/sotn-decomp/blob/master/tools/function_finder/function_finder_psx.py

This adds:

`GET /api/scratch/best-by-name` groups scratches by function name, ranks by match %, filterable by platform/preset/depth/min-match/search

`/scratches/best?platform=saturn&preset=<id>` page consuming the api

Screenshot with fake data:

<img width="803" height="649" alt="image" src="https://github.com/user-attachments/assets/d3f7ddbe-713c-49d0-aee3-6fc4fece8a33" />
