### PR TITLE
Add ido7.1_irix4_c++

### DIFF
--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -941,7 +941,7 @@ IDO71_IRIX4_CXX = IDOCompiler(
     platform=N64,
     base_compiler=IDO71,
     language=Language.OLD_CXX,
-    cc='"${COMPILER_DIR}/OCC-irix4"'
+    cc='"${COMPILER_DIR}/cc-irix4"'
     ' --frontend "${COMPILER_DIR}/../ido4.1"'
     ' --cfront "${COMPILER_DIR}/../ido5.3_c++"'
     ' --backend "${COMPILER_DIR}"'

--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -936,6 +936,18 @@ IDO71_IRIX4 = IDOCompiler(
     ' -c ${COMPILER_FLAGS} -o "${OUTPUT}" "${INPUT}"',
 )
 
+IDO71_IRIX4_CXX = IDOCompiler(
+    id="ido7.1_irix4_c++",
+    platform=N64,
+    base_compiler=IDO71,
+    language=Language.OLD_CXX,
+    cc='"${COMPILER_DIR}/OCC-irix4"'
+    ' --frontend "${COMPILER_DIR}/../ido4.1"'
+    ' --cfront "${COMPILER_DIR}/../ido5.3_c++"'
+    ' --backend "${COMPILER_DIR}"'
+    ' -c ${COMPILER_FLAGS} -o "${OUTPUT}" "${INPUT}"',
+)
+
 IDO71_CXX = IDOCompiler(
     id="ido7.1_c++",
     platform=N64,
@@ -1855,6 +1867,7 @@ _all_compilers: list[Compiler] = [
     IDO60,
     IDO71,
     IDO71_IRIX4,
+    IDO71_IRIX4_CXX,
     IDO71_CXX,
     MIPS_PRO_744,
     GCC272KMC,

--- a/frontend/src/lib/i18n/locales/en/compilers.json
+++ b/frontend/src/lib/i18n/locales/en/compilers.json
@@ -104,6 +104,7 @@
     "ido5.3Pascal": "IDO 5.3 Pascal",
     "ido7.1": "IDO 7.1",
     "ido7.1_irix4": "IDO 7.1 (IRIX 4 frontend)",
+    "ido7.1_irix4_c++": "IDO 7.1 C++ (IRIX 4 cfront)",
     "ido7.1_c++": "IDO 7.1 C++",
     "ido7.1Pascal": "IDO 7.1 Pascal",
 


### PR DESCRIPTION
This I think may be the solution to SSB64's ovl8 issues. It is C++ with IRIX4, and in my local testing I am able to get things matching without resorting to weird file splits.