### PR TITLE
Add MSVC 12.0 (Update 4) compiler

### DIFF
--- a/backend/compilers/compilers.linux.yaml
+++ b/backend/compilers/compilers.linux.yaml
@@ -239,6 +239,7 @@ win32:
   - msvc7.1
   - msvc8.0
   - msvc8.0p
+  - msvc12.0u4
 
 xbox360:
   - msvc_ppc_14.00.2110

--- a/backend/coreapp/compilers.py
+++ b/backend/coreapp/compilers.py
@@ -1592,6 +1592,13 @@ MSVC80P = MSVCCompiler(
     platform=WIN32,
     cc=CL_WIN,
 )
+
+MSVC120U4 = MSVCCompiler(
+    id="msvc12.0u4",
+    platform=WIN32,
+    cc=CL_WIN,
+)
+
 # Watcom doesn't like '/' in paths passed to it so we need to replace them.
 WATCOM_ARGS = ' -zq -i="Z:${COMPILER_DIR}/h" -i="Z:${COMPILER_DIR}/h/nt" ${COMPILER_FLAGS} -fo"Z:${OUTPUT}" "Z:${INPUT}"'
 WATCOM_CC = (
@@ -1970,6 +1977,7 @@ _all_compilers: list[Compiler] = [
     MSVC71,
     MSVC80,
     MSVC80P,
+    MSVC120U4,
     # Watcom, DOS and Win32
     WATCOM_100A_C,
     WATCOM_100A_CPP,

--- a/frontend/src/lib/i18n/locales/en/compilers.json
+++ b/frontend/src/lib/i18n/locales/en/compilers.json
@@ -121,6 +121,7 @@
     "msvc7.1": "Microsoft Visual C/C++ 7.1 .NET 2003",
     "msvc8.0": "Microsoft Visual C/C++ 8.0",
     "msvc8.0p": "Microsoft Visual C/C++ 8.0 (Patched)",
+    "msvc12.0u4": "Microsoft Visual C/C++ 12.0 (Update 4)",
 
     "msvc_ppc_14.00.2110": "Microsoft C/C++ Compiler 14.00.2110 for PowerPC",
     "msvc_ppc_16.00.11886.00": "Microsoft C/C++ Compiler 16.00.11886.00 for PowerPC",


### PR DESCRIPTION
Was able to get it set up locally, but there are some unsupported imports causing it to crash on compile.


https://github.com/decompme/compilers/pull/82

EDIT: Depends on https://github.com/decompals/wibo/pull/127
Noting that this is for Starcraft: Broodwar patch 1.17 (decomp target)