### PR TITLE
Prioritize exact scratch name matches during search, allow 3x page_size scratch results

### DIFF
--- a/backend/coreapp/tests/test_search.py
+++ b/backend/coreapp/tests/test_search.py
@@ -1,10 +1,23 @@
 from django.urls import reverse
 from rest_framework import status
 
+from coreapp.models.scratch import Assembly, Scratch
 from coreapp.tests.common import BaseTestCase
 
 
 class SearchTests(BaseTestCase):
+    def create_search_scratch(self, name: str) -> Scratch:
+        assembly = Assembly.objects.create(
+            hash=f"{name}-assembly",
+            arch="dummy",
+        )
+        return Scratch.objects.create(
+            name=name,
+            compiler="dummy",
+            platform="dummy",
+            target_assembly=assembly,
+        )
+
     def test_rejects_long_query(self) -> None:
         response = self.client.get(reverse("search"), {"search": "a" * 65})
 
@@ -40,3 +53,37 @@ class SearchTests(BaseTestCase):
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_prioritizes_exact_scratch_name_matches(self) -> None:
+        self.create_search_scratch("match extra")
+        exact_match = self.create_search_scratch("match")
+        self.create_search_scratch("another match")
+
+        response = self.client.get(
+            reverse("search"), {"search": "match", "page_size": "1"}
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.json()
+        self.assertEqual(len(results), 3)
+        self.assertEqual(results[0]["item"]["slug"], exact_match.slug)
+        self.assertEqual(
+            {result["item"]["name"] for result in results},
+            {"match extra", "match", "another match"},
+        )
+
+    def test_returns_up_to_three_times_page_size_scratches(self) -> None:
+        scratches = [
+            self.create_search_scratch(f"search result {index}") for index in range(6)
+        ]
+
+        response = self.client.get(
+            reverse("search"), {"search": "search", "page_size": "2"}
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.json()), 6)
+        self.assertEqual(
+            {result["item"]["slug"] for result in response.json()},
+            {scratch.slug for scratch in scratches},
+        )

--- a/backend/coreapp/views/search.py
+++ b/backend/coreapp/views/search.py
@@ -1,4 +1,4 @@
-from django.db.models import Count
+from django.db.models import Case, Count, IntegerField, When
 from rest_framework.response import Response
 from rest_framework.serializers import ValidationError
 from rest_framework.views import APIView
@@ -38,10 +38,23 @@ class SearchViewSet(APIView):
             .select_related("owner__user", "owner__user__github")
             .annotate(num_scratches=Count("scratch"))[:page_size]
         )
-        scratch_qs = Scratch.objects.filter(name__icontains=query).select_related(
-            "owner__user__github",
-            "best_fork__fork__owner__user__github",
-        )[:page_size]
+        # Returns up to 3x page_size, but we should prioritize scratches
+        scratch_page_size = page_size * 3 - user_qs.count() - preset_qs.count()
+        scratch_qs = (
+            Scratch.objects.filter(name__icontains=query)
+            .select_related(
+                "owner__user__github",
+                "best_fork__fork__owner__user__github",
+            )
+            .annotate(
+                exact_match=Case(
+                    When(name__iexact=query, then=1),
+                    default=0,
+                    output_field=IntegerField(),
+                )
+            )
+            .order_by("-exact_match", "name", "slug")[:scratch_page_size]
+        )
 
         results = []
 


### PR DESCRIPTION
Closes #2090.

Also given we allow 15 results (users+presets+scratches), I thought it makes sense to allow `15 - user results - preset results` scratch results, given that is the most common use of the search (i.e. don't limit to just 5 scratch results).